### PR TITLE
Limit OsRng to a single file handle when reading from a file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 
 matrix:
   include:
-    - rust: 1.15.0
+    - rust: 1.22.0
       script:
         - cargo test
         - cargo build --no-default-features # we cannot exclude doc tests


### PR DESCRIPTION
Fix #234.

I'm not entirely happy with the code; it uses `unwrap` a lot and requires use of `unsafe` to access the mutex, and it also requires Rust 1.22; anything older gets:

> error[E0493]: destructors in statics are an unstable feature

`lazy_static` gets around this by using a `Box` cast to a pointer which never gets freed.

The reasons I didn't use `lazy_static` are:

*   it would be difficult to encapsulate the logic in `ReadRng` since `lazy_static` doesn't allow a constructor or argument to be passed
*   it would still require the mutex to safeguard access from other threads