### PR TITLE
Clarify reservoir sampling docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -977,7 +977,8 @@ pub fn random<T: Rand>() -> T {
     thread_rng().gen()
 }
 
-/// Randomly sample up to `amount` elements from an iterator.
+/// Randomly sample up to `amount` elements from a finite iterator.
+/// The order of elements in the sample is not random.
 ///
 /// # Example
 ///


### PR DESCRIPTION
For example, `sample(r, b"ACGT", 4)` always returns `[b'A', b'C', b'G', b'T']`.