### PR TITLE
Make rand compile with nightly

### DIFF
--- a/src/isaac.rs
+++ b/src/isaac.rs
@@ -131,7 +131,7 @@ impl IsaacRng {
         const MIDPOINT: usize = RAND_SIZE_USIZE / 2;
 
         macro_rules! ind {
-            ($x:expr) => ( self.mem[($x >> 2).0 as usize & (RAND_SIZE_USIZE - 1)] )
+            ($x:expr) => ( self.mem[($x >> 2usize).0 as usize & (RAND_SIZE_USIZE - 1)] )
         }
 
         let r = [(0, MIDPOINT), (MIDPOINT, 0)];
@@ -370,7 +370,7 @@ impl Isaac64Rng {
         const MP_VEC: [(usize, usize); 2] = [(0,MIDPOINT), (MIDPOINT, 0)];
         macro_rules! ind {
             ($x:expr) => {
-                *self.mem.get_unchecked((($x >> 3).0 as usize) & (RAND_SIZE_64 - 1))
+                *self.mem.get_unchecked((($x >> 3usize).0 as usize) & (RAND_SIZE_64 - 1))
             }
         }
 


### PR DESCRIPTION
When compiling `rand` with the current nightly it fails because Rustc cannot find the correct type for the second operand of the wrapping shift operation:

    src/isaac.rs:134:37: 134:48 error: the type of this value must be known in this context
    src/isaac.rs:134             ($x:expr) => ( self.mem[($x >> 2).0 as usize & (RAND_SIZE_USIZE - 1)] )
    src/isaac.rs:373:42: 373:53 error: the type of this value must be known in this context
     src/isaac.rs:373                 *self.mem.get_unchecked((($x >> 3).0 as usize) & (RAND_SIZE_64 - 1))

This PR adds an explicit cast to `usize` to fix this, but this may be a regression worth reporting upstream?