### PR TITLE
Partially revert #122 for NetBSD

### DIFF
--- a/src/os.rs
+++ b/src/os.rs
@@ -57,7 +57,6 @@ fn next_u64(mut fill_buf: &mut FnMut(&mut [u8])) -> u64 {
 #[cfg(all(unix, not(target_os = "ios"),
           not(target_os = "nacl"),
           not(target_os = "freebsd"),
-          not(target_os = "netbsd"),
           not(target_os = "openbsd")))]
 mod imp {
     extern crate libc;


### PR DESCRIPTION
Makes NetBSD to work again by restoring `OsRng` implementation using
`/dev/urandom`.

The line should have been removed in previous commit.