### PR TITLE
Enable range sampling for 128-bit integers

### DIFF
--- a/src/distributions/range.rs
+++ b/src/distributions/range.rs
@@ -136,11 +136,15 @@ integer_impl! { i8, u8 }
 integer_impl! { i16, u16 }
 integer_impl! { i32, u32 }
 integer_impl! { i64, u64 }
+#[cfg(feature = "i128_support")]
+integer_impl! { i128, u128 }
 integer_impl! { isize, usize }
 integer_impl! { u8, u8 }
 integer_impl! { u16, u16 }
 integer_impl! { u32, u32 }
 integer_impl! { u64, u64 }
+#[cfg(feature = "i128_support")]
+integer_impl! { u128, u128 }
 integer_impl! { usize, usize }
 
 macro_rules! float_impl {
@@ -200,8 +204,12 @@ mod tests {
                  )*
             }}
         }
+        #[cfg(not(feature = "i128_support"))]
         t!(i8, i16, i32, i64, isize,
-           u8, u16, u32, u64, usize)
+           u8, u16, u32, u64, usize);
+        #[cfg(feature = "i128_support")]
+        t!(i8, i16, i32, i64, i128, isize,
+           u8, u16, u32, u64, u128, usize);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,7 +243,7 @@
 
 #![deny(missing_debug_implementations)]
 
-#![cfg_attr(feature = "i128_support", feature(i128_type))]
+#![cfg_attr(feature = "i128_support", feature(i128_type, i128))]
 
 #[cfg(test)] #[macro_use] extern crate log;
 


### PR DESCRIPTION
As an enhancement for #140, this patch adds support for range sampling.

I'm kinda new to Rust so this change may look naïve or even problematic. I'll try to improve it if needed.