### PR TITLE
Derive Debug for distibutions

### DIFF
--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -34,7 +34,7 @@ use distributions::{ziggurat, ziggurat_tables, Sample, IndependentSample};
 /// let Exp1(x) = rand::random();
 /// println!("{}", x);
 /// ```
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Exp1(pub f64);
 
 // This could be done via `-rng.gen::<f64>().ln()` but that is slower.
@@ -71,7 +71,7 @@ impl Rand for Exp1 {
 /// let v = exp.ind_sample(&mut rand::thread_rng());
 /// println!("{} is from a Exp(2) distribution", v);
 /// ```
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Exp {
     /// `lambda` stored as `1/lambda`, since this is what we scale by.
     lambda_inverse: f64

--- a/src/distributions/gamma.rs
+++ b/src/distributions/gamma.rs
@@ -49,12 +49,12 @@ use super::{IndependentSample, Sample, Exp};
 /// for Generating Gamma Variables" *ACM Trans. Math. Softw.* 26, 3
 /// (September 2000),
 /// 363-372. DOI:[10.1145/358407.358414](http://doi.acm.org/10.1145/358407.358414)
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Gamma {
     repr: GammaRepr,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 enum GammaRepr {
     Large(GammaLargeShape),
     One(Exp),
@@ -75,7 +75,7 @@ enum GammaRepr {
 ///
 /// See `Gamma` for sampling from a Gamma distribution with general
 /// shape parameters.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 struct GammaSmallShape {
     inv_shape: f64,
     large_shape: GammaLargeShape
@@ -85,7 +85,7 @@ struct GammaSmallShape {
 ///
 /// See `Gamma` for sampling from a Gamma distribution with general
 /// shape parameters.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 struct GammaLargeShape {
     scale: f64,
     c: f64,
@@ -195,12 +195,12 @@ impl IndependentSample<f64> for GammaLargeShape {
 /// let v = chi.ind_sample(&mut rand::thread_rng());
 /// println!("{} is from a χ²(11) distribution", v)
 /// ```
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct ChiSquared {
     repr: ChiSquaredRepr,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 enum ChiSquaredRepr {
     // k == 1, Gamma(alpha, ..) is particularly slow for alpha < 1,
     // e.g. when alpha = 1/2 as it would be for this case, so special-
@@ -253,7 +253,7 @@ impl IndependentSample<f64> for ChiSquared {
 /// let v = f.ind_sample(&mut rand::thread_rng());
 /// println!("{} is from an F(2, 32) distribution", v)
 /// ```
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct FisherF {
     numer: ChiSquared,
     denom: ChiSquared,
@@ -297,7 +297,7 @@ impl IndependentSample<f64> for FisherF {
 /// let v = t.ind_sample(&mut rand::thread_rng());
 /// println!("{} is from a t(11) distribution", v)
 /// ```
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct StudentT {
     chi: ChiSquared,
     dof: f64

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -17,8 +17,6 @@
 //! internally. The `IndependentSample` trait is for generating values
 //! that do not need to record state.
 
-#![allow(missing_debug_implementations)]
-
 use std::marker;
 
 use {Rng, Rand};
@@ -55,6 +53,7 @@ pub trait IndependentSample<Support>: Sample<Support> {
 
 /// A wrapper for generating types that implement `Rand` via the
 /// `Sample` & `IndependentSample` traits.
+#[derive(Debug)]
 pub struct RandSample<Sup> {
     _marker: marker::PhantomData<fn() -> Sup>,
 }
@@ -81,8 +80,7 @@ impl<Sup> RandSample<Sup> {
 }
 
 /// A value with a particular weight for use with `WeightedChoice`.
-#[derive(Copy)]
-#[derive(Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct Weighted<T> {
     /// The numerical weight of this item
     pub weight: u32,
@@ -115,6 +113,7 @@ pub struct Weighted<T> {
 ///      println!("{}", wc.ind_sample(&mut rng));
 /// }
 /// ```
+#[derive(Debug)]
 pub struct WeightedChoice<'a, T:'a> {
     items: &'a mut [Weighted<T>],
     weight_range: Range<u32>

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -33,7 +33,7 @@ use distributions::{ziggurat, ziggurat_tables, Sample, IndependentSample};
 /// let StandardNormal(x) = rand::random();
 /// println!("{}", x);
 /// ```
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct StandardNormal(pub f64);
 
 impl Rand for StandardNormal {
@@ -88,7 +88,7 @@ impl Rand for StandardNormal {
 /// let v = normal.ind_sample(&mut rand::thread_rng());
 /// println!("{} is from a N(2, 9) distribution", v)
 /// ```
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Normal {
     mean: f64,
     std_dev: f64,
@@ -136,7 +136,7 @@ impl IndependentSample<f64> for Normal {
 /// let v = log_normal.ind_sample(&mut rand::thread_rng());
 /// println!("{} is from an ln N(2, 9) distribution", v)
 /// ```
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct LogNormal {
     norm: Normal
 }

--- a/src/distributions/range.rs
+++ b/src/distributions/range.rs
@@ -46,7 +46,7 @@ use distributions::{Sample, IndependentSample};
 ///     println!("{}", sum);
 /// }
 /// ```
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Range<X> {
     low: X,
     range: X,


### PR DESCRIPTION
With this patch all public types have Debug implementations. Fixes #130.

I decided to create this PR even though there is an alternative ( #120). However, that PR is failing builds and not complete. If this is merged, #120 becomes redundant.