### PR TITLE
Remove `Sized` constraint for generic `Rng`

### DIFF
--- a/src/chacha.rs
+++ b/src/chacha.rs
@@ -219,10 +219,10 @@ impl<'a> SeedableRng<&'a [u32]> for ChaChaRng {
 }
 
 impl Rand for ChaChaRng {
-    fn rand<R: Rng>(other: &mut R) -> ChaChaRng {
+    fn rand<R: Rng + ?Sized>(other: &mut R) -> ChaChaRng {
         let mut key : [u32; KEY_WORDS] = [0; KEY_WORDS];
         for word in key.iter_mut() {
-            *word = other.gen();
+            *word = other.next_u32();
         }
         SeedableRng::from_seed(&key[..])
     }

--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -40,14 +40,14 @@ pub struct Exp1(pub f64);
 // This could be done via `-rng.gen::<f64>().ln()` but that is slower.
 impl Rand for Exp1 {
     #[inline]
-    fn rand<R:Rng>(rng: &mut R) -> Exp1 {
+    fn rand<R:Rng + ?Sized>(rng: &mut R) -> Exp1 {
         #[inline]
         fn pdf(x: f64) -> f64 {
             (-x).exp()
         }
         #[inline]
-        fn zero_case<R:Rng>(rng: &mut R, _u: f64) -> f64 {
-            ziggurat_tables::ZIG_EXP_R - rng.gen::<f64>().ln()
+        fn zero_case<R:Rng + ?Sized>(rng: &mut R, _u: f64) -> f64 {
+            ziggurat_tables::ZIG_EXP_R - rng.next_f64().ln()
         }
 
         Exp1(ziggurat(rng, false,
@@ -88,11 +88,11 @@ impl Exp {
 }
 
 impl Sample<f64> for Exp {
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
+    fn sample<R: Rng + ?Sized>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
 }
 impl IndependentSample<f64> for Exp {
-    fn ind_sample<R: Rng>(&self, rng: &mut R) -> f64 {
-        let Exp1(n) = rng.gen::<Exp1>();
+    fn ind_sample<R: Rng + ?Sized>(&self, rng: &mut R) -> f64 {
+        let Exp1(n) = Exp1::rand(rng);
         n * self.lambda_inverse
     }
 }

--- a/src/distributions/gamma.rs
+++ b/src/distributions/gamma.rs
@@ -15,7 +15,7 @@
 use self::GammaRepr::*;
 use self::ChiSquaredRepr::*;
 
-use {Rng, Open01};
+use {Rand, Rng, Open01};
 use super::normal::StandardNormal;
 use super::{IndependentSample, Sample, Exp};
 
@@ -134,17 +134,17 @@ impl GammaLargeShape {
 }
 
 impl Sample<f64> for Gamma {
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
+    fn sample<R: Rng + ?Sized>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
 }
 impl Sample<f64> for GammaSmallShape {
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
+    fn sample<R: Rng + ?Sized>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
 }
 impl Sample<f64> for GammaLargeShape {
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
+    fn sample<R: Rng + ?Sized>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
 }
 
 impl IndependentSample<f64> for Gamma {
-    fn ind_sample<R: Rng>(&self, rng: &mut R) -> f64 {
+    fn ind_sample<R: Rng + ?Sized>(&self, rng: &mut R) -> f64 {
         match self.repr {
             Small(ref g) => g.ind_sample(rng),
             One(ref g) => g.ind_sample(rng),
@@ -153,23 +153,23 @@ impl IndependentSample<f64> for Gamma {
     }
 }
 impl IndependentSample<f64> for GammaSmallShape {
-    fn ind_sample<R: Rng>(&self, rng: &mut R) -> f64 {
-        let Open01(u) = rng.gen::<Open01<f64>>();
+    fn ind_sample<R: Rng + ?Sized>(&self, rng: &mut R) -> f64 {
+        let Open01(u) = Open01::<f64>::rand(rng);
 
         self.large_shape.ind_sample(rng) * u.powf(self.inv_shape)
     }
 }
 impl IndependentSample<f64> for GammaLargeShape {
-    fn ind_sample<R: Rng>(&self, rng: &mut R) -> f64 {
+    fn ind_sample<R: Rng + ?Sized>(&self, rng: &mut R) -> f64 {
         loop {
-            let StandardNormal(x) = rng.gen::<StandardNormal>();
+            let StandardNormal(x) = StandardNormal::rand(rng);
             let v_cbrt = 1.0 + self.c * x;
             if v_cbrt <= 0.0 { // a^3 <= 0 iff a <= 0
                 continue
             }
 
             let v = v_cbrt * v_cbrt * v_cbrt;
-            let Open01(u) = rng.gen::<Open01<f64>>();
+            let Open01(u) = Open01::<f64>::rand(rng);
 
             let x_sqr = x * x;
             if u < 1.0 - 0.0331 * x_sqr * x_sqr ||
@@ -225,14 +225,14 @@ impl ChiSquared {
     }
 }
 impl Sample<f64> for ChiSquared {
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
+    fn sample<R: Rng + ?Sized>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
 }
 impl IndependentSample<f64> for ChiSquared {
-    fn ind_sample<R: Rng>(&self, rng: &mut R) -> f64 {
+    fn ind_sample<R: Rng + ?Sized>(&self, rng: &mut R) -> f64 {
         match self.repr {
             DoFExactlyOne => {
                 // k == 1 => N(0,1)^2
-                let StandardNormal(norm) = rng.gen::<StandardNormal>();
+                let StandardNormal(norm) = StandardNormal::rand(rng);
                 norm * norm
             }
             DoFAnythingElse(ref g) => g.ind_sample(rng)
@@ -279,10 +279,10 @@ impl FisherF {
     }
 }
 impl Sample<f64> for FisherF {
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
+    fn sample<R: Rng + ?Sized>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
 }
 impl IndependentSample<f64> for FisherF {
-    fn ind_sample<R: Rng>(&self, rng: &mut R) -> f64 {
+    fn ind_sample<R: Rng + ?Sized>(&self, rng: &mut R) -> f64 {
         self.numer.ind_sample(rng) / self.denom.ind_sample(rng) * self.dof_ratio
     }
 }
@@ -317,11 +317,11 @@ impl StudentT {
     }
 }
 impl Sample<f64> for StudentT {
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
+    fn sample<R: Rng + ?Sized>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
 }
 impl IndependentSample<f64> for StudentT {
-    fn ind_sample<R: Rng>(&self, rng: &mut R) -> f64 {
-        let StandardNormal(norm) = rng.gen::<StandardNormal>();
+    fn ind_sample<R: Rng + ?Sized>(&self, rng: &mut R) -> f64 {
+        let StandardNormal(norm) = StandardNormal::rand(rng);
         norm * (self.dof / self.chi.ind_sample(rng)).sqrt()
     }
 }

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -35,7 +35,7 @@ pub mod exponential;
 pub trait Sample<Support> {
     /// Generate a random value of `Support`, using `rng` as the
     /// source of randomness.
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> Support;
+    fn sample<R: Rng + ?Sized>(&mut self, rng: &mut R) -> Support;
 }
 
 /// `Sample`s that do not require keeping track of state.
@@ -48,7 +48,7 @@ pub trait Sample<Support> {
 // trait called `Sample` and the other should be `DependentSample`.
 pub trait IndependentSample<Support>: Sample<Support> {
     /// Generate a random value.
-    fn ind_sample<R: Rng>(&self, &mut R) -> Support;
+    fn ind_sample<R: Rng + ?Sized>(&self, &mut R) -> Support;
 }
 
 /// A wrapper for generating types that implement `Rand` via the
@@ -64,12 +64,12 @@ impl<Sup> Clone for RandSample<Sup> {
 }
 
 impl<Sup: Rand> Sample<Sup> for RandSample<Sup> {
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> Sup { self.ind_sample(rng) }
+    fn sample<R: Rng + ?Sized>(&mut self, rng: &mut R) -> Sup { self.ind_sample(rng) }
 }
 
 impl<Sup: Rand> IndependentSample<Sup> for RandSample<Sup> {
-    fn ind_sample<R: Rng>(&self, rng: &mut R) -> Sup {
-        rng.gen()
+    fn ind_sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Sup {
+        Sup::rand(rng)
     }
 }
 
@@ -156,11 +156,11 @@ impl<'a, T: Clone> WeightedChoice<'a, T> {
 }
 
 impl<'a, T: Clone> Sample<T> for WeightedChoice<'a, T> {
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> T { self.ind_sample(rng) }
+    fn sample<R: Rng + ?Sized>(&mut self, rng: &mut R) -> T { self.ind_sample(rng) }
 }
 
 impl<'a, T: Clone> IndependentSample<T> for WeightedChoice<'a, T> {
-    fn ind_sample<R: Rng>(&self, rng: &mut R) -> T {
+    fn ind_sample<R: Rng + ?Sized>(&self, rng: &mut R) -> T {
         // we want to find the first element that has cumulative
         // weight > sample_weight, which we do by binary since the
         // cumulative weights of self.items are sorted.
@@ -220,7 +220,7 @@ mod ziggurat_tables;
 // the perf improvement (25-50%) is definitely worth the extra code
 // size from force-inlining.
 #[inline(always)]
-fn ziggurat<R: Rng, P, Z>(
+fn ziggurat<R: Rng + ?Sized, P, Z>(
             rng: &mut R,
             symmetric: bool,
             x_tab: ziggurat_tables::ZigTable,
@@ -243,7 +243,7 @@ fn ziggurat<R: Rng, P, Z>(
         // efficiently and overload next_f32/f64, so by not calling it
         // this may be slower than it would be otherwise.)
         // FIXME: investigate/optimise for the above.
-        let bits: u64 = rng.gen();
+        let bits: u64 = rng.next_u64();
         let i = (bits & 0xff) as usize;
         let f = (bits >> 11) as f64 / SCALE;
 
@@ -262,7 +262,7 @@ fn ziggurat<R: Rng, P, Z>(
             return zero_case(rng, u);
         }
         // algebraically equivalent to f1 + DRanU()*(f0 - f1) < 1
-        if f_tab[i + 1] + (f_tab[i] - f_tab[i + 1]) * rng.gen::<f64>() < pdf(x) {
+        if f_tab[i + 1] + (f_tab[i] - f_tab[i + 1]) * rng.next_f64() < pdf(x) {
             return x;
         }
     }
@@ -277,7 +277,7 @@ mod tests {
     #[derive(PartialEq, Debug)]
     struct ConstRand(usize);
     impl Rand for ConstRand {
-        fn rand<R: Rng>(_: &mut R) -> ConstRand {
+        fn rand<R: Rng + ?Sized>(_: &mut R) -> ConstRand {
             ConstRand(0)
         }
     }

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -37,13 +37,13 @@ use distributions::{ziggurat, ziggurat_tables, Sample, IndependentSample};
 pub struct StandardNormal(pub f64);
 
 impl Rand for StandardNormal {
-    fn rand<R:Rng>(rng: &mut R) -> StandardNormal {
+    fn rand<R:Rng + ?Sized>(rng: &mut R) -> StandardNormal {
         #[inline]
         fn pdf(x: f64) -> f64 {
             (-x*x/2.0).exp()
         }
         #[inline]
-        fn zero_case<R:Rng>(rng: &mut R, u: f64) -> f64 {
+        fn zero_case<R:Rng + ?Sized>(rng: &mut R, u: f64) -> f64 {
             // compute a random number in the tail by hand
 
             // strange initial conditions, because the loop is not
@@ -54,8 +54,8 @@ impl Rand for StandardNormal {
             let mut y = 0.0f64;
 
             while -2.0 * y < x * x {
-                let Open01(x_) = rng.gen::<Open01<f64>>();
-                let Open01(y_) = rng.gen::<Open01<f64>>();
+                let Open01(x_) = Open01::<f64>::rand(rng);
+                let Open01(y_) = Open01::<f64>::rand(rng);
 
                 x = x_.ln() / ziggurat_tables::ZIG_NORM_R;
                 y = y_.ln();
@@ -111,11 +111,11 @@ impl Normal {
     }
 }
 impl Sample<f64> for Normal {
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
+    fn sample<R: Rng + ?Sized>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
 }
 impl IndependentSample<f64> for Normal {
-    fn ind_sample<R: Rng>(&self, rng: &mut R) -> f64 {
-        let StandardNormal(n) = rng.gen::<StandardNormal>();
+    fn ind_sample<R: Rng + ?Sized>(&self, rng: &mut R) -> f64 {
+        let StandardNormal(n) = StandardNormal::rand(rng);
         self.mean + self.std_dev * n
     }
 }
@@ -155,10 +155,10 @@ impl LogNormal {
     }
 }
 impl Sample<f64> for LogNormal {
-    fn sample<R: Rng>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
+    fn sample<R: Rng + ?Sized>(&mut self, rng: &mut R) -> f64 { self.ind_sample(rng) }
 }
 impl IndependentSample<f64> for LogNormal {
-    fn ind_sample<R: Rng>(&self, rng: &mut R) -> f64 {
+    fn ind_sample<R: Rng + ?Sized>(&self, rng: &mut R) -> f64 {
         self.norm.ind_sample(rng).exp()
     }
 }

--- a/src/isaac.rs
+++ b/src/isaac.rs
@@ -243,7 +243,7 @@ impl<'a> SeedableRng<&'a [u32]> for IsaacRng {
 }
 
 impl Rand for IsaacRng {
-    fn rand<R: Rng>(other: &mut R) -> IsaacRng {
+    fn rand<R: Rng + ?Sized>(other: &mut R) -> IsaacRng {
         let mut ret = EMPTY;
         unsafe {
             let ptr = ret.rsl.as_mut_ptr() as *mut u8;
@@ -492,7 +492,7 @@ impl<'a> SeedableRng<&'a [u64]> for Isaac64Rng {
 }
 
 impl Rand for Isaac64Rng {
-    fn rand<R: Rng>(other: &mut R) -> Isaac64Rng {
+    fn rand<R: Rng + ?Sized>(other: &mut R) -> Isaac64Rng {
         let mut ret = EMPTY_64;
         unsafe {
             let ptr = ret.rsl.as_mut_ptr() as *mut u8;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,7 +317,7 @@ type w32 = w<u32>;
 pub trait Rand : Sized {
     /// Generates a random instance of this type using the specified source of
     /// randomness.
-    fn rand<R: Rng>(rng: &mut R) -> Self;
+    fn rand<R: Rng + ?Sized>(rng: &mut R) -> Self;
 }
 
 /// A random number generator.
@@ -645,7 +645,7 @@ impl<R: ?Sized> Rng for Box<R> where R: Rng {
 /// [`gen_iter`]: trait.Rng.html#method.gen_iter
 /// [`Rng`]: trait.Rng.html
 #[derive(Debug)]
-pub struct Generator<'a, T, R:'a> {
+pub struct Generator<'a, T, R: 'a> {
     rng: &'a mut R,
     _marker: marker::PhantomData<fn() -> T>,
 }
@@ -790,10 +790,10 @@ impl SeedableRng<[u32; 4]> for XorShiftRng {
 }
 
 impl Rand for XorShiftRng {
-    fn rand<R: Rng>(rng: &mut R) -> XorShiftRng {
-        let mut tuple: (u32, u32, u32, u32) = rng.gen();
+    fn rand<R: Rng + ?Sized>(rng: &mut R) -> XorShiftRng {
+        let mut tuple = <(u32, u32, u32, u32)>::rand(rng);
         while tuple == (0, 0, 0, 0) {
-            tuple = rng.gen();
+            tuple = Rand::rand(rng);
         }
         let (x, y, z, w_) = tuple;
         XorShiftRng { x: w(x), y: w(y), z: w(z), w: w(w_) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -645,16 +645,16 @@ impl<R: ?Sized> Rng for Box<R> where R: Rng {
 /// [`gen_iter`]: trait.Rng.html#method.gen_iter
 /// [`Rng`]: trait.Rng.html
 #[derive(Debug)]
-pub struct Generator<'a, T, R: 'a> {
+pub struct Generator<'a, T, R: 'a + ?Sized> {
     rng: &'a mut R,
     _marker: marker::PhantomData<fn() -> T>,
 }
 
-impl<'a, T: Rand, R: Rng> Iterator for Generator<'a, T, R> {
+impl<'a, T: Rand, R: Rng + ?Sized> Iterator for Generator<'a, T, R> {
     type Item = T;
 
     fn next(&mut self) -> Option<T> {
-        Some(self.rng.gen())
+        Some(T::rand(self.rng))
     }
 }
 

--- a/src/rand_impls.rs
+++ b/src/rand_impls.rs
@@ -17,39 +17,39 @@ use {Rand,Rng};
 
 impl Rand for isize {
     #[inline]
-    fn rand<R: Rng>(rng: &mut R) -> isize {
+    fn rand<R: Rng + ?Sized>(rng: &mut R) -> isize {
         if mem::size_of::<isize>() == 4 {
-            rng.gen::<i32>() as isize
+            i32::rand(rng) as isize
         } else {
-            rng.gen::<i64>() as isize
+            i64::rand(rng) as isize
         }
     }
 }
 
 impl Rand for i8 {
     #[inline]
-    fn rand<R: Rng>(rng: &mut R) -> i8 {
+    fn rand<R: Rng + ?Sized>(rng: &mut R) -> i8 {
         rng.next_u32() as i8
     }
 }
 
 impl Rand for i16 {
     #[inline]
-    fn rand<R: Rng>(rng: &mut R) -> i16 {
+    fn rand<R: Rng + ?Sized>(rng: &mut R) -> i16 {
         rng.next_u32() as i16
     }
 }
 
 impl Rand for i32 {
     #[inline]
-    fn rand<R: Rng>(rng: &mut R) -> i32 {
+    fn rand<R: Rng + ?Sized>(rng: &mut R) -> i32 {
         rng.next_u32() as i32
     }
 }
 
 impl Rand for i64 {
     #[inline]
-    fn rand<R: Rng>(rng: &mut R) -> i64 {
+    fn rand<R: Rng + ?Sized>(rng: &mut R) -> i64 {
         rng.next_u64() as i64
     }
 }
@@ -57,46 +57,46 @@ impl Rand for i64 {
 #[cfg(feature = "i128_support")]
 impl Rand for i128 {
     #[inline]
-    fn rand<R: Rng>(rng: &mut R) -> i128 {
-        rng.gen::<u128>() as i128
+    fn rand<R: Rng + ?Sized>(rng: &mut R) -> i128 {
+        u128::rand(rng) as i128
     }
 }
 
 impl Rand for usize {
     #[inline]
-    fn rand<R: Rng>(rng: &mut R) -> usize {
+    fn rand<R: Rng + ?Sized>(rng: &mut R) -> usize {
         if mem::size_of::<usize>() == 4 {
-            rng.gen::<u32>() as usize
+            u32::rand(rng) as usize
         } else {
-            rng.gen::<u64>() as usize
+            u64::rand(rng) as usize
         }
     }
 }
 
 impl Rand for u8 {
     #[inline]
-    fn rand<R: Rng>(rng: &mut R) -> u8 {
+    fn rand<R: Rng + ?Sized>(rng: &mut R) -> u8 {
         rng.next_u32() as u8
     }
 }
 
 impl Rand for u16 {
     #[inline]
-    fn rand<R: Rng>(rng: &mut R) -> u16 {
+    fn rand<R: Rng + ?Sized>(rng: &mut R) -> u16 {
         rng.next_u32() as u16
     }
 }
 
 impl Rand for u32 {
     #[inline]
-    fn rand<R: Rng>(rng: &mut R) -> u32 {
+    fn rand<R: Rng + ?Sized>(rng: &mut R) -> u32 {
         rng.next_u32()
     }
 }
 
 impl Rand for u64 {
     #[inline]
-    fn rand<R: Rng>(rng: &mut R) -> u64 {
+    fn rand<R: Rng + ?Sized>(rng: &mut R) -> u64 {
         rng.next_u64()
     }
 }
@@ -104,7 +104,7 @@ impl Rand for u64 {
 #[cfg(feature = "i128_support")]
 impl Rand for u128 {
     #[inline]
-    fn rand<R: Rng>(rng: &mut R) -> u128 {
+    fn rand<R: Rng + ?Sized>(rng: &mut R) -> u128 {
         ((rng.next_u64() as u128) << 64) | (rng.next_u64() as u128)
     }
 }
@@ -124,13 +124,13 @@ macro_rules! float_impls {
                 /// See `Closed01` for the closed interval `[0,1]`,
                 /// and `Open01` for the open interval `(0,1)`.
                 #[inline]
-                fn rand<R: Rng>(rng: &mut R) -> $ty {
+                fn rand<R: Rng + ?Sized>(rng: &mut R) -> $ty {
                     rng.$method_name()
                 }
             }
             impl Rand for Open01<$ty> {
                 #[inline]
-                fn rand<R: Rng>(rng: &mut R) -> Open01<$ty> {
+                fn rand<R: Rng + ?Sized>(rng: &mut R) -> Open01<$ty> {
                     // add a small amount (specifically 2 bits below
                     // the precision of f64/f32 at 1.0), so that small
                     // numbers are larger than 0, but large numbers
@@ -140,7 +140,7 @@ macro_rules! float_impls {
             }
             impl Rand for Closed01<$ty> {
                 #[inline]
-                fn rand<R: Rng>(rng: &mut R) -> Closed01<$ty> {
+                fn rand<R: Rng + ?Sized>(rng: &mut R) -> Closed01<$ty> {
                     // rescale so that 1.0 - epsilon becomes 1.0
                     // precisely.
                     Closed01(rng.$method_name() * SCALE / (SCALE - 1.0))
@@ -154,7 +154,7 @@ float_impls! { f32_rand_impls, f32, 24, next_f32 }
 
 impl Rand for char {
     #[inline]
-    fn rand<R: Rng>(rng: &mut R) -> char {
+    fn rand<R: Rng + ?Sized>(rng: &mut R) -> char {
         // a char is 21 bits
         const CHAR_MASK: u32 = 0x001f_ffff;
         loop {
@@ -171,8 +171,8 @@ impl Rand for char {
 
 impl Rand for bool {
     #[inline]
-    fn rand<R: Rng>(rng: &mut R) -> bool {
-        rng.gen::<u8>() & 1 == 1
+    fn rand<R: Rng + ?Sized>(rng: &mut R) -> bool {
+        u32::rand(rng) & 1 == 1
     }
 }
 
@@ -185,12 +185,12 @@ macro_rules! tuple_impl {
             > Rand for ( $( $tyvar ),* , ) {
 
             #[inline]
-            fn rand<R: Rng>(_rng: &mut R) -> ( $( $tyvar ),* , ) {
+            fn rand<R: Rng + ?Sized>(_rng: &mut R) -> ( $( $tyvar ),* , ) {
                 (
                     // use the $tyvar's to get the appropriate number of
                     // repeats (they're not actually needed)
                     $(
-                        _rng.gen::<$tyvar>()
+                        <$tyvar>::rand(_rng)
                     ),*
                     ,
                 )
@@ -201,7 +201,7 @@ macro_rules! tuple_impl {
 
 impl Rand for () {
     #[inline]
-    fn rand<R: Rng>(_: &mut R) -> () { () }
+    fn rand<R: Rng + ?Sized>(_: &mut R) -> () { () }
 }
 tuple_impl!{A}
 tuple_impl!{A, B}
@@ -222,14 +222,14 @@ macro_rules! array_impl {
 
         impl<T> Rand for [T; $n] where T: Rand {
             #[inline]
-            fn rand<R: Rng>(_rng: &mut R) -> [T; $n] {
-                [_rng.gen::<$t>(), $(_rng.gen::<$ts>()),*]
+            fn rand<R: Rng + ?Sized>(_rng: &mut R) -> [T; $n] {
+                [<$t>::rand(_rng), $(<$ts>::rand(_rng)),*]
             }
         }
     };
     {$n:expr,} => {
         impl<T> Rand for [T; $n] {
-            fn rand<R: Rng>(_rng: &mut R) -> [T; $n] { [] }
+            fn rand<R: Rng + ?Sized>(_rng: &mut R) -> [T; $n] { [] }
         }
     };
 }
@@ -238,9 +238,9 @@ array_impl!{32, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T
 
 impl<T:Rand> Rand for Option<T> {
     #[inline]
-    fn rand<R: Rng>(rng: &mut R) -> Option<T> {
-        if rng.gen() {
-            Some(rng.gen())
+    fn rand<R: Rng + ?Sized>(rng: &mut R) -> Option<T> {
+        if bool::rand(rng) {
+            Some(T::rand(rng))
         } else {
             None
         }


### PR DESCRIPTION
Preface: **This is a breaking change!!**

Recently I tried using `Rand` on a `Rng` trait object but I was unable to since `Rand::rand` _requires_ that the `Rng` be `Sized`.

This is mostly a proof-of-concept that should be considered when going through with the next iteration of this project.

Limitations:
- Methods like `choose` are implemented generically on `Rng`. These cannot be used within the context of a trait object.
- Cannot use conveniences like `if rng.gen() { ... }` when `Rng` is not `Sized`
- Breaks current `#[derive(Rand)]` implementation
  - Relies on `gen` and `gen_range`