### PR TITLE
Add trait SampleRng: Rng and related doc

### DIFF
--- a/benches/generators.rs
+++ b/benches/generators.rs
@@ -9,7 +9,7 @@ const BYTES_LEN: usize = 1024;
 use std::mem::size_of;
 use test::{black_box, Bencher};
 
-use rand::{Rng, NewRng, StdRng, OsRng, JitterRng};
+use rand::{Rng, SampleRng, NewRng, StdRng, OsRng, JitterRng};
 use rand::{XorShiftRng, Hc128Rng, IsaacRng, Isaac64Rng, ChaChaRng};
 
 macro_rules! gen_bytes {

--- a/benches/misc.rs
+++ b/benches/misc.rs
@@ -5,7 +5,7 @@ extern crate rand;
 
 use test::{black_box, Bencher};
 
-use rand::{Rng, weak_rng};
+use rand::{SampleRng, weak_rng};
 use rand::seq::*;
 
 #[bench]

--- a/rand-derive/src/lib.rs
+++ b/rand-derive/src/lib.rs
@@ -108,7 +108,7 @@ fn impl_rand_derive(ast: &syn::MacroInput) -> quote::Tokens {
     quote! {
         impl #impl_generics ::rand::Rand for #name #ty_generics #where_clause {
             #[inline]
-            fn rand<__R: ::rand::Rng>(__rng: &mut __R) -> Self {
+            fn rand<__R: ::rand::SampleRng>(__rng: &mut __R) -> Self {
                 #rand
             }
         }

--- a/rand-derive/tests/rand_macros.rs
+++ b/rand-derive/tests/rand_macros.rs
@@ -4,7 +4,7 @@ extern crate rand;
 #[macro_use]
 extern crate rand_derive;
 
-use rand::Rng;
+use rand::SampleRng;
 
 #[derive(Rand)]
 struct Struct {

--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -10,7 +10,7 @@
 
 //! The exponential distribution.
 
-use {Rng, Rand};
+use {Rng, SampleRng, Rand};
 use distributions::{ziggurat, ziggurat_tables, Sample, IndependentSample};
 
 /// A wrapper around an `f64` to generate Exp(1) random numbers.

--- a/src/distributions/gamma.rs
+++ b/src/distributions/gamma.rs
@@ -15,7 +15,7 @@
 use self::GammaRepr::*;
 use self::ChiSquaredRepr::*;
 
-use {Rng, Open01};
+use {Rng, SampleRng, Open01};
 use super::normal::StandardNormal;
 use super::{IndependentSample, Sample, Exp};
 

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -19,7 +19,7 @@
 
 use core::marker;
 
-use {Rng, Rand};
+use {Rng, SampleRng, Rand};
 
 pub use self::range::Range;
 #[cfg(feature="std")]

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -10,7 +10,7 @@
 
 //! The normal and derived distributions.
 
-use {Rng, Rand, Open01};
+use {Rng, SampleRng, Rand, Open01};
 use distributions::{ziggurat, ziggurat_tables, Sample, IndependentSample};
 
 /// A wrapper around an `f64` to generate N(0, 1) random numbers

--- a/src/distributions/range.rs
+++ b/src/distributions/range.rs
@@ -14,7 +14,7 @@
 
 use core::num::Wrapping as w;
 
-use Rng;
+use {Rng, SampleRng};
 use distributions::{Sample, IndependentSample};
 
 /// Sample values uniformly between two bounds.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -503,7 +503,7 @@ pub trait Rng {
 /// (converting that randomness to the desired type and distribution).
 /// 
 /// [`Rng`]: trait.Rng.html
-pub trait SampleRng: Rng {
+pub trait SampleRng: Rng + Sized {
     /// Return a random value of a `Rand` type.
     ///
     /// # Example
@@ -517,7 +517,7 @@ pub trait SampleRng: Rng {
     /// println!("{:?}", rng.gen::<(f64, bool)>());
     /// ```
     #[inline(always)]
-    fn gen<T: Rand>(&mut self) -> T where Self: Sized {
+    fn gen<T: Rand>(&mut self) -> T {
         Rand::rand(self)
     }
 
@@ -535,7 +535,7 @@ pub trait SampleRng: Rng {
     /// println!("{:?}", rng.gen_iter::<(f64, bool)>().take(5)
     ///                     .collect::<Vec<(f64, bool)>>());
     /// ```
-    fn gen_iter<'a, T: Rand>(&'a mut self) -> Generator<'a, T, Self> where Self: Sized {
+    fn gen_iter<'a, T: Rand>(&'a mut self) -> Generator<'a, T, Self> {
         Generator { rng: self, _marker: marker::PhantomData }
     }
 
@@ -562,7 +562,7 @@ pub trait SampleRng: Rng {
     /// let m: f64 = rng.gen_range(-40.0f64, 1.3e5f64);
     /// println!("{}", m);
     /// ```
-    fn gen_range<T: PartialOrd + SampleRange>(&mut self, low: T, high: T) -> T where Self: Sized {
+    fn gen_range<T: PartialOrd + SampleRange>(&mut self, low: T, high: T) -> T {
         assert!(low < high, "SampleRng::gen_range called with low >= high");
         Range::new(low, high).ind_sample(self)
     }
@@ -577,7 +577,7 @@ pub trait SampleRng: Rng {
     /// let mut rng = thread_rng();
     /// println!("{}", rng.gen_weighted_bool(3));
     /// ```
-    fn gen_weighted_bool(&mut self, n: u32) -> bool where Self: Sized {
+    fn gen_weighted_bool(&mut self, n: u32) -> bool {
         n <= 1 || self.gen_range(0, n) == 0
     }
 
@@ -591,7 +591,7 @@ pub trait SampleRng: Rng {
     /// let s: String = thread_rng().gen_ascii_chars().take(10).collect();
     /// println!("{}", s);
     /// ```
-    fn gen_ascii_chars<'a>(&'a mut self) -> AsciiGenerator<'a, Self> where Self: Sized {
+    fn gen_ascii_chars<'a>(&'a mut self) -> AsciiGenerator<'a, Self> {
         AsciiGenerator { rng: self }
     }
 
@@ -609,7 +609,7 @@ pub trait SampleRng: Rng {
     /// println!("{:?}", rng.choose(&choices));
     /// assert_eq!(rng.choose(&choices[..0]), None);
     /// ```
-    fn choose<'a, T>(&mut self, values: &'a [T]) -> Option<&'a T> where Self: Sized {
+    fn choose<'a, T>(&mut self, values: &'a [T]) -> Option<&'a T> {
         if values.is_empty() {
             None
         } else {
@@ -620,7 +620,7 @@ pub trait SampleRng: Rng {
     /// Return a mutable pointer to a random element from `values`.
     ///
     /// Return `None` if `values` is empty.
-    fn choose_mut<'a, T>(&mut self, values: &'a mut [T]) -> Option<&'a mut T> where Self: Sized {
+    fn choose_mut<'a, T>(&mut self, values: &'a mut [T]) -> Option<&'a mut T> {
         if values.is_empty() {
             None
         } else {
@@ -646,7 +646,7 @@ pub trait SampleRng: Rng {
     /// rng.shuffle(&mut y);
     /// println!("{:?}", y);
     /// ```
-    fn shuffle<T>(&mut self, values: &mut [T]) where Self: Sized {
+    fn shuffle<T>(&mut self, values: &mut [T]) {
         let mut i = values.len();
         while i >= 2 {
             // invariant: elements with index >= i have been locked in place.

--- a/src/rand_impls.rs
+++ b/src/rand_impls.rs
@@ -12,7 +12,7 @@
 
 use core::{char, mem};
 
-use {Rand, Rng, SeedableRng};
+use {Rand, Rng, SampleRng, SeedableRng};
 
 impl Rand for isize {
     #[inline]
@@ -255,7 +255,7 @@ impl<T: SeedableRng> Rand for T {
 #[cfg(test)]
 mod tests {
     use impls;
-    use {Rng, Open01, Closed01};
+    use {Rng, SampleRng, Open01, Closed01};
 
     struct ConstantRng(u64);
     impl Rng for ConstantRng {

--- a/src/read.rs
+++ b/src/read.rs
@@ -25,7 +25,7 @@ use {Rng, Error, ErrorKind, impls};
 /// # Example
 ///
 /// ```rust
-/// use rand::{read, Rng};
+/// use rand::{read, SampleRng};
 ///
 /// let data = vec![1, 2, 3, 4, 5, 6, 7, 8];
 /// let mut rng = read::ReadRng::new(&data[..]);

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -10,7 +10,7 @@
 
 //! Functions for randomly accessing and sampling sequences.
 
-use super::Rng;
+use super::SampleRng;
 
 // This crate is only enabled when either std or alloc is available.
 // BTreeMap is not as fast in tests, but better than nothing.
@@ -41,7 +41,7 @@ use super::Rng;
 /// ```
 pub fn sample_iter<T, I, R>(rng: &mut R, iterable: I, amount: usize) -> Result<Vec<T>, Vec<T>>
     where I: IntoIterator<Item=T>,
-          R: Rng,
+          R: SampleRng,
 {
     let mut iter = iterable.into_iter();
     let mut reservoir = Vec::with_capacity(amount);
@@ -85,7 +85,7 @@ pub fn sample_iter<T, I, R>(rng: &mut R, iterable: I, amount: usize) -> Result<V
 /// println!("{:?}", seq::sample_slice(&mut rng, &values, 3));
 /// ```
 pub fn sample_slice<R, T>(rng: &mut R, slice: &[T], amount: usize) -> Vec<T>
-    where R: Rng,
+    where R: SampleRng,
           T: Clone
 {
     let indices = sample_indices(rng, slice.len(), amount);
@@ -113,7 +113,7 @@ pub fn sample_slice<R, T>(rng: &mut R, slice: &[T], amount: usize) -> Vec<T>
 /// println!("{:?}", seq::sample_slice_ref(&mut rng, &values, 3));
 /// ```
 pub fn sample_slice_ref<'a, R, T>(rng: &mut R, slice: &'a [T], amount: usize) -> Vec<&'a T>
-    where R: Rng
+    where R: SampleRng
 {
     let indices = sample_indices(rng, slice.len(), amount);
 
@@ -133,7 +133,7 @@ pub fn sample_slice_ref<'a, R, T>(rng: &mut R, slice: &'a [T], amount: usize) ->
 ///
 /// Panics if `amount > length`
 pub fn sample_indices<R>(rng: &mut R, length: usize, amount: usize) -> Vec<usize>
-    where R: Rng,
+    where R: SampleRng,
 {
     if amount > length {
         panic!("`amount` must be less than or equal to `slice.len()`");
@@ -166,7 +166,7 @@ pub fn sample_indices<R>(rng: &mut R, length: usize, amount: usize) -> Vec<usize
 /// This is better than using a HashMap "cache" when `amount >= length / 2` since it does not
 /// require allocating an extra cache and is much faster.
 fn sample_indices_inplace<R>(rng: &mut R, length: usize, amount: usize) -> Vec<usize>
-    where R: Rng,
+    where R: SampleRng,
 {
     debug_assert!(amount <= length);
     let mut indices: Vec<usize> = Vec::with_capacity(length);
@@ -193,7 +193,7 @@ fn sample_indices_cache<R>(
     length: usize,
     amount: usize,
 ) -> Vec<usize>
-    where R: Rng,
+    where R: SampleRng,
 {
     debug_assert!(amount <= length);
     #[cfg(feature="std")] let mut cache = HashMap::with_capacity(amount);
@@ -227,7 +227,7 @@ fn sample_indices_cache<R>(
 #[cfg(test)]
 mod test {
     use super::*;
-    use {XorShiftRng, SeedableRng};
+    use {XorShiftRng, Rng, SeedableRng};
     #[cfg(not(feature="std"))]
     use alloc::Vec;
 

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -10,7 +10,7 @@
 
 //! Functions for randomly accessing and sampling sequences.
 
-use super::SampleRng;
+use super::{Rng, SampleRng};
 
 // This crate is only enabled when either std or alloc is available.
 // BTreeMap is not as fast in tests, but better than nothing.
@@ -41,7 +41,7 @@ use super::SampleRng;
 /// ```
 pub fn sample_iter<T, I, R>(rng: &mut R, iterable: I, amount: usize) -> Result<Vec<T>, Vec<T>>
     where I: IntoIterator<Item=T>,
-          R: SampleRng,
+          R: Rng,
 {
     let mut iter = iterable.into_iter();
     let mut reservoir = Vec::with_capacity(amount);
@@ -85,7 +85,7 @@ pub fn sample_iter<T, I, R>(rng: &mut R, iterable: I, amount: usize) -> Result<V
 /// println!("{:?}", seq::sample_slice(&mut rng, &values, 3));
 /// ```
 pub fn sample_slice<R, T>(rng: &mut R, slice: &[T], amount: usize) -> Vec<T>
-    where R: SampleRng,
+    where R: Rng,
           T: Clone
 {
     let indices = sample_indices(rng, slice.len(), amount);
@@ -113,7 +113,7 @@ pub fn sample_slice<R, T>(rng: &mut R, slice: &[T], amount: usize) -> Vec<T>
 /// println!("{:?}", seq::sample_slice_ref(&mut rng, &values, 3));
 /// ```
 pub fn sample_slice_ref<'a, R, T>(rng: &mut R, slice: &'a [T], amount: usize) -> Vec<&'a T>
-    where R: SampleRng
+    where R: Rng
 {
     let indices = sample_indices(rng, slice.len(), amount);
 
@@ -133,7 +133,7 @@ pub fn sample_slice_ref<'a, R, T>(rng: &mut R, slice: &'a [T], amount: usize) ->
 ///
 /// Panics if `amount > length`
 pub fn sample_indices<R>(rng: &mut R, length: usize, amount: usize) -> Vec<usize>
-    where R: SampleRng,
+    where R: Rng,
 {
     if amount > length {
         panic!("`amount` must be less than or equal to `slice.len()`");
@@ -166,7 +166,7 @@ pub fn sample_indices<R>(rng: &mut R, length: usize, amount: usize) -> Vec<usize
 /// This is better than using a HashMap "cache" when `amount >= length / 2` since it does not
 /// require allocating an extra cache and is much faster.
 fn sample_indices_inplace<R>(rng: &mut R, length: usize, amount: usize) -> Vec<usize>
-    where R: SampleRng,
+    where R: Rng,
 {
     debug_assert!(amount <= length);
     let mut indices: Vec<usize> = Vec::with_capacity(length);
@@ -193,7 +193,7 @@ fn sample_indices_cache<R>(
     length: usize,
     amount: usize,
 ) -> Vec<usize>
-    where R: SampleRng,
+    where R: Rng,
 {
     debug_assert!(amount <= length);
     #[cfg(feature="std")] let mut cache = HashMap::with_capacity(amount);


### PR DESCRIPTION
Move high-level `Rng` functionality to an extension trait. See [documentation here](trait.SeedableRng.html).

This change is necessary to keep a similar interface for users while allowing a separate `rand-core` crate. Note that users often won't need to import `Rng` at all, as many of the examples and the `seq` module show.

Related:

- This was called `Sample`, but using `SampleRng` is consistent with other extension-traits and perhaps less confusing
- The plan was to remove `next_f32` and `next_f64` from `Rng`. That may or may not happen; it's not necessary for this change or the `rand-core` split, and those are definitely low-level methods.
- `Rand`, `Sample` and `IndepedentSample` all use `Rng`, not `SampleRng` still. That could change but would be a breaking change (since all the above may be replaced by a single `Distribution` trait, we can make the change then). I'm not certain which is best; possibly `SampleRng` since this eliminates the need to import `Rng` in many cases?

Also, @burdges said recently he was against this trait and the `rand-core` split. I don't think usage will be much different for end users (if anything, documentation is improved by separating front- and back-end functionality) and several people have requested `rand-core` so I think overall this is a win.