### PR TITLE
Add inline attribute to SampleRange::construct_range

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -10,7 +10,7 @@ mod distributions;
 use std::mem::size_of;
 use test::{black_box, Bencher};
 use rand::{XorShiftRng, StdRng, IsaacRng, Isaac64Rng, Rng};
-use rand::{OsRng, weak_rng};
+use rand::{OsRng, sample, weak_rng};
 
 #[bench]
 fn rand_xorshift(b: &mut Bencher) {
@@ -84,5 +84,14 @@ fn rand_shuffle_100(b: &mut Bencher) {
     let x : &mut [usize] = &mut [1; 100];
     b.iter(|| {
         rng.shuffle(x);
+    })
+}
+
+#[bench]
+fn rand_sample_10_of_100(b: &mut Bencher) {
+    let mut rng = weak_rng();
+    let x : &[usize] = &[1; 100];
+    b.iter(|| {
+        sample(&mut rng, x, 10);
     })
 }

--- a/src/distributions/range.rs
+++ b/src/distributions/range.rs
@@ -96,6 +96,7 @@ macro_rules! integer_impl {
             // "bit-equal", so casting between them is a no-op & a
             // bijection.
 
+            #[inline]
             fn construct_range(low: $ty, high: $ty) -> Range<$ty> {
                 let range = (w(high as $unsigned) - w(low as $unsigned)).0;
                 let unsigned_max: $unsigned = ::std::$unsigned::MAX;
@@ -112,6 +113,7 @@ macro_rules! integer_impl {
                     accept_zone: zone as $ty
                 }
             }
+
             #[inline]
             fn sample_range<R: Rng>(r: &Range<$ty>, rng: &mut R) -> $ty {
                 loop {


### PR DESCRIPTION
This improves the benchmark for `sample` and `shuffle` (these are the only functions that call `gen_range` explicitly in a loop):

```
rand_sample_10_of_100  3,889      3,437              -452  -11.62%
rand_shuffle_100       3,780      3,158              -622  -16.46%
```

Others benchmarks was not affected.