### PR TITLE
Change the Rand trait for bool

### DIFF
--- a/src/rand_impls.rs
+++ b/src/rand_impls.rs
@@ -155,7 +155,13 @@ impl Rand for char {
 impl Rand for bool {
     #[inline]
     fn rand<R: Rng>(rng: &mut R) -> bool {
-        rng.gen::<u8>() & 1 == 1
+        // Generate a 32-bit value and test the sign.
+        // Many PRNGs exhibit non-uniform random quality across their bits. The
+        // low order bit of LCGs, for example, flips 0/1. Even some high
+        // quality PRNGs, like Xoroshiro128+, have strange low order bit
+        // behavior. Testing the sign offers protection against these common
+        // pathologies.
+        rng.gen::<i32>() < 0
     }
 }
 


### PR DESCRIPTION
To generate a bool, generate a 32-bit value and test the sign.

Some common pseudo-random number generators exhibit an uneven quality distribution across their bits. Linear congruential generators return odd and even numbers in an alternating fashion. The low order bit of Xoroshiro128+ behaves like a linear feedback shift register. By testing the sign, we can instead rely on the high ordered bit of an emission, which will generally be of higher quality.
