### PR TITLE
Make `Fill_via_u*_chunks` not modify `src`

### DIFF
--- a/src/prng/chacha.rs
+++ b/src/prng/chacha.rs
@@ -208,8 +208,20 @@ impl Rng for ChaChaRng {
     }
 
 
-    fn fill_bytes(&mut self, bytes: &mut [u8]) {
-        impls::fill_bytes_via_u32(self, bytes)
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        let mut read_len = 0;
+        while read_len < dest.len() {
+            if self.index >= self.buffer.len() {
+                self.update();
+            }
+
+            let (consumed_u32, filled_u8) =
+                impls::fill_via_u32_chunks(&self.buffer[self.index..],
+                                           &mut dest[read_len..]);
+
+            self.index += consumed_u32;
+            read_len += filled_u8;
+        }
     }
 }
 

--- a/src/prng/hc128.rs
+++ b/src/prng/hc128.rs
@@ -342,7 +342,7 @@ impl Rng for Hc128Rng {
         // Continue filling from the current set of results
         if self.index < 16 {
             let (consumed_u32, filled_u8) =
-                impls::fill_via_u32_chunks(&mut self.results[self.index..],
+                impls::fill_via_u32_chunks(&self.results[self.index..],
                                            dest);
 
             self.index += consumed_u32;
@@ -367,7 +367,7 @@ impl Rng for Hc128Rng {
             self.state.update(&mut self.results);
 
             let (consumed_u32, _) =
-                impls::fill_via_u32_chunks(&mut self.results,
+                impls::fill_via_u32_chunks(&self.results,
                                            &mut dest[filled..]);
 
             self.index = consumed_u32;
@@ -384,7 +384,7 @@ impl Rng for Hc128Rng {
             }
 
             let (consumed_u32, filled_u8) =
-                impls::fill_via_u32_chunks(&mut self.results[self.index..],
+                impls::fill_via_u32_chunks(&self.results[self.index..],
                                            &mut dest[read_len..]);
 
             self.index += consumed_u32;

--- a/src/prng/isaac.rs
+++ b/src/prng/isaac.rs
@@ -242,7 +242,7 @@ impl Rng for IsaacRng {
             }
 
             let (consumed_u32, filled_u8) =
-                impls::fill_via_u32_chunks(&mut self.rsl[(self.index as usize)..],
+                impls::fill_via_u32_chunks(&self.rsl[(self.index as usize)..],
                                            &mut dest[read_len..]);
 
             self.index += consumed_u32 as u32;

--- a/src/prng/isaac64.rs
+++ b/src/prng/isaac64.rs
@@ -245,7 +245,7 @@ impl Rng for Isaac64Rng {
             }
 
             let (consumed_u64, filled_u8) =
-                impls::fill_via_u64_chunks(&mut self.rsl[self.index as usize..],
+                impls::fill_via_u64_chunks(&self.rsl[self.index as usize..],
                                            &mut dest[read_len..]);
 
             self.index += consumed_u64 as u32;


### PR DESCRIPTION
I now have 4 branches with `BlockRngCore` trait experiments, but it is hard to get them in a reviewable state. It is mostly the addition of a `BlockRng` wrapper and just a lot of code moving around.

One functional change is the one in this PR. Because it touches somewhat difficult code using unsafe it seemed best to split it out.

Another thing I can split out are changes to the documentation of ChaCha.