### PR TITLE
add type annotations (fixes build on 1.7.0-nightly (d5e229057 2016-01…

### DIFF
--- a/src/isaac.rs
+++ b/src/isaac.rs
@@ -131,7 +131,7 @@ impl IsaacRng {
         const MIDPOINT: usize = RAND_SIZE_USIZE / 2;
 
         macro_rules! ind {
-            ($x:expr) => ( self.mem[($x >> 2).0 as usize & (RAND_SIZE_USIZE - 1)] )
+            ($x:expr) => ( self.mem[($x >> 2u64).0 as usize & (RAND_SIZE_USIZE - 1)] )
         }
 
         let r = [(0, MIDPOINT), (MIDPOINT, 0)];
@@ -370,7 +370,7 @@ impl Isaac64Rng {
         const MP_VEC: [(usize, usize); 2] = [(0,MIDPOINT), (MIDPOINT, 0)];
         macro_rules! ind {
             ($x:expr) => {
-                *self.mem.get_unchecked((($x >> 3).0 as usize) & (RAND_SIZE_64 - 1))
+                *self.mem.get_unchecked((($x >> 3u64).0 as usize) & (RAND_SIZE_64 - 1))
             }
         }
 

--- a/src/isaac.rs
+++ b/src/isaac.rs
@@ -131,7 +131,7 @@ impl IsaacRng {
         const MIDPOINT: usize = RAND_SIZE_USIZE / 2;
 
         macro_rules! ind {
-            ($x:expr) => ( self.mem[($x >> 2u64).0 as usize & (RAND_SIZE_USIZE - 1)] )
+            ($x:expr) => ( self.mem[($x >> 2usize).0 as usize & (RAND_SIZE_USIZE - 1)] )
         }
 
         let r = [(0, MIDPOINT), (MIDPOINT, 0)];
@@ -370,7 +370,7 @@ impl Isaac64Rng {
         const MP_VEC: [(usize, usize); 2] = [(0,MIDPOINT), (MIDPOINT, 0)];
         macro_rules! ind {
             ($x:expr) => {
-                *self.mem.get_unchecked((($x >> 3u64).0 as usize) & (RAND_SIZE_64 - 1))
+                *self.mem.get_unchecked((($x >> 3usize).0 as usize) & (RAND_SIZE_64 - 1))
             }
         }
 


### PR DESCRIPTION
I'm a happy user of rand (thanks btw!!) and I noticed the build broke against the latest nightly 2016-01-04.

Here's the build log:
https://travis-ci.org/numerodix/emcache/jobs/100445665

I fixed the compile error (tested using multirust to get the nightly).