### PR TITLE
Update README.md license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ fn main() {
 # License
 
 `rand` is primarily distributed under the terms of both the MIT
-license and the Apache License (Version 2.0), with portions covered by various
-BSD-like licenses.
+license and the Apache License (Version 2.0).
 
 See LICENSE-APACHE, and LICENSE-MIT for details.


### PR DESCRIPTION
The license declaration in the README is non-specific. I think this is a hold-over from extraction from the Rust repo. The Rust repo has a file that details the other licenses involved. I scanned through this code and most of it has a rust standard mit/apache header. Some files have no header, and could be under BSD, but if that's the case, that specific license text needs to be added somewhere to this repo.