### PR TITLE
 Implement Rng for Box with alloc feature

### DIFF
--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -105,7 +105,7 @@ mod test {
     #[test]
     fn test_exp() {
         let mut exp = Exp::new(10.0);
-        let mut rng = ::test::rng();
+        let mut rng = ::test::rng(221);
         for _ in 0..1000 {
             assert!(exp.sample(&mut rng) >= 0.0);
             assert!(exp.ind_sample(&mut rng) >= 0.0);

--- a/src/distributions/gamma.rs
+++ b/src/distributions/gamma.rs
@@ -334,7 +334,7 @@ mod test {
     #[test]
     fn test_chi_squared_one() {
         let mut chi = ChiSquared::new(1.0);
-        let mut rng = ::test::rng();
+        let mut rng = ::test::rng(201);
         for _ in 0..1000 {
             chi.sample(&mut rng);
             chi.ind_sample(&mut rng);
@@ -343,7 +343,7 @@ mod test {
     #[test]
     fn test_chi_squared_small() {
         let mut chi = ChiSquared::new(0.5);
-        let mut rng = ::test::rng();
+        let mut rng = ::test::rng(202);
         for _ in 0..1000 {
             chi.sample(&mut rng);
             chi.ind_sample(&mut rng);
@@ -352,7 +352,7 @@ mod test {
     #[test]
     fn test_chi_squared_large() {
         let mut chi = ChiSquared::new(30.0);
-        let mut rng = ::test::rng();
+        let mut rng = ::test::rng(203);
         for _ in 0..1000 {
             chi.sample(&mut rng);
             chi.ind_sample(&mut rng);
@@ -367,7 +367,7 @@ mod test {
     #[test]
     fn test_f() {
         let mut f = FisherF::new(2.0, 32.0);
-        let mut rng = ::test::rng();
+        let mut rng = ::test::rng(204);
         for _ in 0..1000 {
             f.sample(&mut rng);
             f.ind_sample(&mut rng);
@@ -377,7 +377,7 @@ mod test {
     #[test]
     fn test_t() {
         let mut t = StudentT::new(11.0);
-        let mut rng = ::test::rng();
+        let mut rng = ::test::rng(205);
         for _ in 0..1000 {
             t.sample(&mut rng);
             t.ind_sample(&mut rng);

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -335,36 +335,36 @@ mod tests {
             }}
         }
 
-        t!(vec!(Weighted { weight: 1, item: 10}), [10]);
+        t!([Weighted { weight: 1, item: 10}], [10]);
 
         // skip some
-        t!(vec!(Weighted { weight: 0, item: 20},
-                Weighted { weight: 2, item: 21},
-                Weighted { weight: 0, item: 22},
-                Weighted { weight: 1, item: 23}),
+        t!([Weighted { weight: 0, item: 20},
+            Weighted { weight: 2, item: 21},
+            Weighted { weight: 0, item: 22},
+            Weighted { weight: 1, item: 23}],
            [21,21, 23]);
 
         // different weights
-        t!(vec!(Weighted { weight: 4, item: 30},
-                Weighted { weight: 3, item: 31}),
+        t!([Weighted { weight: 4, item: 30},
+            Weighted { weight: 3, item: 31}],
            [30,30,30,30, 31,31,31]);
 
         // check that we're binary searching
         // correctly with some vectors of odd
         // length.
-        t!(vec!(Weighted { weight: 1, item: 40},
-                Weighted { weight: 1, item: 41},
-                Weighted { weight: 1, item: 42},
-                Weighted { weight: 1, item: 43},
-                Weighted { weight: 1, item: 44}),
+        t!([Weighted { weight: 1, item: 40},
+            Weighted { weight: 1, item: 41},
+            Weighted { weight: 1, item: 42},
+            Weighted { weight: 1, item: 43},
+            Weighted { weight: 1, item: 44}],
            [40, 41, 42, 43, 44]);
-        t!(vec!(Weighted { weight: 1, item: 50},
-                Weighted { weight: 1, item: 51},
-                Weighted { weight: 1, item: 52},
-                Weighted { weight: 1, item: 53},
-                Weighted { weight: 1, item: 54},
-                Weighted { weight: 1, item: 55},
-                Weighted { weight: 1, item: 56}),
+        t!([Weighted { weight: 1, item: 50},
+            Weighted { weight: 1, item: 51},
+            Weighted { weight: 1, item: 52},
+            Weighted { weight: 1, item: 53},
+            Weighted { weight: 1, item: 54},
+            Weighted { weight: 1, item: 55},
+            Weighted { weight: 1, item: 56}],
            [50, 51, 52, 53, 54, 55, 56]);
     }
 

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -311,9 +311,10 @@ mod tests {
     fn test_rand_sample() {
         let mut rand_sample = RandSample::<ConstRand>::new();
 
-        assert_eq!(rand_sample.sample(&mut ::test::rng()), ConstRand(0));
-        assert_eq!(rand_sample.ind_sample(&mut ::test::rng()), ConstRand(0));
+        assert_eq!(rand_sample.sample(&mut ::test::rng(231)), ConstRand(0));
+        assert_eq!(rand_sample.ind_sample(&mut ::test::rng(232)), ConstRand(0));
     }
+
     #[test]
     fn test_weighted_choice() {
         // this makes assumptions about the internal implementation of

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -405,7 +405,7 @@ mod tests {
     }
     #[test] #[should_panic]
     fn test_weighted_choice_weight_overflows() {
-        let x = ::std::u32::MAX / 2; // x + x + 2 is the overflow
+        let x = ::core::u32::MAX / 2; // x + x + 2 is the overflow
         WeightedChoice::new(&mut [Weighted { weight: x, item: 0 },
                                   Weighted { weight: 1, item: 1 },
                                   Weighted { weight: x, item: 2 },

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -171,7 +171,7 @@ mod tests {
     #[test]
     fn test_normal() {
         let mut norm = Normal::new(10.0, 10.0);
-        let mut rng = ::test::rng();
+        let mut rng = ::test::rng(210);
         for _ in 0..1000 {
             norm.sample(&mut rng);
             norm.ind_sample(&mut rng);
@@ -187,7 +187,7 @@ mod tests {
     #[test]
     fn test_log_normal() {
         let mut lnorm = LogNormal::new(10.0, 10.0);
-        let mut rng = ::test::rng();
+        let mut rng = ::test::rng(211);
         for _ in 0..1000 {
             lnorm.sample(&mut rng);
             lnorm.ind_sample(&mut rng);

--- a/src/distributions/range.rs
+++ b/src/distributions/range.rs
@@ -185,7 +185,7 @@ mod tests {
 
     #[test]
     fn test_integers() {
-        let mut rng = ::test::rng();
+        let mut rng = ::test::rng(251);
         macro_rules! t {
             ($($ty:ident),*) => {{
                 $(
@@ -214,7 +214,7 @@ mod tests {
 
     #[test]
     fn test_floats() {
-        let mut rng = ::test::rng();
+        let mut rng = ::test::rng(252);
         macro_rules! t {
             ($($ty:ty),*) => {{
                 $(
@@ -237,5 +237,4 @@ mod tests {
 
         t!(f32, f64)
     }
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -624,7 +624,9 @@ impl<'a, R: ?Sized> Rng for &'a mut R where R: Rng {
     }
 }
 
-#[cfg(feature="std")]
+#[cfg(all(feature="alloc", not(feature="std")))]
+use alloc::boxed::Box;
+#[cfg(any(feature="std", feature="alloc"))]
 impl<R: ?Sized> Rng for Box<R> where R: Rng {
     fn next_u32(&mut self) -> u32 {
         (**self).next_u32()

--- a/src/rand_impls.rs
+++ b/src/rand_impls.rs
@@ -249,7 +249,7 @@ impl<T:Rand> Rand for Option<T> {
 #[cfg(test)]
 mod tests {
     use impls;
-    use {Rng, thread_rng, Open01, Closed01};
+    use {Rng, Open01, Closed01};
 
     struct ConstantRng(u64);
     impl Rng for ConstantRng {
@@ -278,7 +278,7 @@ mod tests {
     fn rand_open() {
         // this is unlikely to catch an incorrect implementation that
         // generates exactly 0 or 1, but it keeps it sane.
-        let mut rng = thread_rng();
+        let mut rng = ::test::rng(501);
         for _ in 0..1_000 {
             // strict inequalities
             let Open01(f) = rng.gen::<Open01<f64>>();
@@ -291,7 +291,7 @@ mod tests {
 
     #[test]
     fn rand_closed() {
-        let mut rng = thread_rng();
+        let mut rng = ::test::rng(502);
         for _ in 0..1_000 {
             // strict inequalities
             let Closed01(f) = rng.gen::<Closed01<f64>>();

--- a/src/reseeding.rs
+++ b/src/reseeding.rs
@@ -223,12 +223,8 @@ mod test {
         let mut v = [0u8; FILL_BYTES_V_LEN];
         ::test::rng(321).fill_bytes(&mut v);
 
-        // To test that `fill_bytes` actually did something, check that the
-        // average of `v` is not 0.
-        let mut sum = 0.0;
-        for &x in v.iter() {
-            sum += x as f64;
-        }
-        assert!(sum / v.len() as f64 != 0.0);
+        // To test that `fill_bytes` actually did something, check that not all
+        // bytes are zero.
+        assert!(!v.iter().all(|&x| x == 0));
     }
 }

--- a/src/reseeding.rs
+++ b/src/reseeding.rs
@@ -221,7 +221,7 @@ mod test {
     #[test]
     fn test_rng_fill_bytes() {
         let mut v = [0u8; FILL_BYTES_V_LEN];
-        ::test::rng().fill_bytes(&mut v);
+        ::test::rng(321).fill_bytes(&mut v);
 
         // To test that `fill_bytes` actually did something, check that the
         // average of `v` is not 0.

--- a/src/reseeding.rs
+++ b/src/reseeding.rs
@@ -148,8 +148,7 @@ impl Default for ReseedWithDefault {
 #[cfg(test)]
 mod test {
     use impls;
-    use std::default::Default;
-    use std::iter::repeat;
+    use core::default::Default;
     use super::{ReseedingRng, ReseedWithDefault};
     use {SeedableRng, Rng};
 
@@ -207,24 +206,22 @@ mod test {
 
     #[test]
     fn test_rng_reseed() {
-        let mut r: MyRng = SeedableRng::from_seed((ReseedWithDefault, 3));
-        let string1: String = r.gen_ascii_chars().take(100).collect();
+        let mut rng: MyRng = SeedableRng::from_seed((ReseedWithDefault, 3));
+        let mut results1 = [0u32; 32];
+        for i in results1.iter_mut() { *i = rng.next_u32(); }
 
-        r.reseed((ReseedWithDefault, 3));
+        rng.reseed((ReseedWithDefault, 3));
 
-        let string2: String = r.gen_ascii_chars().take(100).collect();
-        assert_eq!(string1, string2);
+        let mut results2 = [0u32; 32];
+        for i in results2.iter_mut() { *i = rng.next_u32(); }
+        assert_eq!(results1, results2);
     }
 
     const FILL_BYTES_V_LEN: usize = 13579;
     #[test]
     fn test_rng_fill_bytes() {
-        let mut v = repeat(0u8).take(FILL_BYTES_V_LEN).collect::<Vec<_>>();
+        let mut v = [0u8; FILL_BYTES_V_LEN];
         ::test::rng().fill_bytes(&mut v);
-
-        // Sanity test: if we've gotten here, `fill_bytes` has not infinitely
-        // recursed.
-        assert_eq!(v.len(), FILL_BYTES_V_LEN);
 
         // To test that `fill_bytes` actually did something, check that the
         // average of `v` is not 0.

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -226,7 +226,7 @@ fn sample_indices_cache<R>(
 #[cfg(test)]
 mod test {
     use super::*;
-    use {thread_rng, XorShiftRng, SeedableRng};
+    use {XorShiftRng, SeedableRng};
     #[cfg(not(feature="std"))]
     use alloc::Vec;
 
@@ -235,7 +235,7 @@ mod test {
         let min_val = 1;
         let max_val = 100;
 
-        let mut r = thread_rng();
+        let mut r = ::test::rng(401);
         let vals = (min_val..max_val).collect::<Vec<i32>>();
         let small_sample = sample_iter(&mut r, vals.iter(), 5).unwrap();
         let large_sample = sample_iter(&mut r, vals.iter(), vals.len() + 5).unwrap_err();
@@ -253,7 +253,7 @@ mod test {
     fn test_sample_slice_boundaries() {
         let empty: &[u8] = &[];
 
-        let mut r = thread_rng();
+        let mut r = ::test::rng(402);
 
         // sample 0 items
         assert_eq!(&sample_slice(&mut r, empty, 0)[..], []);
@@ -298,7 +298,7 @@ mod test {
         let xor_rng = XorShiftRng::from_seed;
 
         let max_range = 100;
-        let mut r = thread_rng();
+        let mut r = ::test::rng(403);
 
         for length in 1usize..max_range {
             let amount = r.gen_range(0, length);

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -227,6 +227,8 @@ fn sample_indices_cache<R>(
 mod test {
     use super::*;
     use {thread_rng, XorShiftRng, SeedableRng};
+    #[cfg(not(feature="std"))]
+    use alloc::Vec;
 
     #[test]
     fn test_sample_iter() {
@@ -254,25 +256,25 @@ mod test {
         let mut r = thread_rng();
 
         // sample 0 items
-        assert_eq!(sample_slice(&mut r, empty, 0), vec![]);
-        assert_eq!(sample_slice(&mut r, &[42, 2, 42], 0), vec![]);
+        assert_eq!(&sample_slice(&mut r, empty, 0)[..], []);
+        assert_eq!(&sample_slice(&mut r, &[42, 2, 42], 0)[..], []);
 
         // sample 1 item
-        assert_eq!(sample_slice(&mut r, &[42], 1), vec![42]);
+        assert_eq!(&sample_slice(&mut r, &[42], 1)[..], [42]);
         let v = sample_slice(&mut r, &[1, 42], 1)[0];
         assert!(v == 1 || v == 42);
 
         // sample "all" the items
         let v = sample_slice(&mut r, &[42, 133], 2);
-        assert!(v == vec![42, 133] || v == vec![133, 42]);
+        assert!(&v[..] == [42, 133] || v[..] == [133, 42]);
 
-        assert_eq!(sample_indices_inplace(&mut r, 0, 0), vec![]);
-        assert_eq!(sample_indices_inplace(&mut r, 1, 0), vec![]);
-        assert_eq!(sample_indices_inplace(&mut r, 1, 1), vec![0]);
+        assert_eq!(&sample_indices_inplace(&mut r, 0, 0)[..], []);
+        assert_eq!(&sample_indices_inplace(&mut r, 1, 0)[..], []);
+        assert_eq!(&sample_indices_inplace(&mut r, 1, 1)[..], [0]);
 
-        assert_eq!(sample_indices_cache(&mut r, 0, 0), vec![]);
-        assert_eq!(sample_indices_cache(&mut r, 1, 0), vec![]);
-        assert_eq!(sample_indices_cache(&mut r, 1, 1), vec![0]);
+        assert_eq!(&sample_indices_cache(&mut r, 0, 0)[..], []);
+        assert_eq!(&sample_indices_cache(&mut r, 1, 0)[..], []);
+        assert_eq!(&sample_indices_cache(&mut r, 1, 1)[..], [0]);
 
         // Make sure lucky 777's aren't lucky
         let slice = &[42, 777];
@@ -303,8 +305,6 @@ mod test {
             let seed: [u32; 4] = [
                 r.next_u32(), r.next_u32(), r.next_u32(), r.next_u32()
             ];
-
-            println!("Selecting indices: len={}, amount={}, seed={:?}", length, amount, seed);
 
             // assert that the two index methods give exactly the same result
             let inplace = sample_indices_inplace(


### PR DESCRIPTION
As discussed in https://github.com/rust-lang-nursery/rand/pull/225#discussion_r160139979.

I thought to run `cargo test --no-default-features --feature=alloc`, but that did not work. Endless compiler warnings.

I have included a couple a couple of commits that fix some of the tests that depend on needless memory allocations. Still about 40 compiler errors to go, most of which have to do with `tread_rng` not being available in `lib.rs`.

The test in `lib.rs` are where most of the remain problems are, and I didn't feel like fixing them at the moment. Those tests date from 5/6 years ago when `rand.rs` was the only file and things were very different. Several are now part of submodules, or could use a close look.

So testing on `no_std` does not work yet, but I hoped to leave that for another PR.