### PR TITLE
Add support for OpenBSD's getentropy(2)

### DIFF
--- a/src/os.rs
+++ b/src/os.rs
@@ -23,6 +23,8 @@ use Rng;
 ///   service provider with the `PROV_RSA_FULL` type.
 /// - iOS: calls SecRandomCopyBytes as /dev/(u)random is sandboxed.
 /// - PNaCl: calls into the `nacl-irt-random-0.1` IRT interface.
+/// - FreeBSD: use the `kernel.arandom` `sysctl(2)` interface
+/// - OpenBSD: use the `getentropy(2)` system call
 ///
 /// This does not block.
 pub struct OsRng(imp::OsRng);


### PR DESCRIPTION
OpenBSD has a simple syscall to get entropy. Use it instead of falling back on device files.

`getentropy(2)` is available on every version of OpenBSD that supports Rust, so I'm not bothering checking for it's presence (since OpenBSD 5.6).