### PR TITLE
Bump to 0.3.19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: rust
 sudo: false
-before_script:
-  - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
 
 matrix:
   include:
@@ -11,16 +9,19 @@ matrix:
       os: osx
     - rust: beta
     - rust: nightly
+      before_script:
+        - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
       script:
-        - cargo test
+        - cargo doc --no-deps --all-features
+        - cargo bench
         - cargo test --features nightly
-        - cargo test --manifest-path rand-derive/Cargo.toml
-        - cargo doc --no-deps --features nightly
+      after_success:
+        - travis-cargo --only nightly doc-upload
+
 script:
   - cargo test
   - cargo test --manifest-path rand-derive/Cargo.toml
-after_success:
-  - travis-cargo --only nightly doc-upload
+
 env:
   global:
     secure: "BdDntVHSompN+Qxz5Rz45VI4ZqhD72r6aPl166FADlnkIwS6N6FLWdqs51O7G5CpoMXEDvyYrjmRMZe/GYLIG9cmqmn/wUrWPO+PauGiIuG/D2dmfuUNvSTRcIe7UQLXrfP3yyfZPgqsH6pSnNEVopquQKy3KjzqepgriOJtbyY="

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.3.18"
+version = "0.3.19"
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,9 @@ nightly = ["i128_support"]
 libc = "0.2"
 
 [dev-dependencies]
-log = "0.3.0"
+# log 0.3.9 is a wrapper around 0.4.0 which doesn't work with rustc 1.15
+# To keep our CI pin on 1.15 we require log <= 0.3.8.
+log = "0.3, <=0.3.8"
 
 [workspace]
 members = ["rand-derive"]

--- a/src/os.rs
+++ b/src/os.rs
@@ -53,13 +53,13 @@ impl fmt::Debug for OsRng {
     }
 }
 
-fn next_u32(mut fill_buf: &mut FnMut(&mut [u8])) -> u32 {
+fn next_u32(fill_buf: &mut FnMut(&mut [u8])) -> u32 {
     let mut buf: [u8; 4] = [0; 4];
     fill_buf(&mut buf);
     unsafe { mem::transmute::<[u8; 4], u32>(buf) }
 }
 
-fn next_u64(mut fill_buf: &mut FnMut(&mut [u8])) -> u64 {
+fn next_u64(fill_buf: &mut FnMut(&mut [u8])) -> u64 {
     let mut buf: [u8; 8] = [0; 8];
     fill_buf(&mut buf);
     unsafe { mem::transmute::<[u8; 8], u64>(buf) }


### PR DESCRIPTION
PRs since `0.3.18`: #193 #207
Sorry for the inconvenience, but this new version on `0.3` branch is required to unblock rust-lang/rust#46278 (#207 fixes broken links in compiler docs).