### PR TITLE
Update .travis to build on all stable versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: rust
 rust:
   - 1.0.0
+  - 1.1.0
+  - 1.2.0
+  - 1.3.0
+  - 1.4.0
   - stable
   - beta
   - nightly


### PR DESCRIPTION
Including Rust 1.4 explicitly, since 1.5 is around the corner.