### PR TITLE
Bump to 0.3.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.3.16"
+version = "0.3.17"
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
I have bumped Cargo.toml to 0.3.17 and would like to propose/request a release of this commit tree as 0.3.17.