### PR TITLE
Debug impls for non-distribution public types

### DIFF
--- a/src/chacha.rs
+++ b/src/chacha.rs
@@ -26,7 +26,7 @@ const CHACHA_ROUNDS: u32 = 20; // Cryptographically secure from 8 upwards as of 
 ///
 /// [1]: D. J. Bernstein, [*ChaCha, a variant of
 /// Salsa20*](http://cr.yp.to/chacha.html)
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct ChaChaRng {
     buffer:  [w32; STATE_WORDS], // Internal buffer of output
     state:   [w32; STATE_WORDS], // Initial state

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -17,6 +17,8 @@
 //! internally. The `IndependentSample` trait is for generating values
 //! that do not need to record state.
 
+#![allow(missing_debug_implementations)]
+
 use std::marker;
 
 use {Rng, Rand};

--- a/src/isaac.rs
+++ b/src/isaac.rs
@@ -15,6 +15,7 @@
 use std::slice;
 use std::iter::repeat;
 use std::num::Wrapping as w;
+use std::fmt;
 
 use {Rng, SeedableRng, Rand, w32, w64};
 
@@ -257,6 +258,12 @@ impl Rand for IsaacRng {
 
         ret.init(true);
         return ret;
+    }
+}
+
+impl fmt::Debug for IsaacRng {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "IsaacRng {{}}")
     }
 }
 
@@ -503,6 +510,11 @@ impl Rand for Isaac64Rng {
     }
 }
 
+impl fmt::Debug for Isaac64Rng {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Isaac64Rng {{}}")
+    }
+}
 
 #[cfg(test)]
 mod test {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,7 +241,10 @@
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/rand/")]
 
+#![deny(missing_debug_implementations)]
+
 #[cfg(test)] #[macro_use] extern crate log;
+
 
 use std::cell::RefCell;
 use std::marker;
@@ -604,6 +607,7 @@ impl<R: ?Sized> Rng for Box<R> where R: Rng {
 ///
 /// [`gen_iter`]: trait.Rng.html#method.gen_iter
 /// [`Rng`]: trait.Rng.html
+#[derive(Debug)]
 pub struct Generator<'a, T, R:'a> {
     rng: &'a mut R,
     _marker: marker::PhantomData<fn() -> T>,
@@ -623,6 +627,7 @@ impl<'a, T: Rand, R: Rng> Iterator for Generator<'a, T, R> {
 ///
 /// [`gen_ascii_chars`]: trait.Rng.html#method.gen_ascii_chars
 /// [`Rng`]: trait.Rng.html
+#[derive(Debug)]
 pub struct AsciiGenerator<'a, R:'a> {
     rng: &'a mut R,
 }
@@ -682,7 +687,7 @@ pub trait SeedableRng<Seed>: Rng {
 /// RNGs"](http://www.jstatsoft.org/v08/i14/paper). *Journal of
 /// Statistical Software*. Vol. 8 (Issue 14).
 #[allow(missing_copy_implementations)]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct XorShiftRng {
     x: w32,
     y: w32,
@@ -772,6 +777,7 @@ impl Rand for XorShiftRng {
 /// let Open01(val) = random::<Open01<f32>>();
 /// println!("f32 from (0,1): {}", val);
 /// ```
+#[derive(Debug)]
 pub struct Open01<F>(pub F);
 
 /// A wrapper for generating floating point numbers uniformly in the
@@ -789,11 +795,12 @@ pub struct Open01<F>(pub F);
 /// let Closed01(val) = random::<Closed01<f32>>();
 /// println!("f32 from [0,1]: {}", val);
 /// ```
+#[derive(Debug)]
 pub struct Closed01<F>(pub F);
 
 /// The standard RNG. This is designed to be efficient on the current
 /// platform.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct StdRng {
     rng: IsaacWordRng,
 }
@@ -856,6 +863,7 @@ pub fn weak_rng() -> XorShiftRng {
 }
 
 /// Controls how the thread-local RNG is reseeded.
+#[derive(Debug)]
 struct ThreadRngReseeder;
 
 impl reseeding::Reseeder<StdRng> for ThreadRngReseeder {
@@ -870,7 +878,7 @@ const THREAD_RNG_RESEED_THRESHOLD: u64 = 32_768;
 type ThreadRngInner = reseeding::ReseedingRng<StdRng, ThreadRngReseeder>;
 
 /// The thread-local RNG.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ThreadRng {
     rng: Rc<RefCell<ThreadRngInner>>,
 }

--- a/src/os.rs
+++ b/src/os.rs
@@ -11,7 +11,7 @@
 //! Interfaces to the operating system provided random number
 //! generators.
 
-use std::{io, mem};
+use std::{io, mem, fmt};
 use Rng;
 
 /// A random number generator that retrieves randomness straight from
@@ -40,6 +40,12 @@ impl Rng for OsRng {
     fn next_u32(&mut self) -> u32 { self.0.next_u32() }
     fn next_u64(&mut self) -> u64 { self.0.next_u64() }
     fn fill_bytes(&mut self, v: &mut [u8]) { self.0.fill_bytes(v) }
+}
+
+impl fmt::Debug for OsRng {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "OsRng {{}}")
+    }
 }
 
 fn next_u32(mut fill_buf: &mut FnMut(&mut [u8])) -> u32 {
@@ -213,6 +219,7 @@ mod imp {
     use Rng;
     use self::libc::{c_int, size_t};
 
+    #[derive(Debug)]
     pub struct OsRng;
 
     enum SecRandom {}
@@ -259,6 +266,7 @@ mod imp {
 
     use super::{next_u32, next_u64};
 
+    #[derive(Debug)]
     pub struct OsRng;
 
     impl OsRng {
@@ -302,6 +310,7 @@ mod imp {
 
     use super::{next_u32, next_u64};
 
+    #[derive(Debug)]
     pub struct OsRng;
 
     impl OsRng {
@@ -339,6 +348,7 @@ mod imp {
     use Rng;
     use read::ReadRng;
 
+    #[derive(Debug)]
     pub struct OsRng {
         inner: ReadRng<File>,
     }
@@ -396,6 +406,7 @@ mod imp {
         fn CryptReleaseContext(hProv: HCRYPTPROV, dwFlags: DWORD) -> BOOL;
     }
 
+    #[derive(Debug)]
     pub struct OsRng {
         hcryptprov: HCRYPTPROV
     }
@@ -463,6 +474,7 @@ mod imp {
 
     use super::{next_u32, next_u64};
 
+    #[derive(Debug)]
     pub struct OsRng(extern fn(dest: *mut libc::c_void,
                                bytes: libc::size_t,
                                read: *mut libc::size_t) -> libc::c_int);

--- a/src/read.rs
+++ b/src/read.rs
@@ -30,6 +30,7 @@ use Rng;
 /// let mut rng = read::ReadRng::new(&data[..]);
 /// println!("{:x}", rng.gen::<u32>());
 /// ```
+#[derive(Debug)]
 pub struct ReadRng<R> {
     reader: R
 }

--- a/src/reseeding.rs
+++ b/src/reseeding.rs
@@ -21,6 +21,7 @@ const DEFAULT_GENERATION_THRESHOLD: u64 = 32 * 1024;
 
 /// A wrapper around any RNG which reseeds the underlying RNG after it
 /// has generated a certain number of random bytes.
+#[derive(Debug)]
 pub struct ReseedingRng<R, Rsdr> {
     rng: R,
     generation_threshold: u64,
@@ -132,7 +133,7 @@ pub trait Reseeder<R> {
 
 /// Reseed an RNG using a `Default` instance. This reseeds by
 /// replacing the RNG with the result of a `Default::default` call.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct ReseedWithDefault;
 
 impl<R: Rng + Default> Reseeder<R> for ReseedWithDefault {


### PR DESCRIPTION
Solution for #130.

Changes:
* `#[derive(Debug)]` for public types where possible.
* Opaque `Type {}` debug for remaining public types (`OsRng`, `IsaacRng` and `Isaac64Rng`).
* `#![deny(missing_debug_implementations)]` on crate.

There are no implementations for the `distributions` module as there is already a PR for that. I added a temporary `#![allow(missing_debug_implementations)]` until it is merged.

I figured most types will just need a derive. For those that don't, this can be a good discussion starter. Personally, I'm not sure what to do with the types where derive isn't possible. I don't see any point in exposing 512+ ints for ISAAC, so perhaps `IsaacRng {}` is the best we can do.