### PR TITLE
Mark some distribution constructors #[inline]

### DIFF
--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -80,6 +80,7 @@ pub struct Exp {
 impl Exp {
     /// Construct a new `Exp` with the given shape parameter
     /// `lambda`. Panics if `lambda <= 0`.
+    #[inline]
     pub fn new(lambda: f64) -> Exp {
         assert!(lambda > 0.0, "Exp::new called with `lambda` <= 0");
         Exp { lambda_inverse: 1.0 / lambda }

--- a/src/distributions/gamma.rs
+++ b/src/distributions/gamma.rs
@@ -97,6 +97,7 @@ impl Gamma {
     /// distribution.
     ///
     /// Panics if `shape <= 0` or `scale <= 0`.
+    #[inline]
     pub fn new(shape: f64, scale: f64) -> Gamma {
         assert!(shape > 0.0, "Gamma::new called with shape <= 0");
         assert!(scale > 0.0, "Gamma::new called with scale <= 0");

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -101,6 +101,7 @@ impl Normal {
     /// # Panics
     ///
     /// Panics if `std_dev < 0`.
+    #[inline]
     pub fn new(mean: f64, std_dev: f64) -> Normal {
         assert!(std_dev >= 0.0, "Normal::new called with `std_dev` < 0");
         Normal {
@@ -147,6 +148,7 @@ impl LogNormal {
     /// # Panics
     ///
     /// Panics if `std_dev < 0`.
+    #[inline]
     pub fn new(mean: f64, std_dev: f64) -> LogNormal {
         assert!(std_dev >= 0.0, "LogNormal::new called with `std_dev` < 0");
         LogNormal { norm: Normal::new(mean, std_dev) }


### PR DESCRIPTION
Mark some distribution constructors #[inline]

Most of these are very simple and should be inlined (nuance: be *inlinable*).