### PR TITLE
Replace the `Sample` and `IndependentSample` traits with `Distribution`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ keywords = ["random"]
 [dependencies]
 log = "0.3.0"
 libc = "0.1.1"
+num = "0.1.27"
 
 [dev-dependencies.rand_macros]
 path = "rand_macros"

--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -11,7 +11,7 @@
 //! The exponential distribution.
 
 use {Rng, Rand};
-use distributions::{ziggurat, ziggurat_tables, Sample, IndependentSample};
+use distributions::{ziggurat, ziggurat_tables, Distribution};
 
 /// A wrapper around an `f64` to generate Exp(1) random numbers.
 ///
@@ -58,10 +58,10 @@ impl Rand for Exp1 {
 /// # Example
 ///
 /// ```rust
-/// use rand::distributions::{Exp, IndependentSample};
+/// use rand::distributions::{Exp, Distribution};
 ///
 /// let exp = Exp::new(2.0);
-/// let v = exp.ind_sample(&mut rand::thread_rng());
+/// let v = exp.sample(&mut rand::thread_rng());
 /// println!("{} is from a Exp(2) distribution", v);
 /// ```
 #[derive(Clone, Copy)]
@@ -79,11 +79,10 @@ impl Exp {
     }
 }
 
-impl Sample<f64> for Exp {
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
-}
-impl IndependentSample<f64> for Exp {
-    fn ind_sample<R: Rng>(&self, rng: &mut R) -> f64 {
+impl Distribution for Exp {
+    type Output = f64;
+
+    fn sample<R: Rng>(&self, rng: &mut R) -> f64 {
         let Exp1(n) = rng.gen::<Exp1>();
         n * self.lambda_inverse
     }
@@ -91,16 +90,15 @@ impl IndependentSample<f64> for Exp {
 
 #[cfg(test)]
 mod test {
-    use distributions::{Sample, IndependentSample};
+    use distributions::Distribution;
     use super::Exp;
 
     #[test]
     fn test_exp() {
-        let mut exp = Exp::new(10.0);
+        let exp = Exp::new(10.0);
         let mut rng = ::test::rng();
         for _ in 0..1000 {
             assert!(exp.sample(&mut rng) >= 0.0);
-            assert!(exp.ind_sample(&mut rng) >= 0.0);
         }
     }
     #[test]
@@ -122,12 +120,12 @@ mod bench {
     use self::test::Bencher;
     use std::mem::size_of;
     use super::Exp;
-    use distributions::Sample;
+    use distributions::Distribution;
 
     #[bench]
     fn rand_exp(b: &mut Bencher) {
         let mut rng = ::test::weak_rng();
-        let mut exp = Exp::new(2.71828 * 3.14159);
+        let exp = Exp::new(2.71828 * 3.14159);
 
         b.iter(|| {
             for _ in 0..::RAND_BENCH_N {

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -11,11 +11,10 @@
 //! Sampling from random distributions.
 //!
 //! This is a generalization of `Rand` to allow parameters to control the
-//! exact properties of the generated values, e.g. the mean and standard
-//! deviation of a normal distribution. The `Sample` trait is the most
-//! general, and allows for generating values that change some state
-//! internally. The `IndependentSample` trait is for generating values
-//! that do not need to record state.
+//! distribution of the generated values, e.g. the mean and standard deviation
+//! of a normal distribution. The `Distribution` trait allows for generating values
+//! from a distribution that is independent of the number of samples generated,
+//! i.e. sampling "with replacement".
 
 use std::num::{Float, Int};
 use std::marker;
@@ -32,50 +31,37 @@ pub mod gamma;
 pub mod normal;
 pub mod exponential;
 
-/// Types that can be used to create a random instance of `Support`.
-pub trait Sample<Support> {
-    /// Generate a random value of `Support`, using `rng` as the
-    /// source of randomness.
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> Support;
-}
-
-/// `Sample`s that do not require keeping track of state.
+/// Type that can be used to create a random instance of `Output`.
 ///
 /// Since no state is recorded, each sample is (statistically)
 /// independent of all others, assuming the `Rng` used has this
 /// property.
-// FIXME maybe having this separate is overkill (the only reason is to
-// take &self rather than &mut self)? or maybe this should be the
-// trait called `Sample` and the other should be `DependentSample`.
-pub trait IndependentSample<Support>: Sample<Support> {
-    /// Generate a random value.
-    fn ind_sample<R: Rng>(&self, &mut R) -> Support;
+pub trait Distribution {
+    type Output;
+    /// Generate a random value of `Output`, using `rng` as the
+    /// source of randomness.
+    fn sample<R: Rng>(&self, rng: &mut R) -> <Self as Distribution>::Output;
 }
 
-/// A wrapper for generating types that implement `Rand` via the
-/// `Sample` & `IndependentSample` traits.
-pub struct RandSample<Sup> {
-    _marker: marker::PhantomData<fn() -> Sup>,
+/// A wrapper for generating types that implement `Distribution` via the
+/// `Rand` trait.
+pub struct RandDistribution<T> {
+    _marker: marker::PhantomData<fn() -> T>,
 }
 
-impl<Sup> Copy for RandSample<Sup> {}
-impl<Sup> Clone for RandSample<Sup> {
+impl<Sup> Copy for RandDistribution<Sup> {}
+impl<Sup> Clone for RandDistribution<Sup> {
     fn clone(&self) -> Self { *self }
 }
 
-impl<Sup: Rand> Sample<Sup> for RandSample<Sup> {
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> Sup { self.ind_sample(rng) }
+impl<T: Rand> Distribution for RandDistribution<T> {
+    type Output = T;
+    fn sample<R: Rng>(&self, rng: &mut R) -> T { rng.gen() }
 }
 
-impl<Sup: Rand> IndependentSample<Sup> for RandSample<Sup> {
-    fn ind_sample<R: Rng>(&self, rng: &mut R) -> Sup {
-        rng.gen()
-    }
-}
-
-impl<Sup> RandSample<Sup> {
-    pub fn new() -> RandSample<Sup> {
-        RandSample { _marker: marker::PhantomData }
+impl<T> RandDistribution<T> {
+    pub fn new() -> RandDistribution<T> {
+        RandDistribution { _marker: marker::PhantomData }
     }
 }
 
@@ -94,15 +80,14 @@ pub struct Weighted<T> {
 /// Each item has an associated weight that influences how likely it
 /// is to be chosen: higher weight is more likely.
 ///
-/// The `Clone` restriction is a limitation of the `Sample` and
-/// `IndependentSample` traits. Note that `&T` is (cheaply) `Clone` for
-/// all `T`, as is `u32`, so one can store references or indices into
-/// another vector.
+/// The `Clone` restriction is a limitation of the `Distribution` trait. Note that
+/// `&T` is (cheaply) `Clone` for all `T`, as is `u32`, so one can store
+/// references or indices into another vector.
 ///
 /// # Example
 ///
 /// ```rust
-/// use rand::distributions::{Weighted, WeightedChoice, IndependentSample};
+/// use rand::distributions::{Weighted, WeightedChoice, Distribution};
 ///
 /// let mut items = vec!(Weighted { weight: 2, item: 'a' },
 ///                      Weighted { weight: 4, item: 'b' },
@@ -111,7 +96,7 @@ pub struct Weighted<T> {
 /// let mut rng = rand::thread_rng();
 /// for _ in 0..16 {
 ///      // on average prints 'a' 4 times, 'b' 8 and 'c' twice.
-///      println!("{}", wc.ind_sample(&mut rng));
+///      println!("{}", wc.sample(&mut rng));
 /// }
 /// ```
 pub struct WeightedChoice<'a, T:'a> {
@@ -155,18 +140,16 @@ impl<'a, T: Clone> WeightedChoice<'a, T> {
     }
 }
 
-impl<'a, T: Clone> Sample<T> for WeightedChoice<'a, T> {
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> T { self.ind_sample(rng) }
-}
+impl<'a, T: Clone> Distribution for WeightedChoice<'a, T> {
+    type Output = T;
 
-impl<'a, T: Clone> IndependentSample<T> for WeightedChoice<'a, T> {
-    fn ind_sample<R: Rng>(&self, rng: &mut R) -> T {
+    fn sample<R: Rng>(&self, rng: &mut R) -> T {
         // we want to find the first element that has cumulative
         // weight > sample_weight, which we do by binary since the
         // cumulative weights of self.items are sorted.
 
         // choose a weight in [0, total_weight)
-        let sample_weight = self.weight_range.ind_sample(rng);
+        let sample_weight = self.weight_range.sample(rng);
 
         // short circuit when it's the first item
         if sample_weight < self.items[0].weight {
@@ -272,7 +255,7 @@ fn ziggurat<R: Rng, P, Z>(
 mod tests {
 
     use {Rng, Rand};
-    use super::{RandSample, WeightedChoice, Weighted, Sample, IndependentSample};
+    use super::{RandDistribution, WeightedChoice, Weighted, Distribution};
 
     #[derive(PartialEq, Debug)]
     struct ConstRand(usize);
@@ -296,10 +279,9 @@ mod tests {
 
     #[test]
     fn test_rand_sample() {
-        let mut rand_sample = RandSample::<ConstRand>::new();
+        let rand_sample = RandDistribution::<ConstRand>::new();
 
         assert_eq!(rand_sample.sample(&mut ::test::rng()), ConstRand(0));
-        assert_eq!(rand_sample.ind_sample(&mut ::test::rng()), ConstRand(0));
     }
     #[test]
     fn test_weighted_choice() {
@@ -317,7 +299,7 @@ mod tests {
                 let mut rng = CountingRng { i: 0 };
 
                 for &val in expected.iter() {
-                    assert_eq!(wc.ind_sample(&mut rng), val)
+                    assert_eq!(wc.sample(&mut rng), val)
                 }
             }}
         }

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -65,6 +65,27 @@ impl<T> RandDistribution<T> {
     }
 }
 
+/// A distribution that always returns the same value.
+///
+/// # Example
+///
+/// ```rust
+/// use rand::distributions::{Distribution, Constant};
+///
+/// let d = Constant(42);
+/// let v = d.sample(&mut rand::thread_rng());
+/// assert_eq!(v, 42);
+/// ```
+pub struct Constant<T>(pub T);
+
+impl<T: Clone> Distribution for Constant<T> {
+    type Output = T;
+
+    fn sample<R: Rng>(&self, _: &mut R) -> T {
+        self.0.clone()
+    }
+}
+
 /// A value with a particular weight for use with `WeightedChoice`.
 #[derive(Copy)]
 #[derive(Clone)]
@@ -255,7 +276,7 @@ fn ziggurat<R: Rng, P, Z>(
 mod tests {
 
     use {Rng, Rand};
-    use super::{RandDistribution, WeightedChoice, Weighted, Distribution};
+    use super::{RandDistribution, WeightedChoice, Weighted, Distribution, Constant};
 
     #[derive(PartialEq, Debug)]
     struct ConstRand(usize);
@@ -283,6 +304,16 @@ mod tests {
 
         assert_eq!(rand_sample.sample(&mut ::test::rng()), ConstRand(0));
     }
+
+    #[test]
+    fn test_constant() {
+        let d = Constant(11);
+
+        assert_eq!(d.sample(&mut ::test::rng()), 11);
+        assert_eq!(d.sample(&mut ::test::rng()), 11);
+        assert_eq!(d.sample(&mut ::test::rng()), 11);
+    }
+
     #[test]
     fn test_weighted_choice() {
         // this makes assumptions about the internal implementation of

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -16,7 +16,9 @@
 //! from a distribution that is independent of the number of samples generated,
 //! i.e. sampling "with replacement".
 
-use std::num::{Float, Int};
+extern crate num;
+
+use self::num::traits::{Float, CheckedAdd};
 use std::marker;
 
 use {Rng, Rand};
@@ -142,7 +144,7 @@ impl<'a, T: Clone> WeightedChoice<'a, T> {
         // weights so we can binary search. This *could* drop elements
         // with weight == 0 as an optimisation.
         for item in items.iter_mut() {
-            running_total = match running_total.checked_add(item.weight) {
+            running_total = match running_total.checked_add(&item.weight) {
                 Some(n) => n,
                 None => panic!("WeightedChoice::new called with a total weight \
                                larger than a u32 can contain")

--- a/src/distributions/range.rs
+++ b/src/distributions/range.rs
@@ -15,12 +15,12 @@
 use std::num::Wrapping as w;
 
 use Rng;
-use distributions::{Sample, IndependentSample};
+use distributions::Distribution;
 
 /// Sample values uniformly between two bounds.
 ///
 /// This gives a uniform distribution (assuming the RNG used to sample
-/// it is itself uniform & the `SampleRange` implementation for the
+/// it is itself uniform & the `RangeDistribution` implementation for the
 /// given type is correct), even for edge cases like `low = 0u8`,
 /// `high = 170u8`, for which a naive modulo operation would return
 /// numbers less than 85 with double the probability to those greater
@@ -34,14 +34,14 @@ use distributions::{Sample, IndependentSample};
 /// # Example
 ///
 /// ```rust
-/// use rand::distributions::{IndependentSample, Range};
+/// use rand::distributions::{Distribution, Range};
 ///
 /// fn main() {
 ///     let between = Range::new(10, 10000);
 ///     let mut rng = rand::thread_rng();
 ///     let mut sum = 0;
 ///     for _ in 0..1000 {
-///         sum += between.ind_sample(&mut rng);
+///         sum += between.sample(&mut rng);
 ///     }
 ///     println!("{}", sum);
 /// }
@@ -53,29 +53,27 @@ pub struct Range<X> {
     accept_zone: X
 }
 
-impl<X: SampleRange + PartialOrd> Range<X> {
+impl<X: RangeDistribution + PartialOrd> Range<X> {
     /// Create a new `Range` instance that samples uniformly from
     /// `[low, high)`. Panics if `low >= high`.
     pub fn new(low: X, high: X) -> Range<X> {
         assert!(low < high, "Range::new called with `low >= high`");
-        SampleRange::construct_range(low, high)
+        RangeDistribution::construct_range(low, high)
     }
 }
 
-impl<Sup: SampleRange> Sample<Sup> for Range<Sup> {
-    #[inline]
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> Sup { self.ind_sample(rng) }
-}
-impl<Sup: SampleRange> IndependentSample<Sup> for Range<Sup> {
-    fn ind_sample<R: Rng>(&self, rng: &mut R) -> Sup {
-        SampleRange::sample_range(self, rng)
+impl<Sup: RangeDistribution> Distribution for Range<Sup> {
+    type Output = Sup;
+
+    fn sample<R: Rng>(&self, rng: &mut R) -> Sup {
+        RangeDistribution::sample_range(self, rng)
     }
 }
 
 /// The helper trait for types that have a sensible way to sample
 /// uniformly between two values. This should not be used directly,
 /// and is only to facilitate `Range`.
-pub trait SampleRange {
+pub trait RangeDistribution {
     /// Construct the `Range` object that `sample_range`
     /// requires. This should not ever be called directly, only via
     /// `Range::new`, which will check that `low < high`, so this
@@ -89,7 +87,7 @@ pub trait SampleRange {
 
 macro_rules! integer_impl {
     ($ty:ty, $unsigned:ident) => {
-        impl SampleRange for $ty {
+        impl RangeDistribution for $ty {
             // we play free and fast with unsigned vs signed here
             // (when $ty is signed), but that's fine, since the
             // contract of this macro is for $ty and $unsigned to be
@@ -143,7 +141,7 @@ integer_impl! { usize, usize }
 
 macro_rules! float_impl {
     ($ty:ty) => {
-        impl SampleRange for $ty {
+        impl RangeDistribution for $ty {
             fn construct_range(low: $ty, high: $ty) -> Range<$ty> {
                 Range {
                     low: low,
@@ -163,7 +161,7 @@ float_impl! { f64 }
 
 #[cfg(test)]
 mod tests {
-    use distributions::{Sample, IndependentSample};
+    use distributions::Distribution;
     use super::Range as Range;
 
     #[should_panic]
@@ -187,11 +185,9 @@ mod tests {
                                             (10, 127),
                                             (::std::$ty::MIN, ::std::$ty::MAX)];
                    for &(low, high) in v.iter() {
-                        let mut sampler: Range<$ty> = Range::new(low, high);
+                        let sampler: Range<$ty> = Range::new(low, high);
                         for _ in 0..1000 {
                             let v = sampler.sample(&mut rng);
-                            assert!(low <= v && v < high);
-                            let v = sampler.ind_sample(&mut rng);
                             assert!(low <= v && v < high);
                         }
                     }
@@ -213,11 +209,9 @@ mod tests {
                                             (1e-35, 1e-25),
                                             (-1e35, 1e35)];
                    for &(low, high) in v.iter() {
-                        let mut sampler: Range<$ty> = Range::new(low, high);
+                        let sampler: Range<$ty> = Range::new(low, high);
                         for _ in 0..1000 {
                             let v = sampler.sample(&mut rng);
-                            assert!(low <= v && v < high);
-                            let v = sampler.ind_sample(&mut rng);
                             assert!(low <= v && v < high);
                         }
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@
 //! and multiply this fraction by 4.
 //!
 //! ```
-//! use rand::distributions::{IndependentSample, Range};
+//! use rand::distributions::{Distribution, Range};
 //!
 //! fn main() {
 //!    let between = Range::new(-1f64, 1.);
@@ -104,8 +104,8 @@
 //!    let mut in_circle = 0;
 //!
 //!    for _ in 0..total {
-//!        let a = between.ind_sample(&mut rng);
-//!        let b = between.ind_sample(&mut rng);
+//!        let a = between.sample(&mut rng);
+//!        let b = between.sample(&mut rng);
 //!        if a*a + b*b <= 1. {
 //!            in_circle += 1;
 //!        }
@@ -137,7 +137,7 @@
 //!
 //! ```
 //! use rand::Rng;
-//! use rand::distributions::{IndependentSample, Range};
+//! use rand::distributions::{Distribution, Range};
 //!
 //! struct SimulationResult {
 //!     win: bool,
@@ -147,10 +147,10 @@
 //! // Run a single simulation of the Monty Hall problem.
 //! fn simulate<R: Rng>(random_door: &Range<u32>, rng: &mut R)
 //!                     -> SimulationResult {
-//!     let car = random_door.ind_sample(rng);
+//!     let car = random_door.sample(rng);
 //!
 //!     // This is our initial choice
-//!     let mut choice = random_door.ind_sample(rng);
+//!     let mut choice = random_door.sample(rng);
 //!
 //!     // The game host opens a door
 //!     let open = game_host_open(car, choice, rng);
@@ -246,8 +246,8 @@ use IsaacRng as IsaacWordRng;
 #[cfg(target_pointer_width = "64")]
 use Isaac64Rng as IsaacWordRng;
 
-use distributions::{Range, IndependentSample};
-use distributions::range::SampleRange;
+use distributions::{Range, Distribution};
+use distributions::range::RangeDistribution;
 
 pub mod distributions;
 pub mod isaac;
@@ -437,9 +437,9 @@ pub trait Rng : Sized {
     /// let m: f64 = rng.gen_range(-40.0f64, 1.3e5f64);
     /// println!("{}", m);
     /// ```
-    fn gen_range<T: PartialOrd + SampleRange>(&mut self, low: T, high: T) -> T {
+    fn gen_range<T: PartialOrd + RangeDistribution>(&mut self, low: T, high: T) -> T {
         assert!(low < high, "Rng.gen_range called with low >= high");
-        Range::new(low, high).ind_sample(self)
+        Range::new(low, high).sample(self)
     }
 
     /// Return a bool with a 1 in n chance of true


### PR DESCRIPTION
The `Sample` trait was always being implemented by calling through to `IndependentSample.ind_sample`, so no replacement for the state-mutating trait (formerly known as `Sample`) has been provided.

The only situation I can imagine needing a state-mutating trait like the old `Sample` is if you are simulating drawing objects from a bag _without replacement_.

This is a breaking change for users of this library.
