### PR TITLE
Revert "Ignore should_panic tests on MSVC"

### DIFF
--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -113,13 +113,11 @@ mod test {
     }
     #[test]
     #[should_panic]
-    #[cfg_attr(target_env = "msvc", ignore)]
     fn test_exp_invalid_lambda_zero() {
         Exp::new(0.0);
     }
     #[test]
     #[should_panic]
-    #[cfg_attr(target_env = "msvc", ignore)]
     fn test_exp_invalid_lambda_neg() {
         Exp::new(-10.0);
     }

--- a/src/distributions/gamma.rs
+++ b/src/distributions/gamma.rs
@@ -358,7 +358,6 @@ mod test {
     }
     #[test]
     #[should_panic]
-    #[cfg_attr(target_env = "msvc", ignore)]
     fn test_chi_squared_invalid_dof() {
         ChiSquared::new(-1.0);
     }

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -363,7 +363,6 @@ mod tests {
     }
 
     #[test] #[should_panic]
-    #[cfg_attr(target_env = "msvc", ignore)]
     fn test_weighted_clone_change_weight() {
         let initial : Weighted<u32> = Weighted {weight: 1, item: 1};
         let mut clone = initial.clone();
@@ -372,7 +371,6 @@ mod tests {
     }
 
     #[test] #[should_panic]
-    #[cfg_attr(target_env = "msvc", ignore)]
     fn test_weighted_clone_change_item() {
         let initial : Weighted<u32> = Weighted {weight: 1, item: 1};
         let mut clone = initial.clone();
@@ -382,18 +380,15 @@ mod tests {
     }
 
     #[test] #[should_panic]
-    #[cfg_attr(target_env = "msvc", ignore)]
     fn test_weighted_choice_no_items() {
         WeightedChoice::<isize>::new(&mut []);
     }
     #[test] #[should_panic]
-    #[cfg_attr(target_env = "msvc", ignore)]
     fn test_weighted_choice_zero_weight() {
         WeightedChoice::new(&mut [Weighted { weight: 0, item: 0},
                                   Weighted { weight: 0, item: 1}]);
     }
     #[test] #[should_panic]
-    #[cfg_attr(target_env = "msvc", ignore)]
     fn test_weighted_choice_weight_overflows() {
         let x = ::std::u32::MAX / 2; // x + x + 2 is the overflow
         WeightedChoice::new(&mut [Weighted { weight: x, item: 0 },

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -179,7 +179,6 @@ mod tests {
     }
     #[test]
     #[should_panic]
-    #[cfg_attr(target_env = "msvc", ignore)]
     fn test_normal_invalid_sd() {
         Normal::new(10.0, -1.0);
     }
@@ -196,7 +195,6 @@ mod tests {
     }
     #[test]
     #[should_panic]
-    #[cfg_attr(target_env = "msvc", ignore)]
     fn test_log_normal_invalid_sd() {
         LogNormal::new(10.0, -1.0);
     }

--- a/src/distributions/range.rs
+++ b/src/distributions/range.rs
@@ -167,13 +167,11 @@ mod tests {
     use super::Range as Range;
 
     #[should_panic]
-    #[cfg_attr(target_env = "msvc", ignore)]
     #[test]
     fn test_range_bad_limits_equal() {
         Range::new(10, 10);
     }
     #[should_panic]
-    #[cfg_attr(target_env = "msvc", ignore)]
     #[test]
     fn test_range_bad_limits_flipped() {
         Range::new(10, 5);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1073,7 +1073,6 @@ mod test {
 
     #[test]
     #[should_panic]
-    #[cfg_attr(target_env = "msvc", ignore)]
     fn test_gen_range_panic_int() {
         let mut r = thread_rng();
         r.gen_range(5, -2);
@@ -1081,7 +1080,6 @@ mod test {
 
     #[test]
     #[should_panic]
-    #[cfg_attr(target_env = "msvc", ignore)]
     fn test_gen_range_panic_usize() {
         let mut r = thread_rng();
         r.gen_range(5, 2);

--- a/src/read.rs
+++ b/src/read.rs
@@ -114,7 +114,6 @@ mod test {
 
     #[test]
     #[should_panic]
-    #[cfg_attr(target_env = "msvc", ignore)]
     fn test_reader_rng_insufficient_bytes() {
         let mut rng = ReadRng::new(&[][..]);
         let mut v = [0u8; 3];


### PR DESCRIPTION
This reverts commit 557c30d0897b8c22f594f3af8571b7c630fbb407.

This was presumably from when i686 didn't support panics but it has for a
long time now so we may as well reenable these tests.