### PR TITLE
Add EntropySource wrapper

### DIFF
--- a/src/jitter.rs
+++ b/src/jitter.rs
@@ -742,7 +742,12 @@ impl Rng for JitterRng {
     }
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {
-        impls::fill_bytes_via_u64(self, dest)
+        // Fill using `next_u32`. This is faster for filling small slices (four
+        // bytes or less), while the overhead is negligible.
+        //
+        // This is done especially for wrappers that implement `next_u32`
+        // themselves via `fill_bytes`.
+        impls::fill_bytes_via_u32(self, dest)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1073,9 +1073,9 @@ impl Rng for EntropyRng {
                             Ok(jitter_rng) => {
                                 switch_rng = Some(EntropySource::Jitter(jitter_rng));
                             }
-                            Err(jitter_error) => {
+                            Err(_jitter_error) => {
                                 warn!("EntropyRng: JitterRng failed: {}",
-                                      jitter_error);
+                                      _jitter_error);
                                 return Err(os_rng_error);
                             }
                         }
@@ -1091,9 +1091,9 @@ impl Rng for EntropyRng {
                         Ok(jitter_rng) => {
                             switch_rng = Some(EntropySource::Jitter(jitter_rng));
                         }
-                        Err(jitter_error) => {
+                        Err(_jitter_error) => {
                             warn!("EntropyRng: JitterRng failed: {}",
-                                  jitter_error);
+                                  _jitter_error);
                             return Err(os_rng_error);
                         }
                     }


### PR DESCRIPTION
This is just an idea I am trying. The PR is based on top of https://github.com/rust-lang-nursery/rand/pull/233, only the last 3 commits are new.

I have added an `EntropySource` wrapper that uses `OsRng`, and if it errors falls back to `JitterRng`. I hope this will help in three situations:
- The fallback mechanism in `NewSeeded` can also be used by user code.
- It is no longer necessary to have a `Reseeder` trait, providing an RNG for reseeding is enough.
- We can hopefully add a feature flag to let `EntropySource` use an external RNG. This will make it and `NewSeeded` available for `no_std` uses.