### PR TITLE
Add note that shuffle uses Fisher–Yates shuffle which is unbiased

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -534,6 +534,9 @@ pub trait Rng {
 
     /// Shuffle a mutable slice in place.
     ///
+    /// This applies Durstenfeld's algorithm for the [Fisher–Yates shuffle](https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm) 
+    /// which produces an unbiased permutation.
+    ///
     /// # Example
     ///
     /// ```rust


### PR DESCRIPTION
Not sure if you actually want that wikipedia link.  Or if one should reference Knuth, etc. instead.  Just saying Fisher–Yates shuffle should help folks figure out that the result is unbiased.  