### PR TITLE
Tweak Open01 and Closed01

### DIFF
--- a/src/rand_impls.rs
+++ b/src/rand_impls.rs
@@ -269,9 +269,38 @@ mod tests {
 
     #[test]
     fn floating_point_edge_cases() {
-        // the test for exact equality is correct here.
-        assert!(ConstantRng(0xffff_ffff).gen::<f32>() != 1.0);
-        assert!(ConstantRng(0xffff_ffff_ffff_ffff).gen::<f64>() != 1.0);
+        const EPSILON32: f32 = 1.0 / (1u32 << 23) as f32;
+        const EPSILON64: f64 = 1.0 / (1u64 << 52) as f64;
+
+        let mut zeros = ConstantRng(0);
+        let mut ones = ConstantRng(!0);
+
+        let zero32 = zeros.gen::<f32>();
+        let zero64 = zeros.gen::<f64>();
+        let one32 = ones.gen::<f32>();
+        let one64 = ones.gen::<f64>();
+        assert_eq!(zero32, 0.0);
+        assert_eq!(zero64, 0.0);
+        assert!(1.0 - EPSILON32 <= one32 && one32 < 1.0);
+        assert!(1.0 - EPSILON64 <= one64 && one64 < 1.0);
+
+        let Closed01(closed_zero32) = zeros.gen::<Closed01<f32>>();
+        let Closed01(closed_zero64) = zeros.gen::<Closed01<f64>>();
+        let Closed01(closed_one32) = ones.gen::<Closed01<f32>>();
+        let Closed01(closed_one64) = ones.gen::<Closed01<f64>>();
+        assert_eq!(closed_zero32, 0.0);
+        assert_eq!(closed_zero64, 0.0);
+        assert_eq!(closed_one32, 1.0);
+        assert_eq!(closed_one64, 1.0);
+
+        let Open01(open_zero32) = zeros.gen::<Open01<f32>>();
+        let Open01(open_zero64) = zeros.gen::<Open01<f64>>();
+        let Open01(open_one32) = ones.gen::<Open01<f32>>();
+        let Open01(open_one64) = ones.gen::<Open01<f64>>();
+        assert!(0.0 < open_zero32 && open_zero32 <= EPSILON32);
+        assert!(0.0 < open_zero64 && open_zero64 <= EPSILON64);
+        assert!(1.0 - EPSILON32 <= open_one32 && open_one32 < 1.0);
+        assert!(1.0 - EPSILON64 <= open_one64 && open_one64 < 1.0);
     }
 
     #[test]

--- a/src/rand_impls.rs
+++ b/src/rand_impls.rs
@@ -131,11 +131,10 @@ macro_rules! float_impls {
             impl Rand for Open01<$ty> {
                 #[inline]
                 fn rand<R: Rng>(rng: &mut R) -> Open01<$ty> {
-                    // add a small amount (specifically 2 bits below
-                    // the precision of f64/f32 at 1.0), so that small
-                    // numbers are larger than 0, but large numbers
-                    // aren't pushed to/above 1.
-                    Open01(rng.$method_name() + 0.25 / SCALE)
+                    // add 0.5 * epsilon, so that smallest number is
+                    // greater than 0, and largest number is still
+                    // less than 1, specifically 1 - 0.5 * epsilon.
+                    Open01(rng.$method_name() + 0.5 / SCALE)
                 }
             }
             impl Rand for Closed01<$ty> {

--- a/src/rand_impls.rs
+++ b/src/rand_impls.rs
@@ -114,6 +114,7 @@ macro_rules! float_impls {
         mod $mod_name {
             use {Rand, Rng, Open01, Closed01};
 
+            // 1.0 / epsilon
             const SCALE: $ty = (1u64 << $mantissa_bits) as $ty;
 
             impl Rand for $ty {
@@ -148,8 +149,8 @@ macro_rules! float_impls {
         }
     }
 }
-float_impls! { f64_rand_impls, f64, 53, next_f64 }
-float_impls! { f32_rand_impls, f32, 24, next_f32 }
+float_impls! { f64_rand_impls, f64, 52, next_f64 }
+float_impls! { f32_rand_impls, f32, 23, next_f32 }
 
 impl Rand for char {
     #[inline]


### PR DESCRIPTION
The PR has two commits:

1. Fix `SCALE` to be 2^52 for `f64` and 2^23 for `f24`. `SCALE` is expected to be 1/ɛ in the remaining code inside `float_impls`, so `$mantissa_bits` should be 52, 23 and not 53, 24. After this commit `Closed01` can produce 0.0 and 1.0, whereas before this commit the maximum was erroneously (1 − ɛ) / (1 − ɛ/2).
2. Remove the bias in `Open01` by adding ɛ/2 rather than the intended ɛ/4 (erroneously ɛ/8 before the first commit above). The largest number is now 1 − ɛ/2 which is still exactly representable, since 1 − ɛ has one spare bit of precision, unlike 1 + ɛ which uses all bits of precision.