### PR TITLE
Sample

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.3.18"
+version = "0.3.19"
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,7 @@
 //! // where the car is. The game host will never open the door with the car.
 //! fn game_host_open<R: Rng>(car: u32, choice: u32, rng: &mut R) -> u32 {
 //!     let choices = free_doors(&[car, choice]);
-//!     rand::sample_reservoir(rng, choices.into_iter(), 1)[0]
+//!     rand::seq::sample_slice(rng, &choices, 1)[0]
 //! }
 //!
 //! // Returns the door we switch to, given our current choice and
@@ -260,12 +260,8 @@ pub use os::OsRng;
 
 pub use isaac::{IsaacRng, Isaac64Rng};
 pub use chacha::ChaChaRng;
-pub use sample::{
-    // TODO: `sample` name will be deprecated in 1.0, use `sample_reservoir` instead
-    sample_reservoir as sample,
-    sample_reservoir,
-    Sample,
-    SampleRef};
+#[deprecated(since="0.3.18", note="renamed to seq::sample_reservoir")]
+pub use seq::{sample_reservoir as sample};
 
 #[cfg(target_pointer_width = "32")]
 use IsaacRng as IsaacWordRng;
@@ -282,7 +278,7 @@ pub mod reseeding;
 mod rand_impls;
 pub mod os;
 pub mod read;
-mod sample;
+pub mod seq;
 
 #[allow(bad_style)]
 type w64 = w<u64>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,8 +260,6 @@ pub use os::OsRng;
 
 pub use isaac::{IsaacRng, Isaac64Rng};
 pub use chacha::ChaChaRng;
-#[deprecated(since="0.3.18", note="renamed to seq::sample_iter")]
-pub use seq::{sample_iter as sample};
 
 #[cfg(target_pointer_width = "32")]
 use IsaacRng as IsaacWordRng;
@@ -1017,6 +1015,31 @@ impl Rng for ThreadRng {
 #[inline]
 pub fn random<T: Rand>() -> T {
     thread_rng().gen()
+}
+
+#[inline(always)]
+#[deprecated(since="0.3.18", note="renamed to seq::sample_iter")]
+/// DEPRECATED: use `seq::sample_iter` instead.
+///
+/// Randomly sample up to `amount` elements from a finite iterator.
+/// The order of elements in the sample is not random.
+///
+/// # Example
+///
+/// ```rust
+/// use rand::{thread_rng, sample};
+///
+/// let mut rng = thread_rng();
+/// let sample = sample(&mut rng, 1..100, 5);
+/// println!("{:?}", sample);
+/// ```
+pub fn sample<T, I, R>(rng: &mut R, iterable: I, amount: usize) -> Vec<T>
+    where I: IntoIterator<Item=T>,
+          R: Rng,
+{
+    // the legacy sample didn't care whether amount was met
+    seq::sample_iter(rng, iterable, amount)
+        .unwrap_or_else(|e| e)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,8 +260,8 @@ pub use os::OsRng;
 
 pub use isaac::{IsaacRng, Isaac64Rng};
 pub use chacha::ChaChaRng;
-#[deprecated(since="0.3.18", note="renamed to seq::sample_reservoir")]
-pub use seq::{sample_reservoir as sample};
+#[deprecated(since="0.3.18", note="renamed to seq::sample_iter")]
+pub use seq::{sample_iter as sample};
 
 #[cfg(target_pointer_width = "32")]
 use IsaacRng as IsaacWordRng;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,7 @@
 //! // where the car is. The game host will never open the door with the car.
 //! fn game_host_open<R: Rng>(car: u32, choice: u32, rng: &mut R) -> u32 {
 //!     let choices = free_doors(&[car, choice]);
-//!     rand::sample(rng, choices.into_iter(), 1)[0]
+//!     rand::sample_reservoir(rng, choices.into_iter(), 1)[0]
 //! }
 //!
 //! // Returns the door we switch to, given our current choice and
@@ -260,6 +260,12 @@ pub use os::OsRng;
 
 pub use isaac::{IsaacRng, Isaac64Rng};
 pub use chacha::ChaChaRng;
+pub use sample::{
+    // TODO: `sample` name will be deprecated in 1.0, use `sample_reservoir` instead
+    sample_reservoir as sample,
+    sample_reservoir,
+    Sample,
+    SampleRef};
 
 #[cfg(target_pointer_width = "32")]
 use IsaacRng as IsaacWordRng;
@@ -276,6 +282,7 @@ pub mod reseeding;
 mod rand_impls;
 pub mod os;
 pub mod read;
+mod sample;
 
 #[allow(bad_style)]
 type w64 = w<u64>;
@@ -1016,40 +1023,9 @@ pub fn random<T: Rand>() -> T {
     thread_rng().gen()
 }
 
-/// Randomly sample up to `amount` elements from a finite iterator.
-/// The order of elements in the sample is not random.
-///
-/// # Example
-///
-/// ```rust
-/// use rand::{thread_rng, sample};
-///
-/// let mut rng = thread_rng();
-/// let sample = sample(&mut rng, 1..100, 5);
-/// println!("{:?}", sample);
-/// ```
-pub fn sample<T, I, R>(rng: &mut R, iterable: I, amount: usize) -> Vec<T>
-    where I: IntoIterator<Item=T>,
-          R: Rng,
-{
-    let mut iter = iterable.into_iter();
-    let mut reservoir: Vec<T> = iter.by_ref().take(amount).collect();
-    // continue unless the iterator was exhausted
-    if reservoir.len() == amount {
-        for (i, elem) in iter.enumerate() {
-            let k = rng.gen_range(0, i + 1 + amount);
-            if let Some(spot) = reservoir.get_mut(k) {
-                *spot = elem;
-            }
-        }
-    }
-    reservoir
-}
-
 #[cfg(test)]
 mod test {
-    use super::{Rng, thread_rng, random, SeedableRng, StdRng, sample,
-                weak_rng};
+    use super::{Rng, thread_rng, random, SeedableRng, StdRng, weak_rng};
     use std::iter::repeat;
 
     pub struct MyRng<R> { inner: R }
@@ -1253,24 +1229,6 @@ mod test {
                       Option<(u32, (bool,))>),
                      (u8, i8, u16, i16, u32, i32, u64, i64),
                      (f32, (f64, (f64,)))) = random();
-    }
-
-    #[test]
-    fn test_sample() {
-        let min_val = 1;
-        let max_val = 100;
-
-        let mut r = thread_rng();
-        let vals = (min_val..max_val).collect::<Vec<i32>>();
-        let small_sample = sample(&mut r, vals.iter(), 5);
-        let large_sample = sample(&mut r, vals.iter(), vals.len() + 5);
-
-        assert_eq!(small_sample.len(), 5);
-        assert_eq!(large_sample.len(), vals.len());
-
-        assert!(small_sample.iter().all(|e| {
-            **e >= min_val && **e <= max_val
-        }));
     }
 
     #[test]

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -1,0 +1,330 @@
+// Copyright 2013-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Functions for sampling data
+
+use super::Rng;
+use std::collections::hash_map::HashMap;
+
+/// The `Sample` trait provides the `sample` method.
+///
+/// This is intended to be implemented for containers that:
+/// - Can be sampled in `O(amount)` time.
+/// - Whos items can be `cloned`.
+///
+/// If cloning is impossible or expensive, use `sample_ref` instead.
+pub trait Sample {
+    /// The returned sampled data. Typically the either a `Vec<T>` or a new instance of the
+    /// container's own type.
+    type Sampled;
+
+    /// Return exactly `amount` randomly sampled values.
+    ///
+    /// Any type which implements `sample` should guarantee that:
+    /// - Both the order and values of `Sampled` is random.
+    /// - The implementation uses `O(amount)` speed and memory
+    /// - The returned values are not references (if so, implement `SampleRef` instead).
+    ///
+    /// Panics if `amount > self.len()`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use rand::{thread_rng, Sample};
+    ///
+    /// let mut rng = thread_rng();
+    /// let values = vec![5, 6, 1, 3, 4, 6, 7];
+    /// println!("{:?}", values.sample(&mut rng, 3))
+    /// ```
+    fn sample<R: Rng>(&self, rng: &mut R, amount: usize) -> Self::Sampled;
+}
+
+/// The `SampleRef` trait provides the `sample_ref` method.
+///
+/// This is intended to be implemented for containers that which can be sampled in `O(amount)` time
+/// and want a fast way to give references to a sample of their items.
+pub trait SampleRef {
+    /// The returned sampled data. Typically the either a `Vec<&T>` or a new instance of the
+    /// container's own type containing references to the underlying data.
+    type SampledRef;
+
+    /// Return exactly `amount` references to randomly sampled values.
+    ///
+    /// Any type which implements `sample_ref` should guarantee that:
+    /// - Both the order and values of `SampledRef` is random.
+    /// - The implementation uses `O(amount)` speed and memory.
+    /// - The returned values are not copies/clones (if so, implement `Sample` instead).
+    ///
+    /// Panics if `amount > self.len()`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use rand::{thread_rng, SampleRef};
+    ///
+    /// let mut rng = thread_rng();
+    /// let values = vec![5, 6, 1, 3, 4, 6, 7];
+    /// println!("{:?}", values.as_slice().sample_ref(&mut rng, 3))
+    /// ```
+    fn sample_ref<R: Rng>(&self, rng: &mut R, amount: usize) -> Self::SampledRef;
+}
+
+/// Randomly sample *up to* `amount` elements from a finite iterator using a reservoir.
+///
+/// The order of elements in the sample is not random. In fact, if `len(iterable) <= amount` then
+/// the output will be in the exact order they were collected.
+///
+/// The reservoir method used allocates only an `Vec` of size `amount`. The size of the iterable
+/// does not affect the amount of memory used.
+///
+/// # Example
+///
+/// ```rust
+/// use rand::{thread_rng, sample_reservoir};
+///
+/// let mut rng = thread_rng();
+/// let sample = sample_reservoir(&mut rng, 1..100, 5);
+/// println!("{:?}", sample);
+/// ```
+pub fn sample_reservoir<T, I, R>(rng: &mut R, iterable: I, amount: usize) -> Vec<T>
+    where I: IntoIterator<Item=T>,
+          R: Rng,
+{
+    let mut iter = iterable.into_iter();
+    let mut reservoir = Vec::with_capacity(amount);
+    reservoir.extend(iter.by_ref().take(amount));
+
+    // continue unless the iterator was exhausted
+    if reservoir.len() == amount {
+        for (i, elem) in iter.enumerate() {
+            let k = rng.gen_range(0, i + 1 + amount);
+            if let Some(spot) = reservoir.get_mut(k) {
+                *spot = elem;
+            }
+        }
+    }
+    reservoir
+}
+
+/// Sample (non-repeating) exactly `amount` of indices from a sequence of the given `length`.
+///
+/// The returned elements and their order are random.
+///
+/// Panics if `amount > length`
+///
+/// TODO: IMO this should be made public since it can be generally useful, although
+/// there might be a way to make the output type more generic/compact.
+fn sample_indices<R>(rng: &mut R, length: usize, amount: usize) -> Vec<usize>
+    where R: Rng,
+{
+    if amount > length {
+        panic!("`amount` must be less than or equal to `slice.len()`");
+    }
+
+    // We are going to have to allocate at least `amount` for the output no matter what. However,
+    // if we use the `cached` version we will have to allocate `amount` as a HashMap as well since
+    // it inserts an element for every loop.
+    //
+    // Therefore, if amount >= length / 2, inplace will be both faster and use less memory.
+    //
+    // TODO: there is probably even more fine-tuning that can be done here since
+    // `HashMap::with_capacity(amount)` probably allocates more than `amount` in practice,
+    // and a trade off could probably be made between memory/cpu, since hashmap operations
+    // are slower than array index swapping.
+    if amount >= length / 2 {
+        sample_indices_inplace(rng, length, amount)
+    } else {
+        sample_indices_cache(rng, length, amount)
+    }
+}
+
+/// Sample an amount of indices using an inplace partial fisher yates method.
+///
+/// This allocates the entire `length` of indices and randomizes only the first `amount`.
+/// It then truncates to `amount` and returns.
+///
+/// This is better than using a HashMap "cache" when `amount >= length / 2` since it does not
+/// require allocating an extra cache and is much faster.
+fn sample_indices_inplace<R>(rng: &mut R, length: usize, amount: usize) -> Vec<usize>
+    where R: Rng,
+{
+    debug_assert!(amount <= length);
+    let amount = if amount == length {
+        // It isn't necessary to shuffle the final element if we are shuffling
+        // the whole array... it would just be shuffled with itself
+        amount - 1
+    } else {
+        amount
+    };
+
+    let mut indices: Vec<usize> = Vec::with_capacity(length);
+    indices.extend(0..length);
+    for i in 0..amount {
+        let j: usize = rng.gen_range(i, length);
+        let tmp = indices[i];
+        indices[i] = indices[j];
+        indices[j] = tmp;
+    }
+    indices.truncate(amount);
+    indices
+}
+
+
+/// This method performs a partial fisher-yates on a range of indices using a HashMap
+/// as a cache to record potential collisions.
+///
+/// The cache avoids allocating the entire `length` of values. This is especially useful when
+/// `amount <<< length`, i.e. select 3 non-repeating from 1_000_000
+fn sample_indices_cache<R>(
+    rng: &mut R,
+    length: usize,
+    amount: usize,
+) -> Vec<usize>
+    where R: Rng,
+{
+    debug_assert!(amount <= length);
+    let mut cache = HashMap::with_capacity(amount);
+    let mut out = Vec::with_capacity(amount);
+    for i in 0..amount {
+        let j: usize = rng.gen_range(i, length);
+
+        // equiv: let tmp = slice[i];
+        let tmp = match cache.get(&i) {
+            Some(e) => *e,
+            None => i,
+        };
+
+        // equiv: slice[i] = slice[j];
+        let x = match cache.get(&j) {
+            Some(x) => *x,
+            None => j,
+        };
+
+        // equiv: slice[j] = tmp;
+        cache.insert(j, tmp);
+
+        // note that in the inplace version, slice[i] is automatically "returned" value
+        out.push(x);
+    }
+    out
+}
+
+impl<'a, T: Clone> Sample for &'a [T] {
+    type Sampled = Vec<T>;
+
+    fn sample<R: Rng>(&self, rng: &mut R, amount: usize) -> Vec<T> {
+        let indices = sample_indices(rng, self.len(), amount);
+
+        let mut out = Vec::with_capacity(amount);
+        out.extend(indices.iter().map(|i| self[*i].clone()));
+        out
+    }
+}
+
+impl<'a, T: Clone> Sample for Vec<T> {
+    type Sampled = Vec<T>;
+
+    fn sample<R: Rng>(&self, rng: &mut R, amount: usize) -> Vec<T> {
+        self.as_slice().sample(rng, amount)
+    }
+}
+
+impl<'a, T> SampleRef for &'a [T] {
+    type SampledRef = Vec<&'a T>;
+
+    fn sample_ref<R: Rng>(&self, rng: &mut R, amount: usize) -> Vec<&'a T> {
+        let indices = sample_indices(rng, self.len(), amount);
+
+        let mut out = Vec::with_capacity(amount);
+        out.extend(indices.iter().map(|i| &self[*i]));
+        out
+    }
+}
+
+// TODO: It looks like implementing this depends on RFC 1598 being implemented.
+// See this: https://github.com/rust-lang/rfcs/issues/1965
+//
+// impl<'a, T> SampleRef for Vec<&'a T>{
+//     type SampledRef = Vec<&'a T>;
+//
+//     fn sample_ref<R: Rng>(&'a self, rng: &mut R, amount: usize) -> Vec<&'a T> {
+//        self.as_slice().sample_ref(rng, amount)
+//     }
+// }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use {thread_rng, XorShiftRng, SeedableRng};
+
+    #[test]
+    fn test_sample_reservoir() {
+        let min_val = 1;
+        let max_val = 100;
+
+        let mut r = thread_rng();
+        let vals = (min_val..max_val).collect::<Vec<i32>>();
+        let small_sample = sample_reservoir(&mut r, vals.iter(), 5);
+        let large_sample = sample_reservoir(&mut r, vals.iter(), vals.len() + 5);
+
+        assert_eq!(small_sample.len(), 5);
+        assert_eq!(large_sample.len(), vals.len());
+
+        assert!(small_sample.iter().all(|e| {
+            **e >= min_val && **e <= max_val
+        }));
+    }
+
+    #[test]
+    /// This test mainly works by asserting that the two cases are equivalent,
+    /// as well as equivalent to the exported function.
+    fn test_sample_indices() {
+        let xor_rng = XorShiftRng::from_seed;
+
+        let max_range = 100;
+        let mut r = thread_rng();
+
+        for length in 1usize..max_range {
+            let amount = r.gen_range(0, length);
+            let seed: [u32; 4] = [
+                r.next_u32(), r.next_u32(), r.next_u32(), r.next_u32()
+            ];
+
+            println!("Selecting indices: len={}, amount={}, seed={:?}", length, amount, seed);
+
+            // assert that the two methods give exactly the same result
+            let inplace = sample_indices_inplace(
+                &mut xor_rng(seed), length, amount);
+            let cache = sample_indices_cache(
+                &mut xor_rng(seed), length, amount);
+            assert_eq!(inplace, cache);
+
+            // assert the basics work
+            let regular = sample_indices(
+                &mut xor_rng(seed), length, amount);
+            assert_eq!(regular.len(), amount);
+            assert!(regular.iter().all(|e| *e < length));
+            assert_eq!(regular, inplace);
+
+            // just for fun, also test sampling from a vector
+            let vec: Vec<usize> = (0..length).collect();
+            {
+                let result = vec.sample(&mut xor_rng(seed), amount);
+                assert_eq!(result, regular);
+            }
+
+            {
+                let result = vec.as_slice().sample_ref(&mut xor_rng(seed), amount);
+                let expected = regular.iter().map(|v| v).collect::<Vec<_>>();
+                assert_eq!(result, expected);
+            }
+        }
+    }
+}

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -66,7 +66,7 @@ pub fn sample_iter<T, I, R>(rng: &mut R, iterable: I, amount: usize) -> Result<V
 ///
 /// This implementation uses `O(amount)` time and memory.
 ///
-/// Panics if `amount > self.len()`
+/// Panics if `amount > slice.len()`
 ///
 /// # Example
 ///
@@ -94,7 +94,7 @@ pub fn sample_slice<R, T>(rng: &mut R, slice: &[T], amount: usize) -> Vec<T>
 ///
 /// This implementation uses `O(amount)` time and memory.
 ///
-/// Panics if `amount > self.len()`
+/// Panics if `amount > slice.len()`
 ///
 /// # Example
 ///
@@ -124,7 +124,7 @@ pub fn sample_slice_ref<'a, R, T>(rng: &mut R, slice: &'a [T], amount: usize) ->
 /// This method is used internally by the slice sampling methods, but it can sometimes be useful to
 /// have the indices themselves so this is provided as an alternative.
 ///
-/// Panics if `amount > self.len()`
+/// Panics if `amount > length`
 pub fn sample_indices<R>(rng: &mut R, length: usize, amount: usize) -> Vec<usize>
     where R: Rng,
 {

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -17,8 +17,9 @@ use std::collections::hash_map::HashMap;
 ///
 /// The following can be returned:
 /// - `Ok`: `Vec` of `amount` non-repeating randomly sampled elements. The order is not random.
-/// - `Err`: `Vec` of *less than* `amount` elements in sequential order. This is considered an
-///   error since exactly `amount` elements is typically expected.
+/// - `Err`: `Vec` of all the elements from `iterable` in sequential order. This happens when the
+///   length of `iterable` was less than `amount`. This is considered an error since exactly
+///   `amount` elements is typically expected.
 ///
 /// This implementation uses `O(len(iterable))` time and `O(amount)` memory.
 ///

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -160,16 +160,7 @@ fn sample_indices_inplace<R>(rng: &mut R, length: usize, amount: usize) -> Vec<u
     debug_assert!(amount <= length);
     let mut indices: Vec<usize> = Vec::with_capacity(length);
     indices.extend(0..length);
-    let end_i = if length != 0 && amount == length {
-        // It isn't necessary to shuffle the final element if we are shuffling
-        // the whole array... it would just be shuffled with itself
-        //
-        // Also, `rng.gen_range(i, i)` panics.
-        amount - 1
-    } else {
-        amount
-    };
-    for i in 0..end_i {
+    for i in 0..amount {
         let j: usize = rng.gen_range(i, length);
         let tmp = indices[i];
         indices[i] = indices[j];
@@ -261,6 +252,15 @@ mod test {
         // sample "all" the items
         let v = sample_slice(&mut r, &[42, 133], 2);
         assert!(v == vec![42, 133] || v == vec![133, 42]);
+
+        assert_eq!(sample_indices_inplace(&mut r, 0, 0), vec![]);
+        assert_eq!(sample_indices_inplace(&mut r, 1, 0), vec![]);
+        assert_eq!(sample_indices_inplace(&mut r, 1, 1), vec![0]);
+
+        assert_eq!(sample_indices_cache(&mut r, 0, 0), vec![]);
+        assert_eq!(sample_indices_cache(&mut r, 1, 0), vec![]);
+        assert_eq!(sample_indices_cache(&mut r, 1, 1), vec![0]);
+
     }
 
     #[test]

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -261,6 +261,21 @@ mod test {
         assert_eq!(sample_indices_cache(&mut r, 1, 0), vec![]);
         assert_eq!(sample_indices_cache(&mut r, 1, 1), vec![0]);
 
+        // Make sure lucky 777's aren't lucky
+        let slice = &[42, 777];
+        let mut num_42 = 0;
+        let total = 1000;
+        for _ in 0..total {
+            let v = sample_slice(&mut r, slice, 1);
+            assert_eq!(v.len(), 1);
+            let v = v[0];
+            assert!(v == 42 || v == 777);
+            if v == 42 {
+                num_42 += 1;
+            }
+        }
+        let ratio_42 = num_42 as f64 / 1000 as f64;
+        assert!(0.4 <= ratio_42 || ratio_42 <= 0.6, "{}", ratio_42);
     }
 
     #[test]

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -28,10 +28,10 @@ use std::collections::hash_map::HashMap;
 /// use rand::{thread_rng, seq};
 ///
 /// let mut rng = thread_rng();
-/// let sample = seq::sample_reservoir(&mut rng, 1..100, 5);
+/// let sample = seq::sample_iter(&mut rng, 1..100, 5);
 /// println!("{:?}", sample);
 /// ```
-pub fn sample_reservoir<T, I, R>(rng: &mut R, iterable: I, amount: usize) -> Vec<T>
+pub fn sample_iter<T, I, R>(rng: &mut R, iterable: I, amount: usize) -> Vec<T>
     where I: IntoIterator<Item=T>,
           R: Rng,
 {
@@ -227,14 +227,14 @@ mod test {
     use {thread_rng, XorShiftRng, SeedableRng};
 
     #[test]
-    fn test_sample_reservoir() {
+    fn test_sample_iter() {
         let min_val = 1;
         let max_val = 100;
 
         let mut r = thread_rng();
         let vals = (min_val..max_val).collect::<Vec<i32>>();
-        let small_sample = sample_reservoir(&mut r, vals.iter(), 5);
-        let large_sample = sample_reservoir(&mut r, vals.iter(), vals.len() + 5);
+        let small_sample = sample_iter(&mut r, vals.iter(), 5);
+        let large_sample = sample_iter(&mut r, vals.iter(), vals.len() + 5);
 
         assert_eq!(small_sample.len(), 5);
         assert_eq!(large_sample.len(), vals.len());


### PR DESCRIPTION
This implements #195, in particular it:

- depricates `rand::sample` and bumps cargo version.
- adds `rand::seq::sample_iter` function which is very similar to `rand::sample` but returns a `Result`.
- adds the `seq::sample_slice` and `seq::sample_slice_ref` functions which sample from a slice in `O(amount)` time and memory.
- adds the `seq::sample_indices` which can sample a range of indicies in `O(amount)` time and memory (helper function if this is desired).

### Second Try:

<details>
- renames `sample` -> `sample_reservoir`. `sample_reservoir` is then imported `as sample` to avoid breaking backwards compatibility (for now) with a TODO for removing it.
- adds the `Sample` trait which adds a `sample(rng, amout) -> Container<T>` method.
- adds the `SampleRef` trait which adds a `sample_ref(rng, amount) -> Container<&T>` method

Comments and criticism welcome!
</details>

### Original Ticket:

<details>
This is an an initial PR for sanity and feedback for #194. This PR contains **breaking changes** so should not be merged into master.

There is still a lot to do here, but I'm hitting a critical issue where the XorShiftRng doesn't seem to be repeatable with the same seed. When running the new test I'm getting log output like:

```
cache length=4                                  
cache j=3                        
inplace length=4                     
inplace j=0 
```

So `j` is different values for the same loop number. Does anyone know a repeatable (with the same seed) random number generator I can use?
</details>