### PR TITLE
Faster and Better weak generators

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -3,64 +3,74 @@
 extern crate test;
 extern crate rand;
 
-const RAND_BENCH_N: u64 = 100;
-
 mod distributions;
 
-use std::mem::size_of;
-use test::{black_box, Bencher};
-use rand::{XorShiftRng, StdRng, IsaacRng, Isaac64Rng, Rng};
-use rand::{OsRng, weak_rng};
+use test::Bencher;
+use rand::{weak_rng, Rng};
 
-#[bench]
-fn rand_xorshift(b: &mut Bencher) {
-    let mut rng: XorShiftRng = OsRng::new().unwrap().gen();
-    b.iter(|| {
-        for _ in 0..RAND_BENCH_N {
-            black_box(rng.gen::<usize>());
-        }
-    });
-    b.bytes = size_of::<usize>() as u64 * RAND_BENCH_N;
-}
-
-#[bench]
-fn rand_isaac(b: &mut Bencher) {
-    let mut rng: IsaacRng = OsRng::new().unwrap().gen();
-    b.iter(|| {
-        for _ in 0..RAND_BENCH_N {
-            black_box(rng.gen::<usize>());
-        }
-    });
-    b.bytes = size_of::<usize>() as u64 * RAND_BENCH_N;
-}
-
-#[bench]
-fn rand_isaac64(b: &mut Bencher) {
-    let mut rng: Isaac64Rng = OsRng::new().unwrap().gen();
-    b.iter(|| {
-        for _ in 0..RAND_BENCH_N {
-            black_box(rng.gen::<usize>());
-        }
-    });
-    b.bytes = size_of::<usize>() as u64 * RAND_BENCH_N;
-}
-
-#[bench]
-fn rand_std(b: &mut Bencher) {
-    let mut rng = StdRng::new().unwrap();
-    b.iter(|| {
-        for _ in 0..RAND_BENCH_N {
-            black_box(rng.gen::<usize>());
-        }
-    });
-    b.bytes = size_of::<usize>() as u64 * RAND_BENCH_N;
-}
+pub const RAND_BENCH_N: u64 = 100;
 
 #[bench]
 fn rand_shuffle_100(b: &mut Bencher) {
     let mut rng = weak_rng();
     let x : &mut [usize] = &mut [1; 100];
     b.iter(|| {
-        rng.shuffle(x);
+        rng.shuffle(x)
     })
+}
+
+mod algorithms {
+    use test::{black_box, Bencher};
+    use std::mem::size_of;
+    use rand::{OsRng, StdRng, weak_rng, XorShiftRng, XorShiftPlusRng, IsaacRng, Isaac64Rng, Rng, ChaChaRng};
+
+    use super::*;
+
+    macro_rules! impl_bench {
+        ($result_ty: ty: $fn_name: ident, $hasher: ident) => (
+            #[bench]
+            fn $fn_name(b: &mut Bencher) {
+                let mut rng: $hasher = OsRng::new().unwrap().gen();
+                b.iter(|| {
+                    for _ in 0..RAND_BENCH_N {
+                        black_box(rng.gen::<$result_ty>());
+                    }
+                });
+                b.bytes = size_of::<$result_ty>() as u64 * RAND_BENCH_N;
+            }
+        )
+    }
+
+    impl_bench!(u32: rand_xorshift_u32, XorShiftRng);
+    impl_bench!(u64: rand_xorshift_u64, XorShiftRng);
+    impl_bench!(u32: rand_rand_xorshiftplus_u32, XorShiftPlusRng);
+    impl_bench!(u64: rand_xorshiftplus_u64, XorShiftPlusRng);
+    impl_bench!(u32: rand_isaac_u32, IsaacRng);
+    impl_bench!(u64: rand_isaac_u64, IsaacRng);
+    impl_bench!(u32: rand_isaac64_u32, Isaac64Rng);
+    impl_bench!(u64: rand_isaac64_u64, Isaac64Rng);
+    impl_bench!(u32: rand_chacha_u32, ChaChaRng);
+    impl_bench!(u64: rand_chacha_u64, ChaChaRng);
+
+    #[bench]
+    fn rand_std(b: &mut Bencher) {
+        let mut rng = StdRng::new().unwrap();
+        b.iter(|| {
+            for _ in 0..RAND_BENCH_N {
+                black_box(rng.gen::<usize>());
+            }
+        });
+        b.bytes = size_of::<usize>() as u64 * RAND_BENCH_N;
+    }
+
+    #[bench]
+    fn rand_weak(b: &mut Bencher) {
+        let mut rng = weak_rng();
+        b.iter(|| {
+            for _ in 0..RAND_BENCH_N {
+                black_box(rng.gen::<usize>());
+            }
+        });
+        b.bytes = size_of::<usize>() as u64 * RAND_BENCH_N;
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,6 +254,7 @@ pub use os::OsRng;
 
 pub use isaac::{IsaacRng, Isaac64Rng};
 pub use chacha::ChaChaRng;
+pub use xorshift::{XorShiftRng, XorShiftPlusRng};
 
 #[cfg(target_pointer_width = "32")]
 use IsaacRng as IsaacWordRng;
@@ -266,6 +267,7 @@ use distributions::range::SampleRange;
 pub mod distributions;
 pub mod isaac;
 pub mod chacha;
+pub mod xorshift;
 pub mod reseeding;
 mod rand_impls;
 pub mod os;
@@ -596,93 +598,6 @@ pub trait SeedableRng<Seed>: Rng {
     /// println!("{}", rng.gen::<f64>());
     /// ```
     fn from_seed(seed: Seed) -> Self;
-}
-
-/// An Xorshift[1] random number
-/// generator.
-///
-/// The Xorshift algorithm is not suitable for cryptographic purposes
-/// but is very fast. If you do not know for sure that it fits your
-/// requirements, use a more secure one such as `IsaacRng` or `OsRng`.
-///
-/// [1]: Marsaglia, George (July 2003). ["Xorshift
-/// RNGs"](http://www.jstatsoft.org/v08/i14/paper). *Journal of
-/// Statistical Software*. Vol. 8 (Issue 14).
-#[allow(missing_copy_implementations)]
-#[derive(Clone)]
-pub struct XorShiftRng {
-    x: w32,
-    y: w32,
-    z: w32,
-    w: w32,
-}
-
-impl XorShiftRng {
-    /// Creates a new XorShiftRng instance which is not seeded.
-    ///
-    /// The initial values of this RNG are constants, so all generators created
-    /// by this function will yield the same stream of random numbers. It is
-    /// highly recommended that this is created through `SeedableRng` instead of
-    /// this function
-    pub fn new_unseeded() -> XorShiftRng {
-        XorShiftRng {
-            x: w(0x193a6754),
-            y: w(0xa8a7d469),
-            z: w(0x97830e05),
-            w: w(0x113ba7bb),
-        }
-    }
-}
-
-impl Rng for XorShiftRng {
-    #[inline]
-    fn next_u32(&mut self) -> u32 {
-        let x = self.x;
-        let t = x ^ (x << 11);
-        self.x = self.y;
-        self.y = self.z;
-        self.z = self.w;
-        let w_ = self.w;
-        self.w = w_ ^ (w_ >> 19) ^ (t ^ (t >> 8));
-        self.w.0
-    }
-}
-
-impl SeedableRng<[u32; 4]> for XorShiftRng {
-    /// Reseed an XorShiftRng. This will panic if `seed` is entirely 0.
-    fn reseed(&mut self, seed: [u32; 4]) {
-        assert!(!seed.iter().all(|&x| x == 0),
-                "XorShiftRng.reseed called with an all zero seed.");
-
-        self.x = w(seed[0]);
-        self.y = w(seed[1]);
-        self.z = w(seed[2]);
-        self.w = w(seed[3]);
-    }
-
-    /// Create a new XorShiftRng. This will panic if `seed` is entirely 0.
-    fn from_seed(seed: [u32; 4]) -> XorShiftRng {
-        assert!(!seed.iter().all(|&x| x == 0),
-                "XorShiftRng::from_seed called with an all zero seed.");
-
-        XorShiftRng {
-            x: w(seed[0]),
-            y: w(seed[1]),
-            z: w(seed[2]),
-            w: w(seed[3]),
-        }
-    }
-}
-
-impl Rand for XorShiftRng {
-    fn rand<R: Rng>(rng: &mut R) -> XorShiftRng {
-        let mut tuple: (u32, u32, u32, u32) = rng.gen();
-        while tuple == (0, 0, 0, 0) {
-            tuple = rng.gen();
-        }
-        let (x, y, z, w_) = tuple;
-        XorShiftRng { x: w(x), y: w(y), z: w(z), w: w(w_) }
-    }
 }
 
 /// A wrapper for generating floating point numbers uniformly in the

--- a/src/xorshift.rs
+++ b/src/xorshift.rs
@@ -1,0 +1,205 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! The Xorshift family of random number generators.
+use std::num::Wrapping as w;
+
+use {Rng, SeedableRng, Rand, w32, w64};
+
+/// A Xorshift128+[1] random number generator.
+///
+/// The Xorshift128+ algorithm is not suitable for cryptographic purposes
+/// but is very fast. If you do not know for sure that it fits your
+/// requirements, use a more secure one such as `IsaacRng` or `OsRng`.
+/// This variant uses 64bit arithmetic and is appropriated for 64bit architectures.
+/// Compared to Xorshift128 this variant also produces a higher quality distribution.
+///
+/// [1]: Vigna, S. (2014). [Further scramblings of 
+/// Marsaglia's xorshift generators](http://arxiv.org/pdf/1404.0390.pdf).
+/// arXiv preprint arXiv:1404.0390.
+#[derive(Copy, Clone)]
+pub struct XorShiftPlusRng {
+    s: [w64; 2]
+}
+
+impl XorShiftPlusRng {
+    /// Creates a new XorShiftPlusRng instance which is not seeded.
+    ///
+    /// The initial values of this RNG are constants, so all generators created
+    /// by this function will yield the same stream of random numbers. It is
+    /// highly recommended that this is created through `SeedableRng` instead of
+    /// this function
+    pub fn new_unseeded() -> XorShiftPlusRng {
+        XorShiftPlusRng {
+            s: [w(0x193a6754a8a7d469), w(0x97830e05113ba7bb)]
+        }
+    }
+}
+
+impl Rng for XorShiftPlusRng {
+    #[inline]
+    fn next_u32(&mut self) -> u32 {
+        self.next_u64() as u32
+    }
+
+    #[inline]
+    fn next_u64(&mut self) -> u64 {
+        let mut s1 = self.s[0];
+        let s0 = self.s[1];
+        self.s[0] = s0;
+        s1 = s1 ^ (s1 << 23); // a
+        self.s[1] = s1 ^ s0 ^ (s1 >> 17) ^ (s0 >> 26); // b, c
+        (self.s[1] + s0).0
+    }
+}
+
+impl SeedableRng<[u64; 2]> for XorShiftPlusRng {
+    /// Reseed an XorShiftPlusRng. This will panic if `seed` is entirely 0.
+    fn reseed(&mut self, seed: [u64; 2]) {
+        assert!(seed != [0, 0],
+                "XorShiftPlusRng.reseed called with an all zero seed.");
+
+        self.s = [w(seed[0]), w(seed[1])];
+    }
+
+    /// Create a new XorShiftPlusRng. This will panic if `seed` is entirely 0.
+    fn from_seed(seed: [u64; 2]) -> XorShiftPlusRng {
+        assert!(seed != [0, 0],
+                "XorShiftPlusRng::from_seed called with an all zero seed.");
+
+        XorShiftPlusRng {
+            s: [w(seed[0]), w(seed[1])]
+        }
+    }
+}
+
+impl Rand for XorShiftPlusRng {
+    fn rand<R: Rng>(rng: &mut R) -> XorShiftPlusRng {
+        let mut seed: (u64, u64) = rng.gen();
+        while seed == (0, 0) {
+            seed = rng.gen();
+        }
+        XorShiftPlusRng { s: [w(seed.0), w(seed.1)] }
+    }
+}
+
+/// An Xorshift128[1] random number generator.
+///
+/// The Xorshift128 algorithm is not suitable for cryptographic purposes
+/// but is very fast. If you do not know for sure that it fits your
+/// requirements, use a more secure one such as `IsaacRng` or `OsRng`.
+/// This variant uses 32bit arithmetic and is appropriated for 32bit architectures.
+///
+/// [1]: Marsaglia, George (July 2003). ["Xorshift
+/// RNGs"](http://www.jstatsoft.org/v08/i14/paper). *Journal of
+/// Statistical Software*. Vol. 8 (Issue 14).
+#[derive(Copy, Clone)]
+pub struct XorShiftRng {
+    x: w32,
+    y: w32,
+    z: w32,
+    w: w32,
+}
+
+impl XorShiftRng {
+    /// Creates a new XorShiftRng instance which is not seeded.
+    ///
+    /// The initial values of this RNG are constants, so all generators created
+    /// by this function will yield the same stream of random numbers. It is
+    /// highly recommended that this is created through `SeedableRng` instead of
+    /// this function
+    pub fn new_unseeded() -> XorShiftRng {
+        XorShiftRng {
+            x: w(0x193a6754),
+            y: w(0xa8a7d469),
+            z: w(0x97830e05),
+            w: w(0x113ba7bb),
+        }
+    }
+}
+
+impl Rng for XorShiftRng {
+    #[inline]
+    fn next_u32(&mut self) -> u32 {
+        let x = self.x;
+        let t = x ^ (x << 11);
+        self.x = self.y;
+        self.y = self.z;
+        self.z = self.w;
+        let w_ = self.w;
+        self.w = w_ ^ (w_ >> 19) ^ (t ^ (t >> 8));
+        self.w.0
+    }
+}
+
+impl SeedableRng<[u32; 4]> for XorShiftRng {
+    /// Reseed an XorShiftRng. This will panic if `seed` is entirely 0.
+    fn reseed(&mut self, seed: [u32; 4]) {
+        assert!(seed != [0, 0, 0, 0],
+                "XorShiftRng.reseed called with an all zero seed.");
+
+        self.x = w(seed[0]);
+        self.y = w(seed[1]);
+        self.z = w(seed[2]);
+        self.w = w(seed[3]);
+    }
+
+    /// Create a new XorShiftRng. This will panic if `seed` is entirely 0.
+    fn from_seed(seed: [u32; 4]) -> XorShiftRng {
+        assert!(seed != [0, 0, 0, 0],
+                "XorShiftRng::from_seed called with an all zero seed.");
+
+        XorShiftRng {
+            x: w(seed[0]),
+            y: w(seed[1]),
+            z: w(seed[2]),
+            w: w(seed[3]),
+        }
+    }
+}
+
+impl Rand for XorShiftRng {
+    fn rand<R: Rng>(rng: &mut R) -> XorShiftRng {
+        let mut tuple: (u32, u32, u32, u32) = rng.gen();
+        while tuple == (0, 0, 0, 0) {
+            tuple = rng.gen();
+        }
+        let (x, y, z, w_) = tuple;
+        XorShiftRng { x: w(x), y: w(y), z: w(z), w: w(w_) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use SeedableRng;
+    use super::{XorShiftRng, XorShiftPlusRng};
+
+    #[test]
+    #[should_panic]
+    fn test_xorshift64_zero_seed() {
+        let _: XorShiftRng = SeedableRng::from_seed([0, 0, 0, 0]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_xorshift128p_zero_seed() {
+        let _: XorShiftPlusRng = SeedableRng::from_seed([0, 0]);
+    }
+
+    #[test]
+    fn test_xorshift64_non_zero_seed() {
+        let _: XorShiftRng = SeedableRng::from_seed([1, 1, 0, 0]);
+    }
+
+    #[test]
+    fn test_xorshift128p_non_zero_seed() {
+        let _: XorShiftPlusRng = SeedableRng::from_seed([1, 0]);
+    }
+}


### PR DESCRIPTION
I took a couple of days to research some fast pseudo-random number generators and I thought it'd be nice to contribute to the crate.

This PR contains two commits one adding the xorshift128+ and the other PCG RXS M XS (32 and 64bit variants). I don't think there's precedence for adding both, so I think we should discuss how to proceed.

| Algorithm    | Size     | Quality | x86 (u32) | x86 (u64) | x64 (u32) | x64 (u64) |
|--------------|----------|---------|-----------|-----------|-----------|-----------|
| PCG32        | 4 Bytes  | Fair    | 1365      | 1616      | 1646      | 1677      |
| PCG64        | 8 Bytes  | Great   | 510       | 1016      | 1646      | 3493      |
| Xorshift128   | 16 Bytes | Fair     | 1486      | 1895      | 2094      | 2279      |
| Xorshift128+ | 16 Bytes | Great   | 911       | 1656      | 2000      | 4278      |

x64 benchmarks (my laptop)
```
test algorithms::chacha_u32                        ... bench:       2,477 ns/iter (+/- 191) = 161 MB/s
test algorithms::chacha_u64                        ... bench:       4,783 ns/iter (+/- 353) = 167 MB/s
test algorithms::isaac64_u32                       ... bench:         617 ns/iter (+/- 40) = 648 MB/s
test algorithms::isaac64_u64                       ... bench:         639 ns/iter (+/- 16) = 1251 MB/s
test algorithms::isaac_u32                         ... bench:         847 ns/iter (+/- 30) = 472 MB/s
test algorithms::isaac_u64                         ... bench:       1,579 ns/iter (+/- 130) = 506 MB/s
test algorithms::pcg32_u32                         ... bench:         243 ns/iter (+/- 10) = 1646 MB/s
test algorithms::pcg32_u64                         ... bench:         477 ns/iter (+/- 23) = 1677 MB/s
test algorithms::pcg64_u32                         ... bench:         243 ns/iter (+/- 14) = 1646 MB/s
test algorithms::pcg64_u64                         ... bench:         229 ns/iter (+/- 16) = 3493 MB/s
test algorithms::xorshift_u32                      ... bench:         191 ns/iter (+/- 11) = 2094 MB/s
test algorithms::xorshift_u64                      ... bench:         351 ns/iter (+/- 18) = 2279 MB/s
test algorithms::xorshiftp_u32                     ... bench:         200 ns/iter (+/- 11) = 2000 MB/s
test algorithms::xorshiftp_u64                     ... bench:         187 ns/iter (+/- 7) = 4278 MB/s

```
x86 benchmarks (DO)
```
test algorithms::chacha_u32                        ... bench:       2,644 ns/iter (+/- 21) = 151 MB/s
test algorithms::chacha_u64                        ... bench:       4,964 ns/iter (+/- 28) = 161 MB/s
test algorithms::isaac64_u32                       ... bench:       1,038 ns/iter (+/- 8) = 385 MB/s
test algorithms::isaac64_u64                       ... bench:       1,059 ns/iter (+/- 6) = 755 MB/s
test algorithms::isaac_u32                         ... bench:       1,107 ns/iter (+/- 12) = 361 MB/s
test algorithms::isaac_u64                         ... bench:       2,004 ns/iter (+/- 13) = 399 MB/s
test algorithms::pcg32_u32                         ... bench:         293 ns/iter (+/- 4) = 1365 MB/s
test algorithms::pcg32_u64                         ... bench:         495 ns/iter (+/- 6) = 1616 MB/s
test algorithms::pcg64_u32                         ... bench:         783 ns/iter (+/- 15) = 510 MB/s
test algorithms::pcg64_u64                         ... bench:         787 ns/iter (+/- 9) = 1016 MB/s
test algorithms::xorshift_u32                      ... bench:         269 ns/iter (+/- 4) = 1486 MB/s
test algorithms::xorshift_u64                      ... bench:         422 ns/iter (+/- 6) = 1895 MB/s
test algorithms::xorshiftp_u32                     ... bench:         439 ns/iter (+/- 7) = 911 MB/s
test algorithms::xorshiftp_u64                     ... bench:         483 ns/iter (+/- 5) = 1656 MB/s
```

PCG is neat, it's very compact and provide good quality, even in the 32bit variant!

Although my preference would be to add the xorshift128+ variant and leave the xorshift128 there (probably worth a rename though).

In addition weak_rng should return the fastest algorithm available for the architectures. As 64bit operations kills performance in 32bit architectures this can be as simple as Xorshift64 for 32bit and Xorshift128+ for 64bit.

Finally, users won't need to look elsewhere for a crazy fast random implementation.

Thoughts?