### PR TITLE
Fix formatting warnings with commonmark enabled

### DIFF
--- a/src/distributions/gamma.rs
+++ b/src/distributions/gamma.rs
@@ -185,8 +185,8 @@ impl IndependentSample<f64> for GammaLargeShape {
 ///
 /// For `k > 0` integral, this distribution is the sum of the squares
 /// of `k` independent standard normal random variables. For other
-/// `k`, this uses the equivalent characterisation `χ²(k) = Gamma(k/2,
-/// 2)`.
+/// `k`, this uses the equivalent characterisation
+/// `χ²(k) = Gamma(k/2, 2)`.
 ///
 /// # Example
 ///

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -123,6 +123,7 @@ impl<'a, T: Clone> WeightedChoice<'a, T> {
     /// Create a new `WeightedChoice`.
     ///
     /// Panics if:
+    ///
     /// - `v` is empty
     /// - the total weight is 0
     /// - the total weight is larger than a `u32` can contain.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,8 +354,9 @@ pub trait Rng {
     /// See:
     /// A PRNG specialized in double precision floating point numbers using
     /// an affine transition
-    /// http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/ARTICLES/dSFMT.pdf
-    /// http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/SFMT/dSFMT-slide-e.pdf
+    ///
+    /// * <http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/ARTICLES/dSFMT.pdf>
+    /// * <http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/SFMT/dSFMT-slide-e.pdf>
     ///
     /// By default this is implemented in terms of `next_u32`, but a
     /// random number generator which can generate numbers satisfying

--- a/src/os.rs
+++ b/src/os.rs
@@ -30,8 +30,8 @@ use Rng;
 /// Max OS X, and modern Linux) this may block very early in the init
 /// process, if the CSPRNG has not been seeded yet.[1]
 ///
-/// [1] See https://www.python.org/dev/peps/pep-0524/ for a more in-depth
-///     discussion.
+/// [1] See <https://www.python.org/dev/peps/pep-0524/> for a more
+///     in-depth discussion.
 pub struct OsRng(imp::OsRng);
 
 impl OsRng {


### PR DESCRIPTION
This makes documentation work correctly with the new pulldown-cmark Markdown parser (rust-lang/rust#44229).