### PR TITLE
Update version in docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! rand = "0.3"
+//! rand = "0.4"
 //! ```
 //!
 //! and this to your crate root:


### PR DESCRIPTION
`seq` isn't available in 0.3