### PR TITLE
Speed up range sampling.

### DIFF
--- a/benches/distributions/mod.rs
+++ b/benches/distributions/mod.rs
@@ -1,3 +1,4 @@
 mod exponential;
 mod normal;
 mod gamma;
+mod range;

--- a/benches/distributions/range.rs
+++ b/benches/distributions/range.rs
@@ -1,0 +1,18 @@
+use std::mem::size_of;
+use std::cmp;
+use test::Bencher;
+use rand;
+use rand::distributions::Sample;
+use rand::distributions::Range;
+
+#[bench]
+fn rand_range(b: &mut Bencher) {
+    let mut rng = rand::weak_rng();
+    let mut range = Range::new(10, 10000);
+    b.iter(|| {
+        for _ in 0..::RAND_BENCH_N {
+            range.sample(&mut rng);
+        }
+    });
+    b.bytes = size_of::<u32>() as u64 * ::RAND_BENCH_N;
+}


### PR DESCRIPTION
This change removes division from the rejection sampler in random_range().
Replace divisions in range sampling with bitshifting. Instead of finding a
well fitting range, we generate a number [0,2^n) and reject out of range
values.

In synthetic benchmarks, this approximately doubles the throughput.
