### PR TITLE
Add Rng trait method choose_mut

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -517,6 +517,18 @@ pub trait Rng {
         }
     }
 
+    /// Return a mutable pointer to a random element from `values`.
+    ///
+    /// Return `None` if `values` is empty.
+    fn choose_mut<'a, T>(&mut self, values: &'a mut [T]) -> Option<&'a mut T> where Self: Sized {
+        if values.is_empty() {
+            None
+        } else {
+            let len = values.len();
+            Some(&mut values[self.gen_range(0, len)])
+        }
+    }
+
     /// Shuffle a mutable slice in place.
     ///
     /// # Example


### PR DESCRIPTION
Works like `choose` but takes a mutable slice and returns a mutable reference.