### PR TITLE
Switch back to using winapi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,11 @@ alloc = []  # enables Vec and Box support without std
 
 i128_support = [] # enables i128 and u128 support
 
-[dependencies]
+[target.'cfg(unix)'.dependencies]
 libc = { version = "0.2", optional = true }
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["minwindef", "ntsecapi", "profileapi", "winnt"] }
 
 [dev-dependencies]
 log = "0.3.0"

--- a/src/jitter.rs
+++ b/src/jitter.rs
@@ -690,17 +690,12 @@ mod platform {
 
     #[cfg(target_os = "windows")]
     pub fn get_nstime() -> u64 {
-        #[allow(non_camel_case_types)]
-        type LARGE_INTEGER = i64;
-        #[allow(non_camel_case_types)]
-        type BOOL = i32;
-        extern "system" {
-            fn QueryPerformanceCounter(lpPerformanceCount: *mut LARGE_INTEGER) -> BOOL;
+        extern crate winapi;
+        unsafe {
+            let mut t = super::mem::zeroed();
+            winapi::um::profileapi::QueryPerformanceCounter(&mut t);
+            *t.QuadPart() as u64
         }
-
-        let mut t = 0;
-        unsafe { QueryPerformanceCounter(&mut t); }
-        t as u64
     }
 
     #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]

--- a/src/os.rs
+++ b/src/os.rs
@@ -422,19 +422,16 @@ mod imp {
 
 #[cfg(windows)]
 mod imp {
+    extern crate winapi;
+
     use std::io;
     use Rng;
 
     use super::{next_u32, next_u64};
 
-    type BOOLEAN = u8;
-    type ULONG = u32;
-
-    #[link(name = "advapi32")]
-    extern "system" {
-        // This function's real name is `RtlGenRandom`.
-        fn SystemFunction036(RandomBuffer: *mut u8, RandomBufferLength: ULONG) -> BOOLEAN;
-    }
+    use self::winapi::shared::minwindef::ULONG;
+    use self::winapi::um::ntsecapi::RtlGenRandom;
+    use self::winapi::um::winnt::PVOID;
 
     #[derive(Debug)]
     pub struct OsRng;
@@ -457,7 +454,7 @@ mod imp {
             // split up the buffer.
             for slice in v.chunks_mut(<ULONG>::max_value() as usize) {
                 let ret = unsafe {
-                    SystemFunction036(slice.as_mut_ptr(), slice.len() as ULONG)
+                    RtlGenRandom(slice.as_mut_ptr() as PVOID, slice.len() as ULONG)
                 };
                 if ret == 0 {
                     panic!("couldn't generate random bytes: {}",


### PR DESCRIPTION
Don't merge yet. Still waiting for winapi 0.3 to actually be published before I switch over the dependency to crates.io.

Before and after clean compile times for this PR with latest nightly:
Debug: 1.73 to 3.97
Release: 2.96 to 5.37
Definitely much quicker than back in the winapi 0.2 days.