### PR TITLE
Make Range fields public so others can impl SampleRange

### DIFF
--- a/src/distributions/range.rs
+++ b/src/distributions/range.rs
@@ -48,9 +48,9 @@ use distributions::{Sample, IndependentSample};
 /// ```
 #[derive(Clone, Copy)]
 pub struct Range<X> {
-    low: X,
-    range: X,
-    accept_zone: X
+    pub low: X,
+    pub range: X,
+    pub accept_zone: X
 }
 
 impl<X: SampleRange + PartialOrd> Range<X> {


### PR DESCRIPTION
This allows external types to implement SampleRange and use Range. Currently it is impossible to implement construct_range because the fields are private and a Range struct cannot be created.

Alternative approaches would be to create another new() function on Range, or to not export SampleRange & co.