### PR TITLE
Various changes to `ChaChaRng`

### DIFF
--- a/benches/generators.rs
+++ b/benches/generators.rs
@@ -81,7 +81,7 @@ gen_uint_new!(gen_u64_std, u64, StdRng);
 gen_uint_new!(gen_u64_os, u64, OsRng);
 
 // Do not test JitterRng like the others by running it RAND_BENCH_N times per,
-// measurement, because it is way to slow. Only run it once
+// measurement, because it is way too slow. Only run it once.
 #[bench]
 fn gen_u64_jitter(b: &mut Bencher) {
     let mut rng = JitterRng::new().unwrap();

--- a/src/prng/chacha.rs
+++ b/src/prng/chacha.rs
@@ -25,7 +25,7 @@ const STATE_WORDS: usize = 16;
 /// selected as one of the "stream ciphers suitable for widespread adoption" by
 /// eSTREAM [2].
 ///
-/// ChaCha uses add-rotate-xor (ARX) operations as basis. These are safe
+/// ChaCha uses add-rotate-xor (ARX) operations as its basis. These are safe
 /// against timing attacks, although that is mostly a concern for ciphers and
 /// not for RNGs. Also it is very suitable for SIMD implementation.
 /// Here we do not provide a SIMD implementation yet, except for what is
@@ -33,9 +33,9 @@ const STATE_WORDS: usize = 16;
 ///
 /// With the ChaCha algorithm it is possible to choose the number of rounds the
 /// core algorithm should run. By default `ChaChaRng` is created as ChaCha20,
-/// with means 20 rounds. The number of rounds is a tradeoff between performance
-/// an security, 8 rounds are considered the minimum to be secure. A different
-/// number of rounds can be set with [`set_rounds`].
+/// which means 20 rounds. The number of rounds is a tradeoff between performance
+/// and security, 8 rounds are considered the minimum to be secure. A different
+/// number of rounds can be set using [`set_rounds`].
 ///
 /// We deviate slightly from the ChaCha specification regarding the nonce, which
 /// is used to extend the counter to 128 bits. This is provably as strong as the
@@ -132,8 +132,9 @@ impl ChaChaRng {
     /// The 128 bits used for the counter overlap with the nonce and smaller
     /// counter of ChaCha when used as a stream cipher. It is in theory possible
     /// to use `set_counter` to obtain the conventional ChaCha pseudorandom
-    /// stream associated with a particular nonce, but that is not a supported
-    /// use of this method.
+    /// stream associated with a particular nonce. This is not a supported use
+    /// of the RNG, because a nonce set that way is not treated as a constant
+    /// value but still as part of the counter, besides endian issues.
     ///
     /// # Examples
     ///
@@ -378,23 +379,6 @@ mod test {
                         64, 93, 106, 229, 83, 134, 189, 40,
                         189, 210, 25, 184, 160, 141, 237, 26,
                         168, 54, 239, 204, 139, 119, 13, 199];
-        assert_eq!(results, expected);
-    }
-
-    #[test]
-    fn test_chacha_set_counter() {
-        // Test vector 5 from
-        // https://tools.ietf.org/html/draft-nir-cfrg-chacha20-poly1305-04
-        let seed = [0u8; 32];
-        let mut rng: ChaChaRng = SeedableRng::from_seed(seed);
-        rng.set_counter(0, 2u64.to_be());
-
-        let mut results = [0u32; 16];
-        for i in results.iter_mut() { *i = rng.next_u32(); }
-        let expected = [0x374dc6c2, 0x3736d58c, 0xb904e24a, 0xcd3f93ef,
-                        0x88228b1a, 0x96a4dfb3, 0x5b76ab72, 0xc727ee54,
-                        0x0e0e978a, 0xf3145c95, 0x1b748ea8, 0xf786c297,
-                        0x99c28f5f, 0x628314e8, 0x398a19fa, 0x6ded1b53];
         assert_eq!(results, expected);
     }
 

--- a/src/prng/chacha.rs
+++ b/src/prng/chacha.rs
@@ -281,7 +281,7 @@ mod test {
         // Test vectors 1 and 2 from
         // https://tools.ietf.org/html/draft-nir-cfrg-chacha20-poly1305-04
         let seed = [0u8; 32];
-        let mut rng: ChaChaRng = SeedableRng::from_seed(seed);
+        let mut rng = ChaChaRng::from_seed(seed);
 
         let mut results = [0u32; 16];
         for i in results.iter_mut() { *i = rng.next_u32(); }
@@ -307,7 +307,7 @@ mod test {
                     0, 0, 0, 0, 0, 0, 0, 0,
                     0, 0, 0, 0, 0, 0, 0, 0,
                     0, 0, 0, 0, 0, 0, 0, 1];
-        let mut rng: ChaChaRng = SeedableRng::from_seed(seed);
+        let mut rng = ChaChaRng::from_seed(seed);
 
         // Skip block 0
         for _ in 0..16 { rng.next_u32(); }
@@ -336,13 +336,13 @@ mod test {
         let mut results = [0u32; 16];
 
         // Test block 2 by skipping block 0 and 1
-        let mut rng1: ChaChaRng = SeedableRng::from_seed(seed);
+        let mut rng1 = ChaChaRng::from_seed(seed);
         for _ in 0..32 { rng1.next_u32(); }
         for i in results.iter_mut() { *i = rng1.next_u32(); }
         assert_eq!(results, expected);
 
         // Test block 2 by using `set_counter`
-        let mut rng2: ChaChaRng = SeedableRng::from_seed(seed);
+        let mut rng2 = ChaChaRng::from_seed(seed);
         rng2.set_counter(2, 0);
         for i in results.iter_mut() { *i = rng2.next_u32(); }
         assert_eq!(results, expected);
@@ -351,7 +351,7 @@ mod test {
     #[test]
     fn test_chacha_multiple_blocks() {
         let seed = [0,0,0,0, 1,0,0,0, 2,0,0,0, 3,0,0,0, 4,0,0,0, 5,0,0,0, 6,0,0,0, 7,0,0,0];
-        let mut rng: ChaChaRng = SeedableRng::from_seed(seed);
+        let mut rng = ChaChaRng::from_seed(seed);
 
         // Store the 17*i-th 32-bit word,
         // i.e., the i-th word of the i-th 16-word block
@@ -372,7 +372,7 @@ mod test {
     #[test]
     fn test_chacha_true_bytes() {
         let seed = [0u8; 32];
-        let mut rng: ChaChaRng = SeedableRng::from_seed(seed);
+        let mut rng = ChaChaRng::from_seed(seed);
         let mut results = [0u8; 32];
         rng.fill_bytes(&mut results);
         let expected = [118, 184, 224, 173, 160, 241, 61, 144,
@@ -389,7 +389,7 @@ mod test {
         // Although we do not support setting a nonce, we try it here anyway so
         // we can use this test vector.
         let seed = [0u8; 32];
-        let mut rng: ChaChaRng = SeedableRng::from_seed(seed);
+        let mut rng = ChaChaRng::from_seed(seed);
         rng.set_counter(0, 2u64 << 56);
 
         let mut results = [0u32; 16];
@@ -404,7 +404,7 @@ mod test {
     #[test]
     fn test_chacha_set_rounds() {
         let seed = [0u8; 32];
-        let mut rng: ChaChaRng = SeedableRng::from_seed(seed);
+        let mut rng = ChaChaRng::from_seed(seed);
         rng.set_rounds(8);
 
         let mut results = [0u32; 16];
@@ -420,7 +420,7 @@ mod test {
     #[test]
     fn test_chacha_clone() {
         let seed = [0,0,0,0, 1,0,0,0, 2,0,0,0, 3,0,0,0, 4,0,0,0, 5,0,0,0, 6,0,0,0, 7,0,0,0];
-        let mut rng: ChaChaRng = SeedableRng::from_seed(seed);
+        let mut rng = ChaChaRng::from_seed(seed);
         let mut clone = rng.clone();
         for _ in 0..16 {
             assert_eq!(rng.next_u64(), clone.next_u64());

--- a/src/prng/chacha.rs
+++ b/src/prng/chacha.rs
@@ -246,7 +246,7 @@ impl SeedableRng for ChaChaRng {
     fn from_seed(seed: Self::Seed) -> Self {
         let mut seed_le = [0u32; SEED_WORDS];
         le::read_u32_into(&seed, &mut seed_le);
-        Self {
+        ChaChaRng {
             buffer: [0; STATE_WORDS],
             state: [0x61707865, 0x3320646E, 0x79622D32, 0x6B206574, // constants
                     seed_le[0], seed_le[1], seed_le[2], seed_le[3], // seed

--- a/src/prng/chacha.rs
+++ b/src/prng/chacha.rs
@@ -383,6 +383,25 @@ mod test {
     }
 
     #[test]
+    fn test_chacha_set_counter() {
+        // Test vector 5 from
+        // https://tools.ietf.org/html/draft-nir-cfrg-chacha20-poly1305-04
+        // Although we do not support setting a nonce, we try it here anyway so
+        // we can use this test vector.
+        let seed = [0u8; 32];
+        let mut rng: ChaChaRng = SeedableRng::from_seed(seed);
+        rng.set_counter(0, 2u64 << 56);
+
+        let mut results = [0u32; 16];
+        for i in results.iter_mut() { *i = rng.next_u32(); }
+        let expected = [0x374dc6c2, 0x3736d58c, 0xb904e24a, 0xcd3f93ef,
+                        0x88228b1a, 0x96a4dfb3, 0x5b76ab72, 0xc727ee54,
+                        0x0e0e978a, 0xf3145c95, 0x1b748ea8, 0xf786c297,
+                        0x99c28f5f, 0x628314e8, 0x398a19fa, 0x6ded1b53];
+        assert_eq!(results, expected);
+    }
+
+    #[test]
     fn test_chacha_set_rounds() {
         let seed = [0u8; 32];
         let mut rng: ChaChaRng = SeedableRng::from_seed(seed);

--- a/src/prng/chacha.rs
+++ b/src/prng/chacha.rs
@@ -187,7 +187,7 @@ impl ChaChaRng {
 
     /// Refill the internal output buffer (`self.buffer`)
     fn update(&mut self) {
-        // For some reason extracting this part into a seperate function
+        // For some reason extracting this part into a separate function
         // improves performance by 50%.
         fn core(results: &mut [u32; STATE_WORDS],
                 state: &[u32; STATE_WORDS],


### PR DESCRIPTION
This PR is based on top of https://github.com/rust-lang-nursery/rand/pull/233.

Parts of the changes here come from my attempts with a with `BlockRngCore` trait, like https://github.com/rust-lang-nursery/rand/pull/242. And better to finish this seperately, so all functional changes and changes to the documentation can be reviewed better.

The `init` function contained useful documentation that was not visible because `init` was not a public function. So I moved that to the documentation of ChaChaRng. Also I wrote some more in a similar style as HC-128.

I added some tests and better documentation for `set_counter`. Trying to use it to set a nonce is difficult, considering the trouble with endianness and different standards specifying different schemes for the nonce and counter. So I documented it to be not a supported use of `set_rounds`.

It turned out to be easy to make the number of rounds the core ChaCha algorithm runs configurable, just the addition of a `set_rounds` method.

And I stumbled on a way to improve the performance, by using an `usize` for the number of rounds and keeping the core algorithm a seperate function. No idea why it works though.

Benchmarks before:
```
test gen_bytes_chacha   ... bench:   2,782,004 ns/iter (+/- 5,165) = 368 MB/s
test gen_u32_chacha     ... bench:      10,774 ns/iter (+/- 11) = 371 MB/s
test gen_u64_chacha     ... bench:      21,564 ns/iter (+/- 75) = 370 MB/s
```

Benchmarks after this and https://github.com/rust-lang-nursery/rand/pull/242:
```
test gen_bytes_chacha   ... bench:   1,898,515 ns/iter (+/- 6,578) = 539 MB/s
test gen_u32_chacha     ... bench:       8,357 ns/iter (+/- 24) = 478 MB/s
test gen_u64_chacha     ... bench:      16,207 ns/iter (+/- 47) = 493 MB/s
```

Finally remembered why it is a good idea to wait with generating results until the first use: it makes things like `ChaChaRng::new().set_counter(500)` possible.

cc @burdges, because I know you have an interest in ChaCha.