### PR TITLE
Change derive behavior for enums with less than three variants

### DIFF
--- a/rand-derive/tests/rand_macros.rs
+++ b/rand-derive/tests/rand_macros.rs
@@ -19,7 +19,23 @@ struct Tuple(i16, Option<f64>);
 struct Unit;
 
 #[derive(Rand)]
-enum Enum {
+enum EnumUnit {
+    X,
+}
+
+#[derive(Rand)]
+enum Enum1 {
+    X(u8, f32),
+}
+
+#[derive(Rand)]
+enum Enum2 {
+    X(bool),
+    Y,
+}
+
+#[derive(Rand)]
+enum Enum3 {
     X { x: u8, y: isize },
     Y([bool; 4]),
     Z,
@@ -34,6 +50,9 @@ fn smoke() {
         let _ = rng.gen::<Struct>();
         let _ = rng.gen::<Tuple>();
         let _ = rng.gen::<Unit>();
-        let _ = rng.gen::<Enum>();
+        let _ = rng.gen::<EnumUnit>();
+        let _ = rng.gen::<Enum1>();
+        let _ = rng.gen::<Enum2>();
+        let _ = rng.gen::<Enum3>();
     }
 }


### PR DESCRIPTION
Enums with a single variant will simply have the inner type (if any) generated. This avoids extra calls on the `Rng`.

Enums with two variants will generate a `bool` rather than a number in a range. This ~should be~ **is** a much faster approach, ~although I have not tested it~.

These changes avoid calls to the `unreachable!()` macro, which generates a panic in unnecessary cases like these. This in turn may make the generated functions faster since unused instructions won't be loaded.

Enums with three or more variants should behave the same as before.

---

I got around to benchmarking before and after. These results are from running `thread_rng` 100 times:

| _ns/iter_ | 1 Unit | 1 With Payload | 2 Unit | 2 With Payload |
| --------- | -----: | -------------: | -----: | -------------: |
| Before    | 4,449  | 6,971          | 4,367  | 6,900          |
| After     | 35     | 2,567          | 2,605  | 5,245          |


Here's the code I benchmarked with:

```rust
#[derive(Rand)]
enum Thing {
    A(u8),
    B(u8),
}

#[bench]
fn enum_gen(b: &mut Bencher) {
    let mut rng = thread_rng();
    b.iter(|| {
        for _ in 0..100 {
            let _: Thing = black_box(rng.gen());
        }
    });
}
```