### PR TITLE
Don't use floating point literals in patterns.

### DIFF
--- a/src/distributions/gamma.rs
+++ b/src/distributions/gamma.rs
@@ -102,10 +102,12 @@ impl Gamma {
         assert!(shape > 0.0, "Gamma::new called with shape <= 0");
         assert!(scale > 0.0, "Gamma::new called with scale <= 0");
 
-        let repr = match shape {
-            1.0         => One(Exp::new(1.0 / scale)),
-            0.0 ... 1.0 => Small(GammaSmallShape::new_raw(shape, scale)),
-            _           => Large(GammaLargeShape::new_raw(shape, scale))
+        let repr = if shape == 1.0 {
+            One(Exp::new(1.0 / scale))
+        } else if shape < 1.0 {
+            Small(GammaSmallShape::new_raw(shape, scale))
+        } else {
+            Large(GammaLargeShape::new_raw(shape, scale))
         };
         Gamma { repr: repr }
     }


### PR DESCRIPTION
Fixes #147.