### PR TITLE
Fix broken links in Rand docs (0.3 branch)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,8 +304,8 @@ type w32 = w<u32>;
 ///
 /// [`Open01`]: struct.Open01.html
 /// [`Closed01`]: struct.Closed01.html
-/// [`Exp1`]: struct.Exp1.html
-/// [`StandardNormal`]: struct.StandardNormal.html
+/// [`Exp1`]: distributions/exponential/struct.Exp1.html
+/// [`StandardNormal`]: distributions/normal/struct.StandardNormal.html
 ///
 /// The following aggregate types also implement `Rand` as long as their
 /// component types implement it:


### PR DESCRIPTION
Unblocks rust-lang/rust#46278.