### PR TITLE
Cherry-pick changes to PRNG algorithms

### DIFF
--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -279,8 +279,8 @@ fn ziggurat<R: Rng, P, Z>(
 
 #[cfg(test)]
 mod tests {
-
     use {Rng, Rand};
+    use impls;
     use super::{RandSample, WeightedChoice, Weighted, Sample, IndependentSample};
 
     #[derive(PartialEq, Debug)]
@@ -300,6 +300,10 @@ mod tests {
         }
         fn next_u64(&mut self) -> u64 {
             self.next_u32() as u64
+        }
+        
+        fn fill_bytes(&mut self, dest: &mut [u8]) {
+            impls::fill_bytes_via_u32(self, dest)
         }
     }
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,0 +1,170 @@
+// Copyright 2013-2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Helper functions for implementing `Rng` functions.
+//! 
+//! For cross-platform reproducibility, these functions all use Little Endian:
+//! least-significant part first. For example, `next_u64_via_u32` takes `u32`
+//! values `x, y`, then outputs `(y << 32) | x`. To implement `next_u32`
+//! from `next_u64` in little-endian order, one should use `next_u64() as u32`.
+//! 
+//! Byte-swapping (like the std `to_le` functions) is only needed to convert
+//! to/from byte sequences, and since its purpose is reproducibility,
+//! non-reproducible sources (e.g. `OsRng`) need not bother with it.
+
+// TODO: eventually these should be exported somehow
+#![allow(unused)]
+
+use core::intrinsics::transmute;
+use core::slice;
+use core::cmp::min;
+use core::mem::size_of;
+use Rng;
+
+/// Implement `next_u64` via `next_u32`, little-endian order.
+pub fn next_u64_via_u32<R: Rng+?Sized>(rng: &mut R) -> u64 {
+    // Use LE; we explicitly generate one value before the next.
+    let x = rng.next_u32() as u64;
+    let y = rng.next_u32() as u64;
+    (y << 32) | x
+}
+
+macro_rules! fill_bytes_via {
+    ($rng:ident, $next_u:ident, $BYTES:expr, $dest:ident) => {{
+        let mut left = $dest;
+        while left.len() >= $BYTES {
+            let (l, r) = {left}.split_at_mut($BYTES);
+            left = r;
+            let chunk: [u8; $BYTES] = unsafe {
+                transmute($rng.$next_u().to_le())
+            };
+            l.copy_from_slice(&chunk);
+        }
+        let n = left.len();
+        if n > 0 {
+            let chunk: [u8; $BYTES] = unsafe {
+                transmute($rng.$next_u().to_le())
+            };
+            left.copy_from_slice(&chunk[..n]);
+        }
+    }}
+}
+
+/// Implement `fill_bytes` via `next_u32`, little-endian order.
+pub fn fill_bytes_via_u32<R: Rng+?Sized>(rng: &mut R, dest: &mut [u8]) {
+    fill_bytes_via!(rng, next_u32, 4, dest)
+}
+
+/// Implement `fill_bytes` via `next_u64`, little-endian order.
+pub fn fill_bytes_via_u64<R: Rng+?Sized>(rng: &mut R, dest: &mut [u8]) {
+    fill_bytes_via!(rng, next_u64, 8, dest)
+}
+
+macro_rules! impl_uint_from_fill {
+    ($self:expr, $ty:ty, $N:expr) => ({
+        debug_assert!($N == size_of::<$ty>());
+
+        let mut int: $ty = 0;
+        unsafe {
+            let ptr = &mut int as *mut $ty as *mut u8;
+            let slice = slice::from_raw_parts_mut(ptr, $N);
+            $self.fill_bytes(slice);
+        }
+        int
+    });
+}
+
+macro_rules! fill_via_chunks {
+    ($src:expr, $dest:expr, $N:expr) => ({
+        let chunk_size_u8 = min($src.len() * $N, $dest.len());
+        let chunk_size = (chunk_size_u8 + $N - 1) / $N;
+
+        // Convert to little-endian:
+        for ref mut x in $src[0..chunk_size].iter_mut() {
+            **x = (*x).to_le();
+        }
+
+        let bytes = unsafe { slice::from_raw_parts($src.as_ptr() as *const u8,
+                                                   $src.len() * $N) };
+
+        let dest_chunk = &mut $dest[0..chunk_size_u8];
+        dest_chunk.copy_from_slice(&bytes[0..chunk_size_u8]);
+
+        (chunk_size, chunk_size_u8)
+    });
+}
+
+/// Implement `fill_bytes` by reading chunks from the output buffer of a block
+/// based RNG.
+///
+/// The return values are `(consumed_u32, filled_u8)`.
+///
+/// `filled_u8` is the number of filled bytes in `dest`, which may be less than
+/// the length of `dest`.
+/// `consumed_u32` is the number of words consumed from `src`, which is the same
+/// as `filled_u8 / 4` rounded up.
+///
+/// Note that on big-endian systems values in the output buffer `src` are
+/// mutated. `src[0..consumed_u32]` get converted to little-endian before
+/// copying.
+///
+/// # Example
+/// (from `IsaacRng`)
+///
+/// ```rust,ignore
+/// fn fill_bytes(&mut self, dest: &mut [u8]) {
+///     let mut read_len = 0;
+///     while read_len < dest.len() {
+///         if self.index >= self.rsl.len() {
+///             self.isaac();
+///         }
+///
+///         let (consumed_u32, filled_u8) =
+///             impls::fill_via_u32_chunks(&mut self.rsl[self.index..],
+///                                        &mut dest[read_len..]);
+///
+///         self.index += consumed_u32;
+///         read_len += filled_u8;
+///     }
+/// }
+/// ```
+pub fn fill_via_u32_chunks(src: &mut [u32], dest: &mut [u8]) -> (usize, usize) {
+    fill_via_chunks!(src, dest, 4)
+}
+
+/// Implement `fill_bytes` by reading chunks from the output buffer of a block
+/// based RNG.
+///
+/// The return values are `(consumed_u64, filled_u8)`.
+/// `filled_u8` is the number of filled bytes in `dest`, which may be less than
+/// the length of `dest`.
+/// `consumed_u64` is the number of words consumed from `src`, which is the same
+/// as `filled_u8 / 8` rounded up.
+///
+/// Note that on big-endian systems values in the output buffer `src` are
+/// mutated. `src[0..consumed_u64]` get converted to little-endian before
+/// copying.
+///
+/// See `fill_via_u32_chunks` for an example.
+pub fn fill_via_u64_chunks(src: &mut [u64], dest: &mut [u8]) -> (usize, usize) {
+    fill_via_chunks!(src, dest, 8)
+}
+
+/// Implement `next_u32` via `fill_bytes`, little-endian order.
+pub fn next_u32_via_fill<R: Rng+?Sized>(rng: &mut R) -> u32 {
+    impl_uint_from_fill!(rng, u32, 4)
+}
+
+/// Implement `next_u64` via `fill_bytes`, little-endian order.
+pub fn next_u64_via_fill<R: Rng+?Sized>(rng: &mut R) -> u64 {
+    impl_uint_from_fill!(rng, u64, 8)
+}
+
+// TODO: implement tests for the above

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -68,14 +68,14 @@ pub fn fill_bytes_via_u64<R: Rng+?Sized>(rng: &mut R, dest: &mut [u8]) {
 }
 
 macro_rules! impl_uint_from_fill {
-    ($self:expr, $ty:ty, $N:expr) => ({
+    ($rng:expr, $ty:ty, $N:expr) => ({
         debug_assert!($N == size_of::<$ty>());
 
         let mut int: $ty = 0;
         unsafe {
             let ptr = &mut int as *mut $ty as *mut u8;
             let slice = slice::from_raw_parts_mut(ptr, $N);
-            $self.fill_bytes(slice);
+            $rng.fill_bytes(slice);
         }
         int
     });

--- a/src/jitter.rs
+++ b/src/jitter.rs
@@ -16,7 +16,7 @@
 
 //! Non-physical true random number generator based on timing jitter.
 
-use Rng;
+use {Rng, impls};
 
 use core::{fmt, mem, ptr};
 #[cfg(feature="std")]
@@ -731,22 +731,7 @@ impl Rng for JitterRng {
     }
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {
-        let mut left = dest;
-        while left.len() >= 8 {
-            let (l, r) = {left}.split_at_mut(8);
-            left = r;
-            let chunk: [u8; 8] = unsafe {
-                mem::transmute(self.next_u64().to_le())
-            };
-            l.copy_from_slice(&chunk);
-        }
-        let n = left.len();
-        if n > 0 {
-            let chunk: [u8; 8] = unsafe {
-                mem::transmute(self.next_u64().to_le())
-            };
-            left.copy_from_slice(&chunk[..n]);
-        }
+        impls::fill_bytes_via_u64(self, dest)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,7 +343,15 @@ pub trait Rng {
     fn next_u32(&mut self) -> u32;
 
     /// Return the next random u64.
-    fn next_u64(&mut self) -> u64;
+    /// 
+    /// This function has a default implementation  of `next_u32`. The
+    /// default implementation should not be used in wrapper types since the
+    /// wrapped RNG may have its own implementation which may be more efficient
+    /// or even produce different results.
+    fn next_u64(&mut self) -> u64 {
+        // TODO: remove default implementation once impls module is exposed
+        impls::next_u64_via_u32(self)
+    }
 
     /// Return the next random f32 selected from the half-open
     /// interval `[0, 1)`.
@@ -398,6 +406,11 @@ pub trait Rng {
     }
 
     /// Fill `dest` with random data.
+    /// 
+    /// This function has a default implementation in terms of `next_u64`. The
+    /// default implementation should not be used in wrapper types since the
+    /// wrapped RNG may have its own implementation which may be more efficient
+    /// or even produce different results.
     ///
     /// This method does *not* have a requirement to bear any fixed
     /// relationship to the other methods, for example, it does *not*
@@ -419,7 +432,10 @@ pub trait Rng {
     /// thread_rng().fill_bytes(&mut v);
     /// println!("{:?}", &v[..]);
     /// ```
-    fn fill_bytes(&mut self, dest: &mut [u8]);
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        // TODO: remove default implementation once impls module is exposed
+        impls::fill_bytes_via_u64(self, dest)
+    }
 
     /// Return a random value of a `Rand` type.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -731,7 +731,7 @@ pub struct Closed01<F>(pub F);
 
 /// The standard RNG. This is designed to be efficient on the current
 /// platform.
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct StdRng {
     rng: IsaacWordRng,
 }

--- a/src/prng/chacha.rs
+++ b/src/prng/chacha.rs
@@ -10,13 +10,9 @@
 
 //! The ChaCha random number generator.
 
-use core::num::Wrapping as w;
 use core::fmt;
 use {Rng, SeedableRng, Rand};
 use impls;
-
-#[allow(bad_style)]
-type w32 = w<u32>;
 
 const KEY_WORDS    : usize =  8; // 8 words for the 256-bit key
 const STATE_WORDS  : usize = 16;
@@ -33,9 +29,9 @@ const CHACHA_ROUNDS: u32 = 20; // Cryptographically secure from 8 upwards as of 
 /// Salsa20*](http://cr.yp.to/chacha.html)
 #[derive(Clone)]
 pub struct ChaChaRng {
-    buffer:  [w32; STATE_WORDS], // Internal buffer of output
-    state:   [w32; STATE_WORDS], // Initial state
-    index:   usize,                 // Index into state
+    buffer:  [u32; STATE_WORDS], // Internal buffer of output
+    state:   [u32; STATE_WORDS], // Initial state
+    index:   usize,              // Index into state
 }
 
 // Custom Debug implementation that does not expose the internal state
@@ -47,10 +43,10 @@ impl fmt::Debug for ChaChaRng {
 
 macro_rules! quarter_round{
     ($a: expr, $b: expr, $c: expr, $d: expr) => {{
-        $a = $a + $b; $d = $d ^ $a; $d = w($d.0.rotate_left(16));
-        $c = $c + $d; $b = $b ^ $c; $b = w($b.0.rotate_left(12));
-        $a = $a + $b; $d = $d ^ $a; $d = w($d.0.rotate_left( 8));
-        $c = $c + $d; $b = $b ^ $c; $b = w($b.0.rotate_left( 7));
+        $a = $a.wrapping_add($b); $d ^= $a; $d = $d.rotate_left(16);
+        $c = $c.wrapping_add($d); $b ^= $c; $b = $b.rotate_left(12);
+        $a = $a.wrapping_add($b); $d ^= $a; $d = $d.rotate_left( 8);
+        $c = $c.wrapping_add($d); $b ^= $c; $b = $b.rotate_left( 7);
     }}
 }
 
@@ -70,15 +66,15 @@ macro_rules! double_round{
 }
 
 #[inline]
-fn core(output: &mut [w32; STATE_WORDS], input: &[w32; STATE_WORDS]) {
-    *output = *input;
+fn core(new: &mut [u32; STATE_WORDS], input: &[u32; STATE_WORDS]) {
+    *new = *input;
 
     for _ in 0..CHACHA_ROUNDS / 2 {
-        double_round!(output);
+        double_round!(new);
     }
 
     for i in 0..STATE_WORDS {
-        output[i] = output[i] + input[i];
+        new[i] = new[i].wrapping_add(input[i]);
     }
 }
 
@@ -105,8 +101,8 @@ impl ChaChaRng {
     /// - 2419978656
     pub fn new_unseeded() -> ChaChaRng {
         let mut rng = ChaChaRng {
-            buffer:  [w(0); STATE_WORDS],
-            state:   [w(0); STATE_WORDS],
+            buffer:  [0; STATE_WORDS],
+            state:   [0; STATE_WORDS],
             index:   STATE_WORDS
         };
         rng.init(&[0; KEY_WORDS]);
@@ -133,10 +129,10 @@ impl ChaChaRng {
     /// println!("{:?}", ra.next_u32());
     /// ```
     pub fn set_counter(&mut self, counter_low: u64, counter_high: u64) {
-        self.state[12] = w((counter_low >>  0) as u32);
-        self.state[13] = w((counter_low >> 32) as u32);
-        self.state[14] = w((counter_high >>  0) as u32);
-        self.state[15] = w((counter_high >> 32) as u32);
+        self.state[12] = (counter_low >>  0) as u32;
+        self.state[13] = (counter_low >> 32) as u32;
+        self.state[14] = (counter_high >>  0) as u32;
+        self.state[15] = (counter_high >> 32) as u32;
         self.index = STATE_WORDS; // force recomputation
     }
 
@@ -159,19 +155,19 @@ impl ChaChaRng {
     /// [1]: Daniel J. Bernstein. [*Extending the Salsa20
     /// nonce.*](http://cr.yp.to/papers.html#xsalsa)
     fn init(&mut self, key: &[u32; KEY_WORDS]) {
-        self.state[0] = w(0x61707865);
-        self.state[1] = w(0x3320646E);
-        self.state[2] = w(0x79622D32);
-        self.state[3] = w(0x6B206574);
+        self.state[0] = 0x61707865;
+        self.state[1] = 0x3320646E;
+        self.state[2] = 0x79622D32;
+        self.state[3] = 0x6B206574;
 
         for i in 0..KEY_WORDS {
-            self.state[4+i] = w(key[i]);
+            self.state[4+i] = key[i];
         }
 
-        self.state[12] = w(0);
-        self.state[13] = w(0);
-        self.state[14] = w(0);
-        self.state[15] = w(0);
+        self.state[12] = 0;
+        self.state[13] = 0;
+        self.state[14] = 0;
+        self.state[15] = 0;
 
         self.index = STATE_WORDS;
     }
@@ -181,31 +177,36 @@ impl ChaChaRng {
         core(&mut self.buffer, &self.state);
         self.index = 0;
         // update 128-bit counter
-        self.state[12] = self.state[12] + w(1);
-        if self.state[12] != w(0) { return };
-        self.state[13] = self.state[13] + w(1);
-        if self.state[13] != w(0) { return };
-        self.state[14] = self.state[14] + w(1);
-        if self.state[14] != w(0) { return };
-        self.state[15] = self.state[15] + w(1);
+        self.state[12] = self.state[12].wrapping_add(1);
+        if self.state[12] != 0 { return };
+        self.state[13] = self.state[13].wrapping_add(1);
+        if self.state[13] != 0 { return };
+        self.state[14] = self.state[14].wrapping_add(1);
+        if self.state[14] != 0 { return };
+        self.state[15] = self.state[15].wrapping_add(1);
     }
 }
 
 impl Rng for ChaChaRng {
     #[inline]
     fn next_u32(&mut self) -> u32 {
-        if self.index == STATE_WORDS {
+        // Using a local variable for `index`, and checking the size avoids a
+        // bounds check later on.
+        let mut index = self.index as usize;
+        if index >= STATE_WORDS {
             self.update();
+            index = 0;
         }
 
-        let value = self.buffer[self.index % STATE_WORDS];
+        let value = self.buffer[index];
         self.index += 1;
-        value.0
+        value
     }
-    
+
     fn next_u64(&mut self) -> u64 {
         impls::next_u64_via_u32(self)
     }
+
     
     fn fill_bytes(&mut self, bytes: &mut [u8]) {
         impls::fill_bytes_via_u32(self, bytes)
@@ -224,8 +225,8 @@ impl<'a> SeedableRng<&'a [u32]> for ChaChaRng {
     /// words are used, the remaining are set to zero.
     fn from_seed(seed: &'a [u32]) -> ChaChaRng {
         let mut rng = ChaChaRng {
-            buffer:  [w(0); STATE_WORDS],
-            state:   [w(0); STATE_WORDS],
+            buffer:  [0; STATE_WORDS],
+            state:   [0; STATE_WORDS],
             index:   STATE_WORDS
         };
         rng.init(&[0u32; KEY_WORDS]);
@@ -233,7 +234,7 @@ impl<'a> SeedableRng<&'a [u32]> for ChaChaRng {
         {
             let key = &mut rng.state[4 .. 4+KEY_WORDS];
             for (k, s) in key.iter_mut().zip(seed.iter()) {
-                *k = w(*s);
+                *k = *s;
             }
         }
         rng

--- a/src/prng/chacha.rs
+++ b/src/prng/chacha.rs
@@ -12,6 +12,7 @@
 
 use core::num::Wrapping as w;
 use {Rng, SeedableRng, Rand};
+use impls;
 
 #[allow(bad_style)]
 type w32 = w<u32>;
@@ -195,6 +196,14 @@ impl Rng for ChaChaRng {
         let value = self.buffer[self.index % STATE_WORDS];
         self.index += 1;
         value.0
+    }
+    
+    fn next_u64(&mut self) -> u64 {
+        impls::next_u64_via_u32(self)
+    }
+    
+    fn fill_bytes(&mut self, bytes: &mut [u8]) {
+        impls::fill_bytes_via_u32(self, bytes)
     }
 }
 

--- a/src/prng/chacha.rs
+++ b/src/prng/chacha.rs
@@ -329,6 +329,20 @@ mod test {
     }
 
     #[test]
+    fn test_rng_true_bytes() {
+        let seed : &[_] = &[0u32; 8];
+        let mut ra: ChaChaRng = SeedableRng::from_seed(seed);
+        let mut buf = [0u8; 32];
+        ra.fill_bytes(&mut buf);
+        // Same as first values in test_isaac_true_values as bytes in LE order
+        assert_eq!(buf,
+                   [118, 184, 224, 173, 160, 241, 61, 144,
+                    64, 93, 106, 229, 83, 134, 189, 40,
+                    189, 210, 25, 184, 160, 141, 237, 26,
+                    168, 54, 239, 204, 139, 119, 13, 199]);
+    }
+    
+    #[test]
     fn test_rng_clone() {
         let seed : &[_] = &[0u32; 8];
         let mut rng: ChaChaRng = SeedableRng::from_seed(seed);

--- a/src/prng/chacha.rs
+++ b/src/prng/chacha.rs
@@ -11,6 +11,7 @@
 //! The ChaCha random number generator.
 
 use core::num::Wrapping as w;
+use core::fmt;
 use {Rng, SeedableRng, Rand};
 use impls;
 
@@ -30,11 +31,18 @@ const CHACHA_ROUNDS: u32 = 20; // Cryptographically secure from 8 upwards as of 
 ///
 /// [1]: D. J. Bernstein, [*ChaCha, a variant of
 /// Salsa20*](http://cr.yp.to/chacha.html)
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct ChaChaRng {
     buffer:  [w32; STATE_WORDS], // Internal buffer of output
     state:   [w32; STATE_WORDS], // Initial state
     index:   usize,                 // Index into state
+}
+
+// Custom Debug implementation that does not expose the internal state
+impl fmt::Debug for ChaChaRng {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "ChaChaRng {{}}")
+    }
 }
 
 macro_rules! quarter_round{

--- a/src/prng/isaac.rs
+++ b/src/prng/isaac.rs
@@ -119,6 +119,12 @@ impl fmt::Debug for IsaacRng {
 }
 
 impl IsaacRng {
+    /// Create an ISAAC random number generator using the default
+    /// fixed seed.
+    pub fn new_unseeded() -> IsaacRng {
+        Self::new_from_u64(0)
+    }
+    
     /// Creates an ISAAC random number generator using an u64 as seed.
     /// If `seed == 0` this will produce the same stream of random numbers as
     /// the reference implementation when used unseeded.

--- a/src/prng/isaac.rs
+++ b/src/prng/isaac.rs
@@ -97,6 +97,7 @@ pub struct IsaacRng {
 }
 
 // Cannot be derived because [u32; 256] does not implement Clone
+// FIXME: remove once RFC 2000 gets implemented
 impl Clone for IsaacRng {
     fn clone(&self) -> IsaacRng {
         IsaacRng {
@@ -116,62 +117,21 @@ impl fmt::Debug for IsaacRng {
     }
 }
 
-fn mix(a: &mut w32, b: &mut w32, c: &mut w32, d: &mut w32,
-       e: &mut w32, f: &mut w32, g: &mut w32, h: &mut w32) {
-    *a ^= *b << 11; *d += *a; *b += *c;
-    *b ^= *c >> 2;  *e += *b; *c += *d;
-    *c ^= *d << 8;  *f += *c; *d += *e;
-    *d ^= *e >> 16; *g += *d; *e += *f;
-    *e ^= *f << 10; *h += *e; *f += *g;
-    *f ^= *g >> 4;  *a += *f; *g += *h;
-    *g ^= *h << 8;  *b += *g; *h += *a;
-    *h ^= *a >> 9;  *c += *h; *a += *b;
-}
-
 impl IsaacRng {
     /// Creates an ISAAC random number generator using an u64 as seed.
     /// If `seed == 0` this will produce the same stream of random numbers as
     /// the reference implementation when used unseeded.
     pub fn new_from_u64(seed: u64) -> IsaacRng {
-        let mut a = w(0x1367df5a);
-        let mut b = w(0x95d90059);
-        let mut c = w(0xc3163e4b);
-        let mut d = w(0x0f421ad8);
-        let mut e = w(0xd92a4a78);
-        let mut f = w(0xa51a3c49);
-        let mut g = w(0xc4efea1b);
-        let mut h = w(0x30609119);
-
-        let mut mem = [w(0); RAND_SIZE];
-
-        a += w(seed as u32);
-        b += w((seed >> 32) as u32);
-
-        for i in (0..RAND_SIZE/8).map(|i| i * 8) {
-            mix(&mut a, &mut b, &mut c, &mut d, &mut e, &mut f, &mut g, &mut h);
-            mem[i  ] = a; mem[i+1] = b;
-            mem[i+2] = c; mem[i+3] = d;
-            mem[i+4] = e; mem[i+5] = f;
-            mem[i+6] = g; mem[i+7] = h;
-        }
+        let mut key = [w(0); RAND_SIZE];
+        key[0] = w(seed as u32);
+        key[1] = w((seed >> 32) as u32);
+        // Initialize with only one pass.
         // A second pass does not improve the quality here, because all of
         // the seed was already available in the first round.
         // Not doing the second pass has the small advantage that if `seed == 0`
         // this method produces exactly the same state as the reference
         // implementation when used unseeded.
-
-        let mut rng = IsaacRng {
-            rsl: [w(0); RAND_SIZE],
-            mem: mem,
-            a: w(0),
-            b: w(0),
-            c: w(0),
-            cnt: 0,
-        };
-
-        // Prepare the first set of results
-        rng.isaac();
-        rng
+        init(key, 1)
     }
 
     /// Refills the output buffer (`self.rsl`)
@@ -275,7 +235,7 @@ impl Rng for IsaacRng {
     }
 }
 
-/// Creates a new ISAAC-64 random number generator.
+/// Creates a new ISAAC random number generator.
 ///
 /// The author Bob Jenkins describes how to best initialize ISAAC here:
 /// https://rt.cpan.org/Public/Bug/Display.html?id=64324
@@ -301,7 +261,7 @@ impl Rng for IsaacRng {
 /// mixes it, and combines that with the next 32 bytes, et cetera. Then loops
 /// over all the elements the same way a second time."
 #[inline]
-fn init(key: [w32; RAND_SIZE]) -> IsaacRng {
+fn init(mut mem: [w32; RAND_SIZE], rounds: u32) -> IsaacRng {
     // These numbers are the result of initializing a...h with the
     // fractional part of the golden ratio in binary (0x9e3779b9)
     // and applying mix() 4 times.
@@ -314,28 +274,22 @@ fn init(key: [w32; RAND_SIZE]) -> IsaacRng {
     let mut g = w(0xc4efea1b);
     let mut h = w(0x30609119);
 
-    let mut mem = [w(0); RAND_SIZE];
-
-    macro_rules! memloop {
-        ($arr:expr) => {{
-            for i in (0..RAND_SIZE/8).map(|i| i * 8) {
-                a += $arr[i  ]; b += $arr[i+1];
-                c += $arr[i+2]; d += $arr[i+3];
-                e += $arr[i+4]; f += $arr[i+5];
-                g += $arr[i+6]; h += $arr[i+7];
-                mix(&mut a, &mut b, &mut c, &mut d,
-                    &mut e, &mut f, &mut g, &mut h);
-                mem[i  ] = a; mem[i+1] = b;
-                mem[i+2] = c; mem[i+3] = d;
-                mem[i+4] = e; mem[i+5] = f;
-                mem[i+6] = g; mem[i+7] = h;
-            }
-        }}
+    // Normally this should do two passes, to make all of the seed effect all
+    // of `mem`
+    for _ in 0..rounds {
+        for i in (0..RAND_SIZE/8).map(|i| i * 8) {
+            a += mem[i  ]; b += mem[i+1];
+            c += mem[i+2]; d += mem[i+3];
+            e += mem[i+4]; f += mem[i+5];
+            g += mem[i+6]; h += mem[i+7];
+            mix(&mut a, &mut b, &mut c, &mut d,
+                &mut e, &mut f, &mut g, &mut h);
+            mem[i  ] = a; mem[i+1] = b;
+            mem[i+2] = c; mem[i+3] = d;
+            mem[i+4] = e; mem[i+5] = f;
+            mem[i+6] = g; mem[i+7] = h;
+        }
     }
-
-    memloop!(key);
-    // Do a second pass to make all of the seed affect all of `mem`
-    memloop!(mem);
 
     let mut rng = IsaacRng {
         rsl: [w(0); RAND_SIZE],
@@ -351,6 +305,18 @@ fn init(key: [w32; RAND_SIZE]) -> IsaacRng {
     rng
 }
 
+fn mix(a: &mut w32, b: &mut w32, c: &mut w32, d: &mut w32,
+       e: &mut w32, f: &mut w32, g: &mut w32, h: &mut w32) {
+    *a ^= *b << 11; *d += *a; *b += *c;
+    *b ^= *c >> 2;  *e += *b; *c += *d;
+    *c ^= *d << 8;  *f += *c; *d += *e;
+    *d ^= *e >> 16; *g += *d; *e += *f;
+    *e ^= *f << 10; *h += *e; *f += *g;
+    *f ^= *g >> 4;  *a += *f; *g += *h;
+    *g ^= *h << 8;  *b += *g; *h += *a;
+    *h ^= *a >> 9;  *c += *h; *a += *b;
+}
+
 impl Rand for IsaacRng {
     fn rand<R: Rng>(other: &mut R) -> IsaacRng {
         let mut key = [w(0); RAND_SIZE];
@@ -361,7 +327,7 @@ impl Rand for IsaacRng {
             other.fill_bytes(slice);
         }
 
-        init(key)
+        init(key, 2)
     }
 }
 
@@ -385,7 +351,7 @@ impl<'a> SeedableRng<&'a [u32]> for IsaacRng {
             *rsl_elem = w(seed_elem);
         }
 
-        init(key)
+        init(key, 2)
     }
 }
 

--- a/src/prng/isaac.rs
+++ b/src/prng/isaac.rs
@@ -16,6 +16,7 @@ use core::num::Wrapping as w;
 use core::fmt;
 
 use {Rng, SeedableRng, Rand};
+use impls;
 
 #[allow(non_camel_case_types)]
 type w32 = w<u32>;
@@ -203,6 +204,14 @@ impl Rng for IsaacRng {
         // in bounds, without unsafe. NB. this is a power of two, so
         // it optimises to a bitwise mask).
         self.rsl[self.cnt as usize % RAND_SIZE].0
+    }
+    
+    fn next_u64(&mut self) -> u64 {
+        impls::next_u64_via_u32(self)
+    }
+    
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        impls::fill_bytes_via_u32(self, dest)
     }
 }
 

--- a/src/prng/isaac.rs
+++ b/src/prng/isaac.rs
@@ -422,6 +422,17 @@ mod test {
     }
 
     #[test]
+    fn test_rng_64_true_values() {
+        // As above, using little-endian versions of above values
+        let seed: &[_] = &[1, 23, 456, 7890, 12345];
+        let mut ra: IsaacRng = SeedableRng::from_seed(seed);
+        // Regression test that isaac is actually using the above vector
+        let v = (0..5).map(|_| ra.next_u64()).collect::<Vec<_>>();
+        assert_eq!(v,
+                   vec!(3752888579798383186, 9035083239252078381, 18052294697452424037, 11876559110374379111, 16751462502657800130));
+    }
+
+    #[test]
     fn test_isaac_true_bytes() {
         let seed: &[_] = &[1, 23, 456, 7890, 12345];
         let mut rng1 = IsaacRng::from_seed(seed);

--- a/src/prng/isaac.rs
+++ b/src/prng/isaac.rs
@@ -413,6 +413,20 @@ mod test {
     }
 
     #[test]
+    fn test_isaac_true_bytes() {
+        let seed: &[_] = &[1, 23, 456, 7890, 12345];
+        let mut rng1 = IsaacRng::from_seed(seed);
+        let mut buf = [0u8; 32];
+        rng1.fill_bytes(&mut buf);
+        // Same as first values in test_isaac_true_values as bytes in LE order
+        assert_eq!(buf,
+                   [82, 186, 128, 152, 71, 240, 20, 52,
+                    45, 175, 180, 15, 86, 16, 99, 125,
+                    101, 203, 81, 214, 97, 162, 134, 250,
+                    103, 78, 203, 15, 150, 3, 210, 164]);
+    }
+    
+    #[test]
     fn test_isaac_new_uninitialized() {
         // Compare the results from initializing `IsaacRng` with
         // `new_from_u64(0)`, to make sure it is the same as the reference

--- a/src/prng/isaac.rs
+++ b/src/prng/isaac.rs
@@ -111,6 +111,7 @@ impl Clone for IsaacRng {
     }
 }
 
+// Custom Debug implementation that does not expose the internal state
 impl fmt::Debug for IsaacRng {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "IsaacRng {{}}")

--- a/src/prng/isaac64.rs
+++ b/src/prng/isaac64.rs
@@ -403,21 +403,39 @@ mod test {
                         596345674630742204, 9947027391921273664, 11788097613744130851,
                         10391409374914919106));
     }
-    
+
     #[test]
     fn test_isaac64_true_values_32() {
         let seed: &[_] = &[1, 23, 456, 7890, 12345];
         let mut rng1 = Isaac64Rng::from_seed(seed);
-        let v = (0..10).map(|_| rng1.next_u32()).collect::<Vec<_>>();
+        let v = (0..12).map(|_| rng1.next_u32()).collect::<Vec<_>>();
         // Subset of above values, as an LE u32 sequence
         assert_eq!(v,
                    [141028748, 127386717,
                     1058730652, 3347555894,
                     851491469, 4039984500,
                     2692730210, 288449107,
-                    646103879, 2782923823]);
+                    646103879, 2782923823,
+                    4195642895, 3252674613]);
     }
-    
+
+    #[test]
+    fn test_isaac64_true_values_mixed() {
+        let seed: &[_] = &[1, 23, 456, 7890, 12345];
+        let mut rng = Isaac64Rng::from_seed(seed);
+        // Test alternating between `next_u64` and `next_u32` works as expected.
+        // Values are the same as `test_isaac64_true_values` and
+        // `test_isaac64_true_values_32`.
+        assert_eq!(rng.next_u64(), 547121783600835980);
+        assert_eq!(rng.next_u32(), 1058730652);
+        assert_eq!(rng.next_u32(), 3347555894);
+        assert_eq!(rng.next_u64(), 17351601304698403469);
+        assert_eq!(rng.next_u32(), 2692730210);
+        // Skip one u32
+        assert_eq!(rng.next_u64(), 11952566807690396487);
+        assert_eq!(rng.next_u32(), 4195642895);
+    }
+
     #[test]
     fn test_isaac64_true_bytes() {
         let seed: &[_] = &[1, 23, 456, 7890, 12345];
@@ -431,7 +449,7 @@ mod test {
                     141, 186, 192, 50, 116, 69, 205, 240,
                     98, 205, 127, 160, 83, 98, 49, 17]);
     }
-    
+
     #[test]
     fn test_isaac_new_uninitialized() {
         // Compare the results from initializing `IsaacRng` with

--- a/src/prng/isaac64.rs
+++ b/src/prng/isaac64.rs
@@ -78,6 +78,7 @@ pub struct Isaac64Rng {
     b: w64,
     c: w64,
     index: u32,
+    half_used: bool, // true if only half of the previous result is used
 }
 
 // Cannot be derived because [u64; 256] does not implement Clone
@@ -91,6 +92,7 @@ impl Clone for Isaac64Rng {
             b: self.b,
             c: self.c,
             index: self.index,
+            half_used: self.half_used,
         }
     }
 }
@@ -186,13 +188,33 @@ impl Isaac64Rng {
         self.a = a;
         self.b = b;
         self.index = 0;
+        self.half_used = false;
     }
 }
 
 impl Rng for Isaac64Rng {
     #[inline]
     fn next_u32(&mut self) -> u32 {
-        self.next_u64() as u32
+        // Using a local variable for `index`, and checking the size avoids a
+        // bounds check later on.
+        let mut index = self.index as usize * 2 - self.half_used as usize;
+        if index >= RAND_SIZE * 2 {
+            self.isaac64();
+            index = 0;
+        }
+
+        self.half_used = !self.half_used;
+        self.index += self.half_used as u32;
+
+        // Index as if this is a u32 slice.
+        let rsl = unsafe { &*(&mut self.rsl as *mut [u64; RAND_SIZE]
+                                            as *mut [u32; RAND_SIZE * 2]) };
+
+        if cfg!(target_endian = "little") {
+            rsl[index]
+        } else {
+            rsl[index ^ 1]
+        }
     }
 
     #[inline]
@@ -205,6 +227,7 @@ impl Rng for Isaac64Rng {
 
         let value = self.rsl[index];
         self.index += 1;
+        self.half_used = false;
         value
     }
 
@@ -216,7 +239,7 @@ impl Rng for Isaac64Rng {
             }
 
             let (consumed_u64, filled_u8) =
-                impls::fill_via_u64_chunks(&mut self.rsl[(self.index as usize)..],
+                impls::fill_via_u64_chunks(&mut self.rsl[self.index as usize..],
                                            &mut dest[read_len..]);
 
             self.index += consumed_u64 as u32;
@@ -263,6 +286,7 @@ fn init(mut mem: [w64; RAND_SIZE], rounds: u32) -> Isaac64Rng {
         b: w(0),
         c: w(0),
         index: 0,
+        half_used: false,
     };
 
     // Prepare the first set of results
@@ -386,20 +410,12 @@ mod test {
         let mut rng1 = Isaac64Rng::from_seed(seed);
         let v = (0..10).map(|_| rng1.next_u32()).collect::<Vec<_>>();
         // Subset of above values, as an LE u32 sequence
-        // TODO: switch to this sequence?
-//         assert_eq!(v,
-//                    [141028748, 127386717,
-//                     1058730652, 3347555894,
-//                     851491469, 4039984500,
-//                     2692730210, 288449107,
-//                     646103879, 2782923823]);
-        // Subset of above values, using only low-half of each u64
         assert_eq!(v,
-                   [141028748, 1058730652,
-                    851491469, 2692730210,
-                    646103879, 4195642895,
-                    2836348583, 1312677241,
-                    999139615, 253604626]);
+                   [141028748, 127386717,
+                    1058730652, 3347555894,
+                    851491469, 4039984500,
+                    2692730210, 288449107,
+                    646103879, 2782923823]);
     }
     
     #[test]

--- a/src/prng/isaac64.rs
+++ b/src/prng/isaac64.rs
@@ -105,6 +105,12 @@ impl fmt::Debug for Isaac64Rng {
 }
 
 impl Isaac64Rng {
+    /// Create a 64-bit ISAAC random number generator using the
+    /// default fixed seed.
+    pub fn new_unseeded() -> Isaac64Rng {
+        Self::new_from_u64(0)
+    }
+    
     /// Creates an ISAAC-64 random number generator using an u64 as seed.
     /// If `seed == 0` this will produce the same stream of random numbers as
     /// the reference implementation when used unseeded.

--- a/src/prng/isaac64.rs
+++ b/src/prng/isaac64.rs
@@ -16,6 +16,7 @@ use core::num::Wrapping as w;
 use core::fmt;
 
 use {Rng, SeedableRng, Rand};
+use impls;
 
 #[allow(non_camel_case_types)]
 type w64 = w<u64>;
@@ -208,6 +209,10 @@ impl Rng for Isaac64Rng {
         // in bounds, without unsafe. NB. this is a power of two, so
         // it optimises to a bitwise mask).
         self.rsl[self.cnt as usize % RAND_SIZE].0
+    }
+    
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        impls::fill_bytes_via_u64(self, dest)
     }
 }
 

--- a/src/prng/isaac64.rs
+++ b/src/prng/isaac64.rs
@@ -373,7 +373,21 @@ mod test {
                         596345674630742204, 9947027391921273664, 11788097613744130851,
                         10391409374914919106));
     }
-
+    
+    #[test]
+    fn test_isaac64_true_bytes() {
+        let seed: &[_] = &[1, 23, 456, 7890, 12345];
+        let mut rng1 = Isaac64Rng::from_seed(seed);
+        let mut buf = [0u8; 32];
+        rng1.fill_bytes(&mut buf);
+        // Same as first values in test_isaac64_true_values as bytes in LE order
+        assert_eq!(buf,
+                   [140, 237, 103, 8, 93, 196, 151, 7,
+                    156, 242, 26, 63, 54, 166, 135, 199,
+                    141, 186, 192, 50, 116, 69, 205, 240,
+                    98, 205, 127, 160, 83, 98, 49, 17]);
+    }
+    
     #[test]
     fn test_isaac_new_uninitialized() {
         // Compare the results from initializing `IsaacRng` with

--- a/src/prng/isaac64.rs
+++ b/src/prng/isaac64.rs
@@ -375,6 +375,28 @@ mod test {
     }
     
     #[test]
+    fn test_isaac64_true_values_32() {
+        let seed: &[_] = &[1, 23, 456, 7890, 12345];
+        let mut rng1 = Isaac64Rng::from_seed(seed);
+        let v = (0..10).map(|_| rng1.next_u32()).collect::<Vec<_>>();
+        // Subset of above values, as an LE u32 sequence
+        // TODO: switch to this sequence?
+//         assert_eq!(v,
+//                    [141028748, 127386717,
+//                     1058730652, 3347555894,
+//                     851491469, 4039984500,
+//                     2692730210, 288449107,
+//                     646103879, 2782923823]);
+        // Subset of above values, using only low-half of each u64
+        assert_eq!(v,
+                   [141028748, 1058730652,
+                    851491469, 2692730210,
+                    646103879, 4195642895,
+                    2836348583, 1312677241,
+                    999139615, 253604626]);
+    }
+    
+    #[test]
     fn test_isaac64_true_bytes() {
         let seed: &[_] = &[1, 23, 456, 7890, 12345];
         let mut rng1 = Isaac64Rng::from_seed(seed);

--- a/src/prng/isaac64.rs
+++ b/src/prng/isaac64.rs
@@ -95,6 +95,7 @@ impl Clone for Isaac64Rng {
     }
 }
 
+// Custom Debug implementation that does not expose the internal state
 impl fmt::Debug for Isaac64Rng {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Isaac64Rng {{}}")

--- a/src/prng/isaac64.rs
+++ b/src/prng/isaac64.rs
@@ -24,16 +24,54 @@ type w64 = w<u64>;
 const RAND_SIZE_LEN: usize = 8;
 const RAND_SIZE: usize = 1 << RAND_SIZE_LEN;
 
-/// A random number generator that uses ISAAC-64[1], the 64-bit
-/// variant of the ISAAC algorithm.
+/// A random number generator that uses ISAAC-64, the 64-bit variant of the
+/// ISAAC algorithm.
 ///
-/// The ISAAC algorithm is generally accepted as suitable for
-/// cryptographic purposes, but this implementation has not be
-/// verified as such. Prefer a generator like `OsRng` that defers to
-/// the operating system for cases that need high security.
+/// ISAAC stands for "Indirection, Shift, Accumulate, Add, and Count" which are
+/// the principal bitwise operations employed. It is the most advanced of a
+/// series of array based random number generator designed by Robert Jenkins
+/// in 1996[1].
 ///
-/// [1]: Bob Jenkins, [*ISAAC: A fast cryptographic random number
-/// generator*](http://www.burtleburtle.net/bob/rand/isaacafa.html)
+/// Although ISAAC is designed to be cryptographically secure, its design is not
+/// founded in cryptographic theory. Therefore it is _not recommended for_
+/// cryptographic purposes. It is however one of the strongest non-cryptograpic
+/// RNGs, and that while still being reasonably fast.
+///
+/// ISAAC-64 is mostly similar to ISAAC. Because it operates on 64-bit integers
+/// instead of 32-bit, it uses twice as much memory to hold its state and
+/// results. Also it uses different constants for shifts and indirect indexing,
+/// optimized to give good results for 64bit arithmetic.
+///
+/// ## Overview of the ISAAC-64 algorithm:
+/// (in pseudo-code)
+///
+/// ```text
+/// Input: a, b, c, s[256] // state
+/// Output: r[256] // results
+///
+/// mix(a,i) = !(a ^ a << 21)  if i = 0 mod 4
+///              a ^ a >>  5   if i = 1 mod 4
+///              a ^ a << 12   if i = 2 mod 4
+///              a ^ a >> 33   if i = 3 mod 4
+///
+/// c = c + 1
+/// b = b + c
+///
+/// for i in 0..256 {
+///     x = s_[i]
+///     a = mix(a,i) + s[i+128 mod 256]
+///     y = a + b + s[x>>3 mod 256]
+///     s[i] = y
+///     b = x + s[y>>11 mod 256]
+///     r[i] = b
+/// }
+/// ```
+///
+/// See for more information the description in rand::prng::IsaacRng.
+///
+/// [1]: Bob Jenkins, [*ISAAC and RC4*]
+///      (http://burtleburtle.net/bob/rand/isaac.html)
+
 #[derive(Copy)]
 pub struct Isaac64Rng {
     rsl: [w64; RAND_SIZE],
@@ -123,6 +161,20 @@ impl Isaac64Rng {
     }
 
     /// Refills the output buffer (`self.rsl`)
+    /// See also the pseudocode desciption of the algorithm at the top of this
+    /// file.
+    ///
+    /// Optimisations used (similar to the reference implementation):
+    /// - The loop is unrolled 4 times, once for every constant of mix().
+    /// - The contents of the main loop are moved to a function `rngstep`, to
+    ///   reduce code duplication.
+    /// - We use local variables for a and b, which helps with optimisations.
+    /// - We split the main loop in two, one that operates over 0..128 and one
+    ///   over 128..256. This way we can optimise out the addition and modulus
+    ///   from `s[i+128 mod 256]`.
+    /// - We maintain one index `i` and add `m` or `m2` as base (m2 for the
+    ///   `s[i+128 mod 256]`), relying on the optimizer to turn it into pointer
+    ///   arithmetic.
     fn isaac64(&mut self) {
         self.c += w(1);
         // abbreviations

--- a/src/prng/isaac64.rs
+++ b/src/prng/isaac64.rs
@@ -71,8 +71,6 @@ const RAND_SIZE: usize = 1 << RAND_SIZE_LEN;
 ///
 /// [1]: Bob Jenkins, [*ISAAC and RC4*]
 ///      (http://burtleburtle.net/bob/rand/isaac.html)
-
-#[derive(Copy)]
 pub struct Isaac64Rng {
     rsl: [w64; RAND_SIZE],
     mem: [w64; RAND_SIZE],
@@ -82,82 +80,81 @@ pub struct Isaac64Rng {
     cnt: u32,
 }
 
-static EMPTY_64: Isaac64Rng = Isaac64Rng {
-    cnt: 0,
-    rsl: [w(0); RAND_SIZE],
-    mem: [w(0); RAND_SIZE],
-    a: w(0), b: w(0), c: w(0),
-};
+// Cannot be derived because [u64; 256] does not implement Clone
+impl Clone for Isaac64Rng {
+    fn clone(&self) -> Isaac64Rng {
+        Isaac64Rng {
+            rsl: self.rsl,
+            mem: self.mem,
+            a: self.a,
+            b: self.b,
+            c: self.c,
+            cnt: self.cnt,
+        }
+    }
+}
+
+impl fmt::Debug for Isaac64Rng {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Isaac64Rng {{}}")
+    }
+}
+
+fn mix(a: &mut w64, b: &mut w64, c: &mut w64, d: &mut w64,
+       e: &mut w64, f: &mut w64, g: &mut w64, h: &mut w64) {
+    *a -= *e; *f ^= *h >> 9;  *h += *a;
+    *b -= *f; *g ^= *a << 9;  *a += *b;
+    *c -= *g; *h ^= *b >> 23; *b += *c;
+    *d -= *h; *a ^= *c << 15; *c += *d;
+    *e -= *a; *b ^= *d >> 14; *d += *e;
+    *f -= *b; *c ^= *e << 20; *e += *f;
+    *g -= *c; *d ^= *f >> 17; *f += *g;
+    *h -= *d; *e ^= *g << 14; *g += *h;
+}
 
 impl Isaac64Rng {
-    /// Create a 64-bit ISAAC random number generator using the
-    /// default fixed seed.
-    pub fn new_unseeded() -> Isaac64Rng {
-        let mut rng = EMPTY_64;
-        rng.init(false);
+    /// Creates an ISAAC-64 random number generator using an u64 as seed.
+    /// If `seed == 0` this will produce the same stream of random numbers as
+    /// the reference implementation when used unseeded.
+    pub fn new_from_u64(seed: u64) -> Isaac64Rng {
+        let mut a = w(0x647c4677a2884b7c);
+        let mut b = w(0xb9f8b322c73ac862);
+        let mut c = w(0x8c0ea5053d4712a0);
+        let mut d = w(0xb29b2e824a595524);
+        let mut e = w(0x82f053db8355e0ce);
+        let mut f = w(0x48fe4a0fa5a09315);
+        let mut g = w(0xae985bf2cbfc89ed);
+        let mut h = w(0x98f5704f6c44c0ab);
+
+        let mut mem = [w(0); RAND_SIZE];
+
+        a += w(seed);
+
+        for i in (0..RAND_SIZE/8).map(|i| i * 8) {
+            mix(&mut a, &mut b, &mut c, &mut d, &mut e, &mut f, &mut g, &mut h);
+            mem[i  ] = a; mem[i+1] = b;
+            mem[i+2] = c; mem[i+3] = d;
+            mem[i+4] = e; mem[i+5] = f;
+            mem[i+6] = g; mem[i+7] = h;
+        }
+        // A second pass does not improve the quality here, because all of
+        // the seed was already available in the first round.
+        // Not doing the second pass has the small advantage that if `seed == 0`
+        // this method produces exactly the same state as the reference
+        // implementation when used unseeded.
+
+        let mut rng = Isaac64Rng {
+            rsl: [w(0); RAND_SIZE],
+            mem: mem,
+            a: w(0),
+            b: w(0),
+            c: w(0),
+            cnt: 0,
+        };
+
+        // Prepare the first set of results
+        rng.isaac64();
         rng
-    }
-
-    /// Initialises `self`. If `use_rsl` is true, then use the current value
-    /// of `rsl` as a seed, otherwise construct one algorithmically (not
-    /// randomly).
-    fn init(&mut self, use_rsl: bool) {
-        let mut a = w(0x9e3779b97f4a7c13); // golden ratio
-        let mut b = a;
-        let mut c = a;
-        let mut d = a;
-        let mut e = a;
-        let mut f = a;
-        let mut g = a;
-        let mut h = a;
-
-        macro_rules! mix {
-            () => {{
-                a -= e; f ^= h >> 9;  h += a;
-                b -= f; g ^= a << 9;  a += b;
-                c -= g; h ^= b >> 23; b += c;
-                d -= h; a ^= c << 15; c += d;
-                e -= a; b ^= d >> 14; d += e;
-                f -= b; c ^= e << 20; e += f;
-                g -= c; d ^= f >> 17; f += g;
-                h -= d; e ^= g << 14; g += h;
-            }}
-        }
-
-        for _ in 0..4 {
-            mix!();
-        }
-
-        if use_rsl {
-            macro_rules! memloop {
-                ($arr:expr) => {{
-                    for i in (0..RAND_SIZE/8).map(|i| i * 8) {
-                        a += $arr[i  ]; b += $arr[i+1];
-                        c += $arr[i+2]; d += $arr[i+3];
-                        e += $arr[i+4]; f += $arr[i+5];
-                        g += $arr[i+6]; h += $arr[i+7];
-                        mix!();
-                        self.mem[i  ] = a; self.mem[i+1] = b;
-                        self.mem[i+2] = c; self.mem[i+3] = d;
-                        self.mem[i+4] = e; self.mem[i+5] = f;
-                        self.mem[i+6] = g; self.mem[i+7] = h;
-                    }
-                }}
-            }
-
-            memloop!(self.rsl);
-            memloop!(self.mem);
-        } else {
-            for i in (0..RAND_SIZE/8).map(|i| i * 8) {
-                mix!();
-                self.mem[i  ] = a; self.mem[i+1] = b;
-                self.mem[i+2] = c; self.mem[i+3] = d;
-                self.mem[i+4] = e; self.mem[i+5] = f;
-                self.mem[i+6] = g; self.mem[i+7] = h;
-            }
-        }
-
-        self.isaac64();
     }
 
     /// Refills the output buffer (`self.rsl`)
@@ -228,13 +225,6 @@ impl Isaac64Rng {
     }
 }
 
-// Cannot be derived because [u32; 256] does not implement Clone
-impl Clone for Isaac64Rng {
-    fn clone(&self) -> Isaac64Rng {
-        *self
-    }
-}
-
 impl Rng for Isaac64Rng {
     #[inline]
     fn next_u32(&mut self) -> u32 {
@@ -262,27 +252,79 @@ impl Rng for Isaac64Rng {
         // it optimises to a bitwise mask).
         self.rsl[self.cnt as usize % RAND_SIZE].0
     }
-    
+
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         impls::fill_bytes_via_u64(self, dest)
     }
 }
 
+/// Creates a new ISAAC-64 random number generator.
+fn init(key: [w64; RAND_SIZE]) -> Isaac64Rng {
+    // These numbers are the result of initializing a...h with the
+    // fractional part of the golden ratio in binary (0x9e3779b97f4a7c13)
+    // and applying mix() 4 times.
+    let mut a = w(0x647c4677a2884b7c);
+    let mut b = w(0xb9f8b322c73ac862);
+    let mut c = w(0x8c0ea5053d4712a0);
+    let mut d = w(0xb29b2e824a595524);
+    let mut e = w(0x82f053db8355e0ce);
+    let mut f = w(0x48fe4a0fa5a09315);
+    let mut g = w(0xae985bf2cbfc89ed);
+    let mut h = w(0x98f5704f6c44c0ab);
+
+    let mut mem = [w(0); RAND_SIZE];
+
+    macro_rules! memloop {
+        ($arr:expr) => {{
+            for i in (0..RAND_SIZE/8).map(|i| i * 8) {
+                a += $arr[i  ]; b += $arr[i+1];
+                c += $arr[i+2]; d += $arr[i+3];
+                e += $arr[i+4]; f += $arr[i+5];
+                g += $arr[i+6]; h += $arr[i+7];
+                mix(&mut a, &mut b, &mut c, &mut d,
+                    &mut e, &mut f, &mut g, &mut h);
+                mem[i  ] = a; mem[i+1] = b;
+                mem[i+2] = c; mem[i+3] = d;
+                mem[i+4] = e; mem[i+5] = f;
+                mem[i+6] = g; mem[i+7] = h;
+            }
+        }}
+    }
+
+    memloop!(key);
+    // Do a second pass to make all of the seed affect all of `mem`
+    memloop!(mem);
+
+    let mut rng = Isaac64Rng {
+        rsl: [w(0); RAND_SIZE],
+        mem: mem,
+        a: w(0),
+        b: w(0),
+        c: w(0),
+        cnt: 0,
+    };
+
+    // Prepare the first set of results
+    rng.isaac64();
+    rng
+}
+
+impl Rand for Isaac64Rng {
+    fn rand<R: Rng>(other: &mut R) -> Isaac64Rng {
+        let mut key = [w(0); RAND_SIZE];
+        unsafe {
+            let ptr = key.as_mut_ptr() as *mut u8;
+
+            let slice = slice::from_raw_parts_mut(ptr, RAND_SIZE * 8);
+            other.fill_bytes(slice);
+        }
+        init(key)
+    }
+}
+
 impl<'a> SeedableRng<&'a [u64]> for Isaac64Rng {
     fn reseed(&mut self, seed: &'a [u64]) {
-        // make the seed into [seed[0], seed[1], ..., seed[seed.len()
-        // - 1], 0, 0, ...], to fill rng.rsl.
-        let seed_iter = seed.iter().map(|&x| x).chain(repeat(0u64));
-
-        for (rsl_elem, seed_elem) in self.rsl.iter_mut().zip(seed_iter) {
-            *rsl_elem = w(seed_elem);
-        }
-        self.cnt = 0;
-        self.a = w(0);
-        self.b = w(0);
-        self.c = w(0);
-
-        self.init(true);
+        *self = Self::from_seed(seed);
     }
 
     /// Create an ISAAC random number generator with a seed. This can
@@ -291,34 +333,17 @@ impl<'a> SeedableRng<&'a [u64]> for Isaac64Rng {
     /// constructed with a given seed will generate the same sequence
     /// of values as all other generators constructed with that seed.
     fn from_seed(seed: &'a [u64]) -> Isaac64Rng {
-        let mut rng = EMPTY_64;
-        rng.reseed(seed);
-        rng
-    }
-}
+        let mut key = [w(0); RAND_SIZE];
 
-impl Rand for Isaac64Rng {
-    fn rand<R: Rng>(other: &mut R) -> Isaac64Rng {
-        let mut ret = EMPTY_64;
-        unsafe {
-            let ptr = ret.rsl.as_mut_ptr() as *mut u8;
+        // make the seed into [seed[0], seed[1], ..., seed[seed.len()
+        // - 1], 0, 0, ...], to fill `key`.
+        let seed_iter = seed.iter().map(|&x| x).chain(repeat(0u64));
 
-            let slice = slice::from_raw_parts_mut(ptr, RAND_SIZE * 8);
-            other.fill_bytes(slice);
+        for (rsl_elem, seed_elem) in key.iter_mut().zip(seed_iter) {
+            *rsl_elem = w(seed_elem);
         }
-        ret.cnt = 0;
-        ret.a = w(0);
-        ret.b = w(0);
-        ret.c = w(0);
 
-        ret.init(true);
-        return ret;
-    }
-}
-
-impl fmt::Debug for Isaac64Rng {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Isaac64Rng {{}}")
+        init(key)
     }
 }
 
@@ -380,6 +405,25 @@ mod test {
                         17196852593171130876, 2606123525235546165, 15790932315217671084,
                         596345674630742204, 9947027391921273664, 11788097613744130851,
                         10391409374914919106));
+    }
+
+    #[test]
+    fn test_isaac_new_uninitialized() {
+        // Compare the results from initializing `IsaacRng` with
+        // `new_from_u64(0)`, to make sure it is the same as the reference
+        // implementation when used uninitialized.
+        // Note: We only test the first 16 integers, not the full 256 of the
+        // first block.
+        let mut rng = Isaac64Rng::new_from_u64(0);
+        let vec = (0..16).map(|_| rng.next_u64()).collect::<Vec<_>>();
+        let expected: [u64; 16] = [
+            0xF67DFBA498E4937C, 0x84A5066A9204F380, 0xFEE34BD5F5514DBB,
+            0x4D1664739B8F80D6, 0x8607459AB52A14AA, 0x0E78BC5A98529E49,
+            0xFE5332822AD13777, 0x556C27525E33D01A, 0x08643CA615F3149F,
+            0xD0771FAF3CB04714, 0x30E86F68A37B008D, 0x3074EBC0488A3ADF,
+            0x270645EA7A2790BC, 0x5601A0A8D3763C6A, 0x2F83071F53F325DD,
+            0xB9090F3D42D2D2EA];
+        assert_eq!(vec, expected);
     }
 
     #[test]

--- a/src/prng/xorshift.rs
+++ b/src/prng/xorshift.rs
@@ -12,6 +12,7 @@
 
 use core::num::Wrapping as w;
 use {Rng, SeedableRng, Rand};
+use impls;
 
 /// An Xorshift[1] random number
 /// generator.
@@ -60,6 +61,14 @@ impl Rng for XorShiftRng {
         let w_ = self.w;
         self.w = w_ ^ (w_ >> 19) ^ (t ^ (t >> 8));
         self.w.0
+    }
+    
+    fn next_u64(&mut self) -> u64 {
+        impls::next_u64_via_u32(self)
+    }
+    
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        impls::fill_bytes_via_u32(self, dest)
     }
 }
 

--- a/src/prng/xorshift.rs
+++ b/src/prng/xorshift.rs
@@ -11,6 +11,7 @@
 //! Xorshift generators
 
 use core::num::Wrapping as w;
+use core::fmt;
 use {Rng, SeedableRng, Rand};
 use impls;
 
@@ -24,13 +25,19 @@ use impls;
 /// [1]: Marsaglia, George (July 2003). ["Xorshift
 /// RNGs"](http://www.jstatsoft.org/v08/i14/paper). *Journal of
 /// Statistical Software*. Vol. 8 (Issue 14).
-#[allow(missing_copy_implementations)]
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct XorShiftRng {
     x: w<u32>,
     y: w<u32>,
     z: w<u32>,
     w: w<u32>,
+}
+
+// Custom Debug implementation that does not expose the internal state
+impl fmt::Debug for XorShiftRng {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "XorShiftRng {{}}")
+    }
 }
 
 impl XorShiftRng {

--- a/src/rand_impls.rs
+++ b/src/rand_impls.rs
@@ -248,6 +248,7 @@ impl<T:Rand> Rand for Option<T> {
 
 #[cfg(test)]
 mod tests {
+    use impls;
     use {Rng, thread_rng, Open01, Closed01};
 
     struct ConstantRng(u64);
@@ -259,6 +260,10 @@ mod tests {
         fn next_u64(&mut self) -> u64 {
             let ConstantRng(v) = *self;
             v
+        }
+        
+        fn fill_bytes(&mut self, dest: &mut [u8]) {
+            impls::fill_bytes_via_u64(self, dest)
         }
     }
 

--- a/src/reseeding.rs
+++ b/src/reseeding.rs
@@ -147,6 +147,7 @@ impl Default for ReseedWithDefault {
 
 #[cfg(test)]
 mod test {
+    use impls;
     use std::default::Default;
     use std::iter::repeat;
     use super::{ReseedingRng, ReseedWithDefault};
@@ -161,6 +162,13 @@ mod test {
             self.i += 1;
             // very random
             self.i - 1
+        }
+        fn next_u64(&mut self) -> u64 {
+            impls::next_u64_via_u32(self)
+        }
+        
+        fn fill_bytes(&mut self, dest: &mut [u8]) {
+            impls::fill_bytes_via_u64(self, dest)
         }
     }
     impl Default for Counter {


### PR DESCRIPTION
Notable changes:
-   `Rng::next_u64` and `Rng::fill_bytes` no longer have default implementations
-   `impls` module added (private; the idea is that this gets exported as `rand_core::impls` later)
-   Isaac code massively improved and performance improved by @pitdicker 
-   ChaCha code also improved to a lesser extent

Note that this is based on `core` (PR #208) which accounts for the changes to Cargo.toml and the README.

Also note: yes, I merged these 17 commits by hand (ugh) and ran the tests for each. Reviewing in detail from this PR will be horrible; it may be easier to review the original commits if you want to do that. But everything has already been well reviewed by @pitdicker and myself and there are a bunch of tests, so I'm not too worried.