### PR TITLE
Fix serde tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ script:
   - cargo test
   - cargo test --tests --no-default-features
   - cargo test --features serde-1
+  - cargo test --tests --no-default-features --features=serde-1
   - cargo test --manifest-path rand-derive/Cargo.toml
 
 env:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,4 +37,5 @@ test_script:
   - cargo test --features serde-1
   - cargo test --features nightly
   - cargo test --tests --no-default-features --features=alloc
+  - cargo test --tests --no-default-features --features=serde-1
   - cargo test --manifest-path rand-derive/Cargo.toml

--- a/src/prng/isaac.rs
+++ b/src/prng/isaac.rs
@@ -466,13 +466,14 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature="serde-1")]
-    fn test_rng_serde() {
+    #[cfg(all(feature="serde-1", feature="std"))]
+    fn test_isaac_serde() {
         use bincode;
         use std::io::{BufWriter, BufReader};
 
-        let seed: &[_] = &[1, 23, 456, 7890, 12345];
-        let mut rng: IsaacRng = SeedableRng::from_seed(seed);
+        let seed = [1,0,0,0, 23,0,0,0, 200,1,0,0, 210,30,0,0,
+                     57,48,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0];
+        let mut rng = IsaacRng::from_seed(seed);
 
         let buf: Vec<u8> = Vec::new();
         let mut buf = BufWriter::new(buf);

--- a/src/prng/isaac64.rs
+++ b/src/prng/isaac64.rs
@@ -470,13 +470,14 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature="serde-1")]
-    fn test_rng_serde() {
+    #[cfg(all(feature="serde-1", feature="std"))]
+    fn test_isaac64_serde() {
         use bincode;
         use std::io::{BufWriter, BufReader};
 
-        let seed: &[_] = &[1, 23, 456, 7890, 12345];
-        let mut rng: Isaac64Rng = SeedableRng::from_seed(seed);
+        let seed = [1,0,0,0, 23,0,0,0, 200,1,0,0, 210,30,0,0,
+                     57,48,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0];
+        let mut rng = Isaac64Rng::from_seed(seed);
 
         let buf: Vec<u8> = Vec::new();
         let mut buf = BufWriter::new(buf);

--- a/src/prng/isaac_serde.rs
+++ b/src/prng/isaac_serde.rs
@@ -18,7 +18,7 @@ pub(super) mod rand_size_serde {
     use serde::de::{Visitor,SeqAccess};
     use serde::de;
 
-    use std::fmt;
+    use core::fmt;
 
     pub fn serialize<T, S>(arr: &[T;RAND_SIZE], ser: S) -> Result<S::Ok, S::Error> 
     where
@@ -42,7 +42,7 @@ pub(super) mod rand_size_serde {
         T: Deserialize<'de>+Default+Copy,
         D: Deserializer<'de>,
     {
-        use std::marker::PhantomData;
+        use core::marker::PhantomData;
         struct ArrayVisitor<T> {
             _pd: PhantomData<T>,
         };

--- a/src/prng/xorshift.rs
+++ b/src/prng/xorshift.rs
@@ -125,13 +125,74 @@ impl SeedableRng for XorShiftRng {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(all(feature="serde-1", feature="std"))]
     use {Rng, SeedableRng};
+    use super::XorShiftRng;
+
+    #[test]
+    fn test_xorshift_construction() {
+        // Test that various construction techniques produce a working RNG.
+        let seed = [1,2,3,4, 5,6,7,8, 9,10,11,12, 13,14,15,16];
+        let mut rng1 = XorShiftRng::from_seed(seed);
+        assert_eq!(rng1.next_u64(), 4325440999699518727);
+
+        let mut rng2 = XorShiftRng::from_rng(&mut rng1).unwrap();
+        assert_eq!(rng2.next_u64(), 15614385950550801700);
+    }
+
+    #[test]
+    fn test_xorshift_true_values() {
+        let seed = [16,15,14,13, 12,11,10,9, 8,7,6,5, 4,3,2,1];
+        let mut rng = XorShiftRng::from_seed(seed);
+
+        let mut results = [0u32; 9];
+        for i in results.iter_mut() { *i = rng.next_u32(); }
+        let expected: [u32; 9] = [
+            2081028795, 620940381, 269070770, 16943764, 854422573, 29242889,
+            1550291885, 1227154591, 271695242];
+        assert_eq!(results, expected);
+
+        let mut results = [0u64; 9];
+        for i in results.iter_mut() { *i = rng.next_u64(); }
+        let expected: [u64; 9] = [
+            9247529084182843387, 8321512596129439293, 14104136531997710878,
+            6848554330849612046, 343577296533772213, 17828467390962600268,
+            9847333257685787782, 7717352744383350108, 1133407547287910111];
+        assert_eq!(results, expected);
+
+        let mut results = [0u8; 32];
+        rng.fill_bytes(&mut results);
+        let expected = [102, 57, 212, 16, 233, 130, 49, 183,
+                        158, 187, 44, 203, 63, 149, 45, 17,
+                        117, 129, 131, 160, 70, 121, 158, 155,
+                        224, 209, 192, 53, 10, 62, 57, 72];
+        assert_eq!(results, expected);
+    }
+
+    #[test]
+    fn test_xorshift_zero_seed() {
+        // Xorshift does not work with an all zero seed.
+        // Assert it does not panic.
+        let seed = [0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0];
+        let mut rng = XorShiftRng::from_seed(seed);
+        let a = rng.next_u64();
+        let b = rng.next_u64();
+        assert!(a != 0);
+        assert!(b != a);
+    }
+
+    #[test]
+    fn test_xorshift_clone() {
+        let seed = [1,2,3,4, 5,5,7,8, 8,7,6,5, 4,3,2,1];
+        let mut rng1 = XorShiftRng::from_seed(seed);
+        let mut rng2 = rng1.clone();
+        for _ in 0..16 {
+            assert_eq!(rng1.next_u64(), rng2.next_u64());
+        }
+    }
 
     #[cfg(all(feature="serde-1", feature="std"))]
     #[test]
     fn test_xorshift_serde() {
-        use super::XorShiftRng;
         use bincode;
         use std::io::{BufWriter, BufReader};
 

--- a/src/prng/xorshift.rs
+++ b/src/prng/xorshift.rs
@@ -125,19 +125,18 @@ impl SeedableRng for XorShiftRng {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature="serde-1")]
+    #[cfg(all(feature="serde-1", feature="std"))]
     use {Rng, SeedableRng};
 
-    #[cfg(feature="serde-1")]
+    #[cfg(all(feature="serde-1", feature="std"))]
     #[test]
-    fn test_serde() {
+    fn test_xorshift_serde() {
         use super::XorShiftRng;
-        use thread_rng;
         use bincode;
         use std::io::{BufWriter, BufReader};
 
-        let seed: [u32; 4] = thread_rng().gen();
-        let mut rng: XorShiftRng = SeedableRng::from_seed(seed);
+        let seed = [1,2,3,4, 5,6,7,8, 9,10,11,12, 13,14,15,16];
+        let mut rng = XorShiftRng::from_seed(seed);
 
         let buf: Vec<u8> = Vec::new();
         let mut buf = BufWriter::new(buf);


### PR DESCRIPTION
They are the cause of the recent CI failures.
I also added a few Xorshift test I had laying around.

Another case to test was the combination of serde and `no_std`:
```
cargo test --tests --no-default-features --features serde-1
```