### PR TITLE
Port benches from dhardy/master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
         - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
       script:
         - cargo doc --no-deps --all-features
-        - cargo bench
+        - cargo test --benches
         - cargo test --features nightly
       after_success:
         - travis-cargo --only nightly doc-upload

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ install:
 build: false
 
 test_script:
-  - cargo bench
+  - cargo test --benches
   - cargo test
   - cargo test --features nightly
   - cargo test --manifest-path rand-derive/Cargo.toml

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -9,61 +9,7 @@ mod distributions;
 
 use std::mem::size_of;
 use test::{black_box, Bencher};
-use rand::{XorShiftRng, StdRng, IsaacRng, Isaac64Rng, JitterRng, Rng};
-use rand::OsRng;
-
-#[bench]
-fn rand_jitter(b: &mut Bencher) {
-    let mut rng = JitterRng::new().unwrap();
-    b.iter(|| {
-        black_box(rng.next_u64());
-    });
-    b.bytes = size_of::<u64>() as u64;
-}
-
-#[bench]
-fn rand_xorshift(b: &mut Bencher) {
-    let mut rng: XorShiftRng = OsRng::new().unwrap().gen();
-    b.iter(|| {
-        for _ in 0..RAND_BENCH_N {
-            black_box(rng.gen::<usize>());
-        }
-    });
-    b.bytes = size_of::<usize>() as u64 * RAND_BENCH_N;
-}
-
-#[bench]
-fn rand_isaac(b: &mut Bencher) {
-    let mut rng: IsaacRng = OsRng::new().unwrap().gen();
-    b.iter(|| {
-        for _ in 0..RAND_BENCH_N {
-            black_box(rng.gen::<usize>());
-        }
-    });
-    b.bytes = size_of::<usize>() as u64 * RAND_BENCH_N;
-}
-
-#[bench]
-fn rand_isaac64(b: &mut Bencher) {
-    let mut rng: Isaac64Rng = OsRng::new().unwrap().gen();
-    b.iter(|| {
-        for _ in 0..RAND_BENCH_N {
-            black_box(rng.gen::<usize>());
-        }
-    });
-    b.bytes = size_of::<usize>() as u64 * RAND_BENCH_N;
-}
-
-#[bench]
-fn rand_std(b: &mut Bencher) {
-    let mut rng = StdRng::new().unwrap();
-    b.iter(|| {
-        for _ in 0..RAND_BENCH_N {
-            black_box(rng.gen::<usize>());
-        }
-    });
-    b.bytes = size_of::<usize>() as u64 * RAND_BENCH_N;
-}
+use rand::{StdRng, Rng};
 
 #[bench]
 fn rand_f32(b: &mut Bencher) {

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -10,7 +10,7 @@ mod distributions;
 use std::mem::size_of;
 use test::{black_box, Bencher};
 use rand::{XorShiftRng, StdRng, IsaacRng, Isaac64Rng, JitterRng, Rng};
-use rand::{OsRng, sample, weak_rng};
+use rand::OsRng;
 
 #[bench]
 fn rand_jitter(b: &mut Bencher) {

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -86,21 +86,3 @@ fn rand_f64(b: &mut Bencher) {
     });
     b.bytes = size_of::<f64>() as u64 * RAND_BENCH_N;
 }
-
-#[bench]
-fn rand_shuffle_100(b: &mut Bencher) {
-    let mut rng = weak_rng();
-    let x : &mut [usize] = &mut [1; 100];
-    b.iter(|| {
-        rng.shuffle(x);
-    })
-}
-
-#[bench]
-fn rand_sample_10_of_100(b: &mut Bencher) {
-    let mut rng = weak_rng();
-    let x : &[usize] = &[1; 100];
-    b.iter(|| {
-        sample(&mut rng, x, 10);
-    })
-}

--- a/benches/generators.rs
+++ b/benches/generators.rs
@@ -1,0 +1,133 @@
+#![feature(test)]
+
+extern crate test;
+extern crate rand;
+
+const RAND_BENCH_N: u64 = 1000;
+const BYTES_LEN: usize = 1024;
+
+use std::mem::size_of;
+use test::{black_box, Bencher};
+
+use rand::{Rng, StdRng, OsRng, JitterRng};
+use rand::{XorShiftRng, IsaacRng, Isaac64Rng, ChaChaRng};
+
+macro_rules! gen_bytes {
+    ($fnn:ident, $gen:ident) => {
+        #[bench]
+        fn $fnn(b: &mut Bencher) {
+            let mut rng: $gen = OsRng::new().unwrap().gen();
+            let mut buf = [0u8; BYTES_LEN];
+            b.iter(|| {
+                for _ in 0..RAND_BENCH_N {
+                    rng.fill_bytes(&mut buf);
+                    black_box(buf);
+                }
+            });
+            b.bytes = BYTES_LEN as u64 * RAND_BENCH_N;
+        }
+    }
+}
+
+macro_rules! gen_bytes_new {
+    ($fnn:ident, $gen:ident) => {
+        #[bench]
+        fn $fnn(b: &mut Bencher) {
+            let mut rng = $gen::new().unwrap();
+            let mut buf = [0u8; BYTES_LEN];
+            b.iter(|| {
+                for _ in 0..RAND_BENCH_N {
+                    rng.fill_bytes(&mut buf);
+                    black_box(buf);
+                }
+            });
+            b.bytes = BYTES_LEN as u64 * RAND_BENCH_N;
+        }
+    }
+}
+
+gen_bytes!(gen_bytes_xorshift, XorShiftRng);
+gen_bytes!(gen_bytes_isaac, IsaacRng);
+gen_bytes!(gen_bytes_isaac64, Isaac64Rng);
+gen_bytes!(gen_bytes_chacha, ChaChaRng);
+gen_bytes_new!(gen_bytes_std, StdRng);
+gen_bytes_new!(gen_bytes_os, OsRng);
+
+
+macro_rules! gen_uint {
+    ($fnn:ident, $ty:ty, $gen:ident) => {
+        #[bench]
+        fn $fnn(b: &mut Bencher) {
+            let mut rng: $gen = OsRng::new().unwrap().gen();
+            b.iter(|| {
+                for _ in 0..RAND_BENCH_N {
+                    black_box(rng.gen::<$ty>());
+                }
+            });
+            b.bytes = size_of::<$ty>() as u64 * RAND_BENCH_N;
+        }
+    }
+}
+
+macro_rules! gen_uint_new {
+    ($fnn:ident, $ty:ty, $gen:ident) => {
+        #[bench]
+        fn $fnn(b: &mut Bencher) {
+            let mut rng = $gen::new().unwrap();
+            b.iter(|| {
+                for _ in 0..RAND_BENCH_N {
+                    black_box(rng.gen::<$ty>());
+                }
+            });
+            b.bytes = size_of::<$ty>() as u64 * RAND_BENCH_N;
+        }
+    }
+}
+
+gen_uint!(gen_u32_xorshift, u32, XorShiftRng);
+gen_uint!(gen_u32_isaac, u32, IsaacRng);
+gen_uint!(gen_u32_isaac64, u32, Isaac64Rng);
+gen_uint!(gen_u32_chacha, u32, ChaChaRng);
+gen_uint_new!(gen_u32_std, u32, StdRng);
+gen_uint_new!(gen_u32_os, u32, OsRng);
+
+gen_uint!(gen_u64_xorshift, u64, XorShiftRng);
+gen_uint!(gen_u64_isaac, u64, IsaacRng);
+gen_uint!(gen_u64_isaac64, u64, Isaac64Rng);
+gen_uint!(gen_u64_chacha, u64, ChaChaRng);
+gen_uint_new!(gen_u64_std, u64, StdRng);
+gen_uint_new!(gen_u64_os, u64, OsRng);
+
+#[bench]
+fn gen_u64_jitter(b: &mut Bencher) {
+    let mut rng = JitterRng::new().unwrap();
+    b.iter(|| {
+        black_box(rng.gen::<u64>());
+    });
+    b.bytes = size_of::<u64>() as u64;
+}
+
+macro_rules! init_gen {
+    ($fnn:ident, $gen:ident) => {
+        #[bench]
+        fn $fnn(b: &mut Bencher) {
+            let mut rng: XorShiftRng = OsRng::new().unwrap().gen();
+            b.iter(|| {
+                let r2: $gen = rng.gen();
+                black_box(r2);
+            });
+        }
+    }
+}
+
+init_gen!(init_xorshift, XorShiftRng);
+init_gen!(init_isaac, IsaacRng);
+init_gen!(init_isaac64, Isaac64Rng);
+init_gen!(init_chacha, ChaChaRng);
+
+#[bench]
+fn init_jitter(b: &mut Bencher) {
+    b.iter(|| {
+        black_box(JitterRng::new().unwrap());
+    });
+}

--- a/benches/misc.rs
+++ b/benches/misc.rs
@@ -5,8 +5,8 @@ extern crate rand;
 
 use test::{black_box, Bencher};
 
-use rand::Rng;
-use rand::{sample, weak_rng};
+use rand::{Rng, weak_rng};
+use rand::seq::*;
 
 #[bench]
 fn misc_shuffle_100(b: &mut Bencher) {
@@ -19,10 +19,44 @@ fn misc_shuffle_100(b: &mut Bencher) {
 }
 
 #[bench]
-fn misc_sample_10_of_100(b: &mut Bencher) {
+fn misc_sample_iter_10_of_100(b: &mut Bencher) {
     let mut rng = weak_rng();
     let x : &[usize] = &[1; 100];
     b.iter(|| {
-        black_box(sample(&mut rng, x, 10));
+        black_box(sample_iter(&mut rng, x, 10).unwrap_or_else(|e| e));
     })
 }
+
+#[bench]
+fn misc_sample_slice_10_of_100(b: &mut Bencher) {
+    let mut rng = weak_rng();
+    let x : &[usize] = &[1; 100];
+    b.iter(|| {
+        black_box(sample_slice(&mut rng, x, 10));
+    })
+}
+
+#[bench]
+fn misc_sample_slice_ref_10_of_100(b: &mut Bencher) {
+    let mut rng = weak_rng();
+    let x : &[usize] = &[1; 100];
+    b.iter(|| {
+        black_box(sample_slice_ref(&mut rng, x, 10));
+    })
+}
+
+macro_rules! sample_indices {
+    ($name:ident, $amount:expr, $length:expr) => {
+        #[bench]
+        fn $name(b: &mut Bencher) {
+            let mut rng = weak_rng();
+            b.iter(|| {
+                black_box(sample_indices(&mut rng, $length, $amount));
+            })
+        }
+    }
+}
+
+sample_indices!(misc_sample_indices_10_of_1k, 10, 1000);
+sample_indices!(misc_sample_indices_50_of_1k, 50, 1000);
+sample_indices!(misc_sample_indices_100_of_1k, 100, 1000);

--- a/benches/misc.rs
+++ b/benches/misc.rs
@@ -1,0 +1,28 @@
+#![feature(test)]
+
+extern crate test;
+extern crate rand;
+
+use test::{black_box, Bencher};
+
+use rand::Rng;
+use rand::{sample, weak_rng};
+
+#[bench]
+fn misc_shuffle_100(b: &mut Bencher) {
+    let mut rng = weak_rng();
+    let x : &mut [usize] = &mut [1; 100];
+    b.iter(|| {
+        rng.shuffle(x);
+        black_box(&x);
+    })
+}
+
+#[bench]
+fn misc_sample_10_of_100(b: &mut Bencher) {
+    let mut rng = weak_rng();
+    let x : &[usize] = &[1; 100];
+    b.iter(|| {
+        black_box(sample(&mut rng, x, 10));
+    })
+}

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -144,7 +144,7 @@ pub fn sample_indices<R>(rng: &mut R, length: usize, amount: usize) -> Vec<usize
     // `HashMap::with_capacity(amount)` probably allocates more than `amount` in practice,
     // and a trade off could probably be made between memory/cpu, since hashmap operations
     // are slower than array index swapping.
-    if amount * 20 >= length {
+    if amount >= length / 20 {
         sample_indices_inplace(rng, length, amount)
     } else {
         sample_indices_cache(rng, length, amount)

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -137,12 +137,14 @@ pub fn sample_indices<R>(rng: &mut R, length: usize, amount: usize) -> Vec<usize
     // it inserts an element for every loop.
     //
     // Therefore, if `amount >= length / 2` then inplace will be both faster and use less memory.
+    // In fact, benchmarks show the inplace version is faster for length up to about 20 times
+    // faster than amount.
     //
     // TODO: there is probably even more fine-tuning that can be done here since
     // `HashMap::with_capacity(amount)` probably allocates more than `amount` in practice,
     // and a trade off could probably be made between memory/cpu, since hashmap operations
     // are slower than array index swapping.
-    if amount >= length / 2 {
+    if amount * 20 >= length {
         sample_indices_inplace(rng, length, amount)
     } else {
         sample_indices_cache(rng, length, amount)


### PR DESCRIPTION
This "copies" 2/3 of the updated benchmarks. The distributions benchmark was not included because the distributions API changed massively in dhardy/master.

There's also some new benchmarks for the new seq code by @vitiral and a corresponding adjustment to the factor used to select index sampling method.

I'll leave this PR open to comments for a couple of days before merging.

Full benchmark results on the index sampling:
```
test misc_sample_indices_cache_10k_of_1M   ... bench:     638,669 ns/iter (+/- 45,200)
test misc_sample_indices_cache_20k_of_1M   ... bench:   1,321,714 ns/iter (+/- 48,029)
test misc_sample_indices_cache_30k_of_1M   ... bench:   1,962,807 ns/iter (+/- 136,196)
test misc_sample_indices_cache_40k_of_1M   ... bench:   2,749,011 ns/iter (+/- 193,221)
test misc_sample_indices_cache_50k_of_1M   ... bench:   3,747,376 ns/iter (+/- 224,058)
test misc_sample_indices_inplace_10k_of_1M ... bench:   1,932,205 ns/iter (+/- 29,327)
test misc_sample_indices_inplace_20k_of_1M ... bench:   2,177,965 ns/iter (+/- 182,303)
test misc_sample_indices_inplace_30k_of_1M ... bench:   2,424,295 ns/iter (+/- 269,591)
test misc_sample_indices_inplace_40k_of_1M ... bench:   2,656,004 ns/iter (+/- 186,875)
test misc_sample_indices_inplace_50k_of_1M ... bench:   2,905,461 ns/iter (+/- 415,676)

test misc_sample_indices_cache_100k_of_1M   ... bench:   8,117,463 ns/iter (+/- 2,811,883)
test misc_sample_indices_cache_200k_of_1M   ... bench:  17,116,134 ns/iter (+/- 2,513,516)
test misc_sample_indices_cache_300k_of_1M   ... bench:  33,816,353 ns/iter (+/- 1,446,760)
test misc_sample_indices_cache_400k_of_1M   ... bench:  46,573,604 ns/iter (+/- 863,395)
test misc_sample_indices_cache_500k_of_1M   ... bench:  72,825,164 ns/iter (+/- 862,083)
test misc_sample_indices_inplace_100k_of_1M ... bench:   4,104,628 ns/iter (+/- 171,397)
test misc_sample_indices_inplace_200k_of_1M ... bench:   6,504,177 ns/iter (+/- 242,639)
test misc_sample_indices_inplace_300k_of_1M ... bench:   8,793,716 ns/iter (+/- 326,420)
test misc_sample_indices_inplace_400k_of_1M ... bench:  10,855,500 ns/iter (+/- 563,205)
test misc_sample_indices_inplace_500k_of_1M ... bench:  12,791,521 ns/iter (+/- 604,272)
```
Code:
```rust
macro_rules! sample_indices {
    ($name:ident, $method:ident, $amount:expr, $length:expr) => {
        #[bench]
        fn $name(b: &mut Bencher) {
            let mut rng = weak_rng();
            b.iter(|| {
                black_box($method(&mut rng, $length, $amount));
            })
        }
    }
}

sample_indices!(misc_sample_indices_inplace_10k_of_1M, sample_indices_inplace, 10_000, 1_000_000);
sample_indices!(misc_sample_indices_inplace_20k_of_1M, sample_indices_inplace, 20_000, 1_000_000);
sample_indices!(misc_sample_indices_inplace_30k_of_1M, sample_indices_inplace, 30_000, 1_000_000);
sample_indices!(misc_sample_indices_inplace_40k_of_1M, sample_indices_inplace, 40_000, 1_000_000);
sample_indices!(misc_sample_indices_inplace_50k_of_1M, sample_indices_inplace, 50_000, 1_000_000);

sample_indices!(misc_sample_indices_cache_10k_of_1M, sample_indices_cache, 10_000, 1_000_000);
sample_indices!(misc_sample_indices_cache_20k_of_1M, sample_indices_cache, 20_000, 1_000_000);
sample_indices!(misc_sample_indices_cache_30k_of_1M, sample_indices_cache, 30_000, 1_000_000);
sample_indices!(misc_sample_indices_cache_40k_of_1M, sample_indices_cache, 40_000, 1_000_000);
sample_indices!(misc_sample_indices_cache_50k_of_1M, sample_indices_cache, 50_000, 1_000_000);
```