### PR TITLE
Add ability to compile for core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,12 @@ Random number generators and other randomness functionality.
 keywords = ["random", "rng"]
 
 [dependencies]
-libc = "0.2"
+libc = { version = "0.2", optional = true }
+core_io = { version = "0.0", optional = true }
+
+[features]
+default = ["libc"]
+no_std = ["core_io"]
 
 [dev-dependencies]
 log = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,13 @@ keywords = ["random", "rng"]
 
 [dependencies]
 libc = { version = "0.2", optional = true }
-core_io = { version = "0.0", optional = true }
+core_io = { version = "0.0", optional = true } # enable use of read module on no_std
 
 [features]
 default = ["libc"]
-no_std = ["core_io"]
+no_std = []
+box = [] # enable use of Box on no_std, requires alloc crate and feature
+vec = [] # enable use of Vec on no_std, requires collections crate and feature
 
 [dev-dependencies]
 log = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["random", "rng"]
 
 [dependencies]
 libc = { version = "0.2", optional = true }
-core_io = { version = "0.0", optional = true } # enable use of read module on not(std)
+core_io = { version = "0.1", optional = true } # enable use of read module on not(std)
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,13 @@ keywords = ["random", "rng"]
 
 [dependencies]
 libc = { version = "0.2", optional = true }
-core_io = { version = "0.0", optional = true } # enable use of read module on no_std
+core_io = { version = "0.0", optional = true } # enable use of read module on not(std)
 
 [features]
-default = ["libc"]
-no_std = []
-box = [] # enable use of Box on no_std, requires alloc crate and feature
-vec = [] # enable use of Vec on no_std, requires collections crate and feature
+default = ["std"]
+std = ["libc"]
+box = [] # enable use of Box on not(std), requires alloc crate and feature
+vec = [] # enable use of Vec on not(std), requires collections crate and feature
 
 [dev-dependencies]
 log = "0.3.0"

--- a/src/chacha.rs
+++ b/src/chacha.rs
@@ -10,7 +10,7 @@
 
 //! The ChaCha random number generator.
 
-use std::num::Wrapping as w;
+use core::num::Wrapping as w;
 use {Rng, SeedableRng, Rand, w32};
 
 const KEY_WORDS    : usize =  8; // 8 words for the 256-bit key

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -17,19 +17,19 @@
 //! internally. The `IndependentSample` trait is for generating values
 //! that do not need to record state.
 
-use std::marker;
+use core::marker;
 
 use {Rng, Rand};
 
 pub use self::range::Range;
-pub use self::gamma::{Gamma, ChiSquared, FisherF, StudentT};
-pub use self::normal::{Normal, LogNormal};
-pub use self::exponential::Exp;
+#[cfg(not(feature="no_std"))] pub use self::gamma::{Gamma, ChiSquared, FisherF, StudentT};
+#[cfg(not(feature="no_std"))] pub use self::normal::{Normal, LogNormal};
+#[cfg(not(feature="no_std"))] pub use self::exponential::Exp;
 
 pub mod range;
-pub mod gamma;
-pub mod normal;
-pub mod exponential;
+#[cfg(not(feature="no_std"))] pub mod gamma;
+#[cfg(not(feature="no_std"))] pub mod normal;
+#[cfg(not(feature="no_std"))] pub mod exponential;
 
 /// Types that can be used to create a random instance of `Support`.
 pub trait Sample<Support> {
@@ -201,7 +201,7 @@ impl<'a, T: Clone> IndependentSample<T> for WeightedChoice<'a, T> {
     }
 }
 
-mod ziggurat_tables;
+#[cfg(not(feature="no_std"))] mod ziggurat_tables;
 
 /// Sample a random number using the Ziggurat method (specifically the
 /// ZIGNOR variant from Doornik 2005). Most of the arguments are
@@ -218,6 +218,7 @@ mod ziggurat_tables;
 
 // the perf improvement (25-50%) is definitely worth the extra code
 // size from force-inlining.
+#[cfg(not(feature="no_std"))]
 #[inline(always)]
 fn ziggurat<R: Rng, P, Z>(
             rng: &mut R,

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -22,14 +22,14 @@ use core::marker;
 use {Rng, Rand};
 
 pub use self::range::Range;
-#[cfg(not(feature="no_std"))] pub use self::gamma::{Gamma, ChiSquared, FisherF, StudentT};
-#[cfg(not(feature="no_std"))] pub use self::normal::{Normal, LogNormal};
-#[cfg(not(feature="no_std"))] pub use self::exponential::Exp;
+#[cfg(feature="std")] pub use self::gamma::{Gamma, ChiSquared, FisherF, StudentT};
+#[cfg(feature="std")] pub use self::normal::{Normal, LogNormal};
+#[cfg(feature="std")] pub use self::exponential::Exp;
 
 pub mod range;
-#[cfg(not(feature="no_std"))] pub mod gamma;
-#[cfg(not(feature="no_std"))] pub mod normal;
-#[cfg(not(feature="no_std"))] pub mod exponential;
+#[cfg(feature="std")] pub mod gamma;
+#[cfg(feature="std")] pub mod normal;
+#[cfg(feature="std")] pub mod exponential;
 
 /// Types that can be used to create a random instance of `Support`.
 pub trait Sample<Support> {
@@ -201,7 +201,7 @@ impl<'a, T: Clone> IndependentSample<T> for WeightedChoice<'a, T> {
     }
 }
 
-#[cfg(not(feature="no_std"))] mod ziggurat_tables;
+#[cfg(feature="std")] mod ziggurat_tables;
 
 /// Sample a random number using the Ziggurat method (specifically the
 /// ZIGNOR variant from Doornik 2005). Most of the arguments are
@@ -218,7 +218,7 @@ impl<'a, T: Clone> IndependentSample<T> for WeightedChoice<'a, T> {
 
 // the perf improvement (25-50%) is definitely worth the extra code
 // size from force-inlining.
-#[cfg(not(feature="no_std"))]
+#[cfg(feature="std")]
 #[inline(always)]
 fn ziggurat<R: Rng, P, Z>(
             rng: &mut R,

--- a/src/distributions/range.rs
+++ b/src/distributions/range.rs
@@ -12,7 +12,7 @@
 
 // this is surprisingly complicated to be both generic & correct
 
-use std::num::Wrapping as w;
+use core::num::Wrapping as w;
 
 use Rng;
 use distributions::{Sample, IndependentSample};
@@ -98,7 +98,7 @@ macro_rules! integer_impl {
 
             fn construct_range(low: $ty, high: $ty) -> Range<$ty> {
                 let range = (w(high as $unsigned) - w(low as $unsigned)).0;
-                let unsigned_max: $unsigned = ::std::$unsigned::MAX;
+                let unsigned_max: $unsigned = ::core::$unsigned::MAX;
 
                 // this is the largest number that fits into $unsigned
                 // that `range` divides evenly, so, if we've sampled
@@ -185,7 +185,7 @@ mod tests {
                 $(
                    let v: &[($ty, $ty)] = &[(0, 10),
                                             (10, 127),
-                                            (::std::$ty::MIN, ::std::$ty::MAX)];
+                                            (::core::$ty::MIN, ::core::$ty::MAX)];
                    for &(low, high) in v.iter() {
                         let mut sampler: Range<$ty> = Range::new(low, high);
                         for _ in 0..1000 {

--- a/src/isaac.rs
+++ b/src/isaac.rs
@@ -12,9 +12,9 @@
 
 #![allow(non_camel_case_types)]
 
-use std::slice;
-use std::iter::repeat;
-use std::num::Wrapping as w;
+use core::slice;
+use core::iter::repeat;
+use core::num::Wrapping as w;
 
 use {Rng, SeedableRng, Rand, w32, w64};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,7 +246,7 @@
 
 #[cfg(test)] #[macro_use] extern crate log;
 
-#[cfg(not(feature="no_std"))] extern crate core;
+#[cfg(not(feature="no_std"))] extern crate std as core;
 #[cfg(feature="no_std")] extern crate core_io as io;
 #[cfg(feature="no_std")] extern crate alloc;
 #[cfg(feature="no_std")] extern crate collections;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,14 +242,15 @@
        html_root_url = "https://doc.rust-lang.org/rand/")]
 
 #![cfg_attr(feature="no_std",no_std)]
-#![cfg_attr(feature="no_std",feature(alloc,collections))]
+#![cfg_attr(feature="box",feature(alloc))]
+#![cfg_attr(feature="vec",feature(collections))]
 
 #[cfg(test)] #[macro_use] extern crate log;
 
 #[cfg(not(feature="no_std"))] extern crate std as core;
-#[cfg(feature="no_std")] extern crate core_io as io;
-#[cfg(feature="no_std")] extern crate alloc;
-#[cfg(feature="no_std")] extern crate collections;
+#[cfg(feature="core_io")] extern crate core_io as io;
+#[cfg(feature="box")] extern crate alloc;
+#[cfg(feature="vec")] extern crate collections;
 
 #[cfg(not(feature="no_std"))] use core::cell::RefCell;
 use core::marker;
@@ -257,8 +258,8 @@ use core::mem;
 #[cfg(not(feature="no_std"))] use std::io;
 #[cfg(not(feature="no_std"))] use std::rc::Rc;
 use core::num::Wrapping as w;
-#[cfg(feature="no_std")] use alloc::boxed::Box;
-#[cfg(feature="no_std")] use collections::vec::Vec;
+#[cfg(feature="box")] use alloc::boxed::Box;
+#[cfg(feature="vec")] use collections::vec::Vec;
 
 #[cfg(not(feature="no_std"))] pub use os::OsRng;
 
@@ -279,7 +280,7 @@ pub mod chacha;
 pub mod reseeding;
 mod rand_impls;
 #[cfg(not(feature="no_std"))] pub mod os;
-pub mod read;
+#[cfg(any(not(feature="no_std"),feature="core_io"))] pub mod read;
 
 #[allow(bad_style)]
 type w64 = w<u64>;
@@ -586,6 +587,7 @@ impl<'a, R: ?Sized> Rng for &'a mut R where R: Rng {
     }
 }
 
+#[cfg(any(feature="box",not(feature="no_std")))]
 impl<R: ?Sized> Rng for Box<R> where R: Rng {
     fn next_u32(&mut self) -> u32 {
         (**self).next_u32()
@@ -995,6 +997,7 @@ pub fn random<T: Rand>() -> T {
 /// let sample = sample(&mut rng, 1..100, 5);
 /// println!("{:?}", sample);
 /// ```
+#[cfg(any(feature="vec",not(feature="no_std")))]
 pub fn sample<T, I, R>(rng: &mut R, iterable: I, amount: usize) -> Vec<T>
     where I: IntoIterator<Item=T>,
           R: Rng,

--- a/src/rand_impls.rs
+++ b/src/rand_impls.rs
@@ -10,8 +10,8 @@
 
 //! The implementations of `Rand` for the built-in types.
 
-use std::char;
-use std::mem;
+use core::char;
+use core::mem;
 
 use {Rand,Rng};
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -10,8 +10,8 @@
 
 //! A wrapper around any Read to treat it as an RNG.
 
-#[cfg(not(feature="no_std"))] use std::io::{self, Read};
-#[cfg(feature="no_std")] use io::{self, Read};
+#[cfg(not(feature="std"))] use io::{self, Read};
+#[cfg(feature="std")] use std::io::{self, Read};
 use core::mem;
 use Rng;
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -10,8 +10,9 @@
 
 //! A wrapper around any Read to treat it as an RNG.
 
-use std::io::{self, Read};
-use std::mem;
+#[cfg(not(feature="no_std"))] use std::io::{self, Read};
+#[cfg(feature="no_std")] use io::{self, Read};
+use core::mem;
 use Rng;
 
 /// An RNG that reads random bytes straight from a `Read`. This will

--- a/src/reseeding.rs
+++ b/src/reseeding.rs
@@ -11,7 +11,7 @@
 //! A wrapper around another RNG that reseeds it after it
 //! generates a certain number of random bytes.
 
-use std::default::Default;
+use core::default::Default;
 
 use {Rng, SeedableRng};
 


### PR DESCRIPTION
This patch makes it possible to compile this crate with `no_std` enabled. This mostly just makes available the `Rng` trait and related types. Of course, in core, there is no default RNG.

Basically the patch just chanes all mentions of `std` to `core` and configs-out everything that doesn't work in core. It adds a dependency on my [core_io crate](https://crates.io/crates/core_io) which was made basically the same way.

To use the crate in core-mode, you have to do `{use-default-features=false,features=["no_std"]}`.

I'm happy to carry this patch as a separate `core_rand` crate but I think it'd be nicer if it lived upstream (getting closer to my ultimate goal of making most things available in no_std mode).
