### PR TITLE
[breaking change] Automatically impl Sample for T: IndependentSample

### DIFF
--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -11,7 +11,7 @@
 //! The exponential distribution.
 
 use {Rng, Rand};
-use distributions::{ziggurat, ziggurat_tables, Sample, IndependentSample};
+use distributions::{ziggurat, ziggurat_tables, IndependentSample};
 
 /// A wrapper around an `f64` to generate Exp(1) random numbers.
 ///
@@ -87,9 +87,6 @@ impl Exp {
     }
 }
 
-impl Sample<f64> for Exp {
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
-}
 impl IndependentSample<f64> for Exp {
     fn ind_sample<R: Rng>(&self, rng: &mut R) -> f64 {
         let Exp1(n) = rng.gen::<Exp1>();

--- a/src/distributions/gamma.rs
+++ b/src/distributions/gamma.rs
@@ -17,7 +17,7 @@ use self::ChiSquaredRepr::*;
 
 use {Rng, Open01};
 use super::normal::StandardNormal;
-use super::{IndependentSample, Sample, Exp};
+use super::{IndependentSample, Exp};
 
 /// The Gamma distribution `Gamma(shape, scale)` distribution.
 ///
@@ -131,16 +131,6 @@ impl GammaLargeShape {
     }
 }
 
-impl Sample<f64> for Gamma {
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
-}
-impl Sample<f64> for GammaSmallShape {
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
-}
-impl Sample<f64> for GammaLargeShape {
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
-}
-
 impl IndependentSample<f64> for Gamma {
     fn ind_sample<R: Rng>(&self, rng: &mut R) -> f64 {
         match self.repr {
@@ -222,9 +212,6 @@ impl ChiSquared {
         ChiSquared { repr: repr }
     }
 }
-impl Sample<f64> for ChiSquared {
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
-}
 impl IndependentSample<f64> for ChiSquared {
     fn ind_sample<R: Rng>(&self, rng: &mut R) -> f64 {
         match self.repr {
@@ -276,9 +263,6 @@ impl FisherF {
         }
     }
 }
-impl Sample<f64> for FisherF {
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
-}
 impl IndependentSample<f64> for FisherF {
     fn ind_sample<R: Rng>(&self, rng: &mut R) -> f64 {
         self.numer.ind_sample(rng) / self.denom.ind_sample(rng) * self.dof_ratio
@@ -313,9 +297,6 @@ impl StudentT {
             dof: n
         }
     }
-}
-impl Sample<f64> for StudentT {
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
 }
 impl IndependentSample<f64> for StudentT {
     fn ind_sample<R: Rng>(&self, rng: &mut R) -> f64 {

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -51,6 +51,20 @@ pub trait IndependentSample<Support>: Sample<Support> {
     fn ind_sample<R: Rng>(&self, &mut R) -> Support;
 }
 
+impl<Support, T: IndependentSample<Support>> Sample<Support> for T {
+    #[inline]
+    fn sample<R: Rng>(&mut self, rng: &mut R) -> Support {
+        self.ind_sample(rng)
+    }
+}
+
+impl<'a, Support, T: IndependentSample<Support>> IndependentSample<Support> for &'a T {
+    #[inline]
+    fn ind_sample<R: Rng>(&self, rng: &mut R) -> Support {
+        (*self).ind_sample(rng)
+    }
+}
+
 /// A wrapper for generating types that implement `Rand` via the
 /// `Sample` & `IndependentSample` traits.
 #[derive(Debug)]
@@ -61,10 +75,6 @@ pub struct RandSample<Sup> {
 impl<Sup> Copy for RandSample<Sup> {}
 impl<Sup> Clone for RandSample<Sup> {
     fn clone(&self) -> Self { *self }
-}
-
-impl<Sup: Rand> Sample<Sup> for RandSample<Sup> {
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> Sup { self.ind_sample(rng) }
 }
 
 impl<Sup: Rand> IndependentSample<Sup> for RandSample<Sup> {
@@ -153,10 +163,6 @@ impl<'a, T: Clone> WeightedChoice<'a, T> {
             weight_range: Range::new(0, running_total)
         }
     }
-}
-
-impl<'a, T: Clone> Sample<T> for WeightedChoice<'a, T> {
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> T { self.ind_sample(rng) }
 }
 
 impl<'a, T: Clone> IndependentSample<T> for WeightedChoice<'a, T> {

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -11,7 +11,7 @@
 //! The normal and derived distributions.
 
 use {Rng, Rand, Open01};
-use distributions::{ziggurat, ziggurat_tables, Sample, IndependentSample};
+use distributions::{ziggurat, ziggurat_tables, IndependentSample};
 
 /// A wrapper around an `f64` to generate N(0, 1) random numbers
 /// (a.k.a.  a standard normal, or Gaussian).
@@ -110,9 +110,6 @@ impl Normal {
         }
     }
 }
-impl Sample<f64> for Normal {
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
-}
 impl IndependentSample<f64> for Normal {
     fn ind_sample<R: Rng>(&self, rng: &mut R) -> f64 {
         let StandardNormal(n) = rng.gen::<StandardNormal>();
@@ -153,9 +150,6 @@ impl LogNormal {
         assert!(std_dev >= 0.0, "LogNormal::new called with `std_dev` < 0");
         LogNormal { norm: Normal::new(mean, std_dev) }
     }
-}
-impl Sample<f64> for LogNormal {
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
 }
 impl IndependentSample<f64> for LogNormal {
     fn ind_sample<R: Rng>(&self, rng: &mut R) -> f64 {

--- a/src/distributions/range.rs
+++ b/src/distributions/range.rs
@@ -15,7 +15,7 @@
 use std::num::Wrapping as w;
 
 use Rng;
-use distributions::{Sample, IndependentSample};
+use distributions::IndependentSample;
 
 /// Sample values uniformly between two bounds.
 ///
@@ -62,10 +62,6 @@ impl<X: SampleRange + PartialOrd> Range<X> {
     }
 }
 
-impl<Sup: SampleRange> Sample<Sup> for Range<Sup> {
-    #[inline]
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> Sup { self.ind_sample(rng) }
-}
 impl<Sup: SampleRange> IndependentSample<Sup> for Range<Sup> {
     fn ind_sample<R: Rng>(&self, rng: &mut R) -> Sup {
         SampleRange::sample_range(self, rng)


### PR DESCRIPTION
This removes the need to manually implement Sample for types that implement IndependentSample, cutting down on boilerplate and reducing chances for mis-matched implementations.

It also adds blanket impls for `&T` where `T: IndependentSample`, so that `.sample()` can be called on these types without needing a unique reference.

This is a breaking change because it conflicts with crates that implement both Sample and IndependentSample for their own types.