### PR TITLE
Port rand to CloudABI.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,8 @@ winapi = { version = "0.3", features = ["minwindef", "ntsecapi", "profileapi", "
 [workspace]
 members = ["rand-derive"]
 
+[target.'cfg(target_os = "cloudabi")'.dependencies]
+cloudabi = "0.0.3"
+
 [target.'cfg(target_os = "fuchsia")'.dependencies]
 fuchsia-zircon = "0.3.2"


### PR DESCRIPTION
CloudABI has a special system call, random_get(), that can be used to
obtain random data from the environment (the kernel, emulator, etc). We
can invoke this system call by making use of the cloudabi crate.