### PR TITLE
Add xoroshiro128+ generator.

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -9,12 +9,23 @@ mod distributions;
 
 use std::mem::size_of;
 use test::{black_box, Bencher};
-use rand::{XorShiftRng, StdRng, IsaacRng, Isaac64Rng, Rng};
+use rand::{XorShiftRng, XoroShiroRng, StdRng, IsaacRng, Isaac64Rng, Rng};
 use rand::{OsRng, weak_rng};
 
 #[bench]
 fn rand_xorshift(b: &mut Bencher) {
     let mut rng: XorShiftRng = OsRng::new().unwrap().gen();
+    b.iter(|| {
+        for _ in 0..RAND_BENCH_N {
+            black_box(rng.gen::<usize>());
+        }
+    });
+    b.bytes = size_of::<usize>() as u64 * RAND_BENCH_N;
+}
+
+#[bench]
+fn rand_xoroshiro(b: &mut Bencher) {
+    let mut rng: XoroShiroRng = OsRng::new().unwrap().gen();
     b.iter(|| {
         for _ in 0..RAND_BENCH_N {
             black_box(rng.gen::<usize>());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -752,6 +752,92 @@ impl Rand for XorShiftRng {
     }
 }
 
+/// A xoroshiro+ random number generator.
+///
+/// The xoroshiro+ algorithm is not suitable for cryptographic purposes, but
+/// is very fast and has better statistical properties than `XorShiftRng`.  If
+/// you do not know for sure that it fits your requirements, use a more secure
+/// one such as `IsaacRng` or `OsRng`.
+///
+/// The algorithm used here is translated from [the `xoroshiro128plus.c`
+/// reference source code](http://xorshift.di.unimi.it/xoroshiro128plus.c) by
+/// David Blackman and Sebastiano Vigna.
+#[allow(missing_copy_implementations)]
+#[derive(Clone)]
+pub struct XoroShiroRng {
+    s0: u64,
+    s1: u64,
+}
+
+impl XoroShiroRng {
+    /// Creates a new XoroShiroRng instance which is not seeded.
+    ///
+    /// The initial values of this RNG are constants, so all generators created
+    /// by this function will yield the same stream of random numbers. It is
+    /// highly recommended that this is created through `SeedableRng` instead of
+    /// this function
+    pub fn new_unseeded() -> XoroShiroRng {
+        // These constants were taken from the XorShiftRng implementation above.
+        // The only requirement imposed by the algorithm is that these values
+        // cannot be zero everywhere.
+        XoroShiroRng {
+            s0: 0x193a6754a8a7d469,
+            s1: 0x97830e05113ba7bb,
+        }
+    }
+}
+
+impl Rng for XoroShiroRng {
+    #[inline]
+    fn next_u32(&mut self) -> u32 {
+        self.next_u64() as u32
+    }
+
+    #[inline]
+    fn next_u64(&mut self) -> u64 {
+        let r = self.s0.wrapping_add(self.s1);
+        self.s1 ^= self.s0;
+        self.s0 = self.s0.rotate_left(55) ^ self.s1 ^ (self.s1 << 14);
+        self.s1 = self.s1.rotate_left(36);
+        r
+    }
+}
+
+impl SeedableRng<[u64; 2]> for XoroShiroRng {
+    /// Reseed an XoroShiroRng.  This will panic if `seed` is entirely 0.
+    fn reseed(&mut self, seed: [u64; 2]) {
+        assert!(!seed.iter().all(|&x| x == 0),
+                "XoroShiroRng.reseed called with an all zero seed.");
+
+        self.s0 = seed[0];
+        self.s1 = seed[1];
+    }
+
+    /// Create a new XoroShiroRng.  This will panic if `seed` is entirely 0.
+    fn from_seed(seed: [u64; 2]) -> XoroShiroRng {
+        assert!(!seed.iter().all(|&x| x == 0),
+            "XoroShiroRng::from_seed called with an all zero seed.");
+
+        XoroShiroRng {
+            s0: seed[0],
+            s1: seed[1],
+        }
+    }
+}
+
+impl Rand for XoroShiroRng {
+    fn rand<R: Rng>(rng: &mut R) -> XoroShiroRng {
+        let mut seed: [u64; 2] = rng.gen();
+        while seed == [0, 0] {
+            seed = rng.gen();
+        }
+        XoroShiroRng {
+            s0: seed[0],
+            s1: seed[1],
+        }
+    }
+}
+
 /// A wrapper for generating floating point numbers uniformly in the
 /// open interval `(0,1)` (not including either endpoint).
 ///


### PR DESCRIPTION
This is based on [the reference code][1], sourced from [the author's website][2].

The authors position xoroshiro128+ as the successor to xorshift128+,
with better statistical properties *and* higher performance ([see their website][2]).

This implementation does *not* contain the `jump` function.

Summary of benchmark numbers for a x86_64-pc-windows-msvc nightly 2016-02-12:

```text
test rand_f32                                      ... bench:       4,942 ns/iter (+/- 245) = 809 MB/s
test rand_f64                                      ... bench:       5,011 ns/iter (+/- 154) = 1596 MB/s
test rand_isaac                                    ... bench:      12,894 ns/iter (+/- 307) = 620 MB/s
test rand_isaac64                                  ... bench:       4,991 ns/iter (+/- 166) = 1602 MB/s
test rand_shuffle_100                              ... bench:       1,903 ns/iter (+/- 208)
test rand_std                                      ... bench:       5,027 ns/iter (+/- 167) = 1591 MB/s
test rand_xoroshiro                                ... bench:       1,717 ns/iter (+/- 67) = 4659 MB/s
test rand_xorshift                                 ... bench:       2,716 ns/iter (+/- 103) = 2945 MB/s
```

The same for i686-pc-windows-gnu nightly 2016-04-20:

```text
test rand_f32                                      ... bench:       6,378 ns/iter (+/- 288) = 627 MB/s
test rand_f64                                      ... bench:      11,888 ns/iter (+/- 415) = 672 MB/s
test rand_isaac                                    ... bench:       5,741 ns/iter (+/- 279) = 696 MB/s
test rand_isaac64                                  ... bench:       7,243 ns/iter (+/- 266) = 552 MB/s
test rand_shuffle_100                              ... bench:       1,101 ns/iter (+/- 47)
test rand_std                                      ... bench:       5,785 ns/iter (+/- 263) = 691 MB/s
test rand_xoroshiro                                ... bench:       3,745 ns/iter (+/- 196) = 1068 MB/s
test rand_xorshift                                 ... bench:       1,818 ns/iter (+/- 82) = 2200 MB/s
```

Yes, it *is* slower than xorshift on 32-bit, though it's still faster than everything else.

[1]: http://xorshift.di.unimi.it/xoroshiro128plus.c
[2]: http://xorshift.di.unimi.it/