### PR TITLE
i128 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,10 @@ before_script:
   - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
 script:
   - cargo build --verbose
+  - ([ $TRAVIS_RUST_VERSION != nightly ] || cargo build --verbose --features nightly)
   - cargo test --verbose
-  - cargo doc --no-deps
+  - ([ $TRAVIS_RUST_VERSION != nightly ] || cargo test --verbose --features nightly)
+  - ([ $TRAVIS_RUST_VERSION != nightly ] || cargo doc --no-deps --features nightly)
 after_success:
   - travis-cargo --only nightly doc-upload
 env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ Random number generators and other randomness functionality.
 keywords = ["random", "rng"]
 categories = ["algorithms"]
 
+[features]
+i128_support = []
+nightly = ["i128_support"]
+
 [dependencies]
 libc = "0.2"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,3 +15,4 @@ build: false
 
 test_script:
   - cargo test --verbose --target %TARGET%
+  - cargo test --verbose --target %TARGET% --features nightly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,7 +292,7 @@ pub trait Rng {
     ///
     /// This rarely needs to be called directly, prefer `r.gen()` to
     /// `r.next_u32()`.
-    // FIXME #7771: Should be implemented in terms of next_u64
+    // FIXME #rust-lang/rfcs#628: Should be implemented in terms of next_u64
     fn next_u32(&mut self) -> u32;
 
     /// Return the next random u64.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,6 +243,8 @@
 
 #![deny(missing_debug_implementations)]
 
+#![cfg_attr(feature = "i128_support", feature(i128_type))]
+
 #[cfg(test)] #[macro_use] extern crate log;
 
 

--- a/src/rand_impls.rs
+++ b/src/rand_impls.rs
@@ -54,6 +54,14 @@ impl Rand for i64 {
     }
 }
 
+#[cfg(feature = "i128_support")]
+impl Rand for i128 {
+    #[inline]
+    fn rand<R: Rng>(rng: &mut R) -> i128 {
+        rng.gen::<u128>() as i128
+    }
+}
+
 impl Rand for usize {
     #[inline]
     fn rand<R: Rng>(rng: &mut R) -> usize {
@@ -92,6 +100,15 @@ impl Rand for u64 {
         rng.next_u64()
     }
 }
+
+#[cfg(feature = "i128_support")]
+impl Rand for u128 {
+    #[inline]
+    fn rand<R: Rng>(rng: &mut R) -> u128 {
+        ((rng.next_u64() as u128) << 64) | (rng.next_u64() as u128)
+    }
+}
+
 
 macro_rules! float_impls {
     ($mod_name:ident, $ty:ty, $mantissa_bits:expr, $method_name:ident) => {


### PR DESCRIPTION
This PR implements `Rand` for `i128` and `u128`. Some notes:

* Should `Rng` gain a `next_u128` method?

  This may be desirable in case a `Rng` can directly produce 128 bit wide outputs. 

* Currently `i128` support is enabled using a single feature flag, which may not be the best solution: 

  We probably need two different feature flags in the future: one to enable the `i128` `impl`s and one for toggling the `#![feature(i128_type)]` (`i128_type` will hopefully become stable in the near future, so `#![feature(i128_type)]` will not be needed but the `impl`s will still need to be disabled for older rust versions without `i128` support).

  An alternative would be to automatically enable the features for supporting rust versions using a build script. This would be my preferred solution I think, although I don't know what the policy is for using build scripts like this.

* I'm not completely sure about the travis changes.

Fixes #139.

r? @alexcrichton 

(If you want the fixme update in a separate PR, please tell me).