### PR TITLE
Add log feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
 script:
   - cargo test
   - cargo test --tests --no-default-features
-  - cargo test --features serde-1
+  - cargo test --features serde-1,log
   - cargo test --tests --no-default-features --features=serde-1
   - cargo test --manifest-path rand-derive/Cargo.toml
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ libc = { version = "0.2", optional = true }
 winapi = { version = "0.3", features = ["minwindef", "ntsecapi", "profileapi", "winnt"], optional = true }
 
 [dependencies]
+log = { version = "0.4", optional = true }
+
 serde = {version="1",optional=true}
 serde_derive = {version="1", optional=true}
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ changes since the `0.3` series, but nevertheless contains some significant
 new code, including a new "external" entropy source (`JitterRng`) and `no_std`
 support.
 
-Version `0.5` is in development and contains significant performance
-improvements for the ISAAC random number generators.
+Version `0.5` is in development and will contain significant breaking changes.
 
 ## Examples
 
@@ -68,21 +67,22 @@ println!("i32: {}, u32: {}", rng.gen::<i32>(), rng.gen::<u32>())
 By default, `rand` is built with all stable features available. The following
 optional features are available:
 
+-   `alloc` can be used instead of `std` to provide `Vec` and `Box`
 -   `i128_support` enables support for generating `u128` and `i128` values
+-   `log` enables some logging via the `log` crate
 -   `nightly` enables all unstable features (`i128_support`)
+-   `serde-1` enables serialisation for some types, via Serde version 1
 -   `std` enabled by default; by setting "default-features = false" `no_std`
     mode is activated; this removes features depending on `std` functionality:
-
-        -   `OsRng` is entirely unavailable
-        -   `JitterRng` code is still present, but a nanosecond timer must be
-            provided via `JitterRng::new_with_timer`
-        -   Since no external entropy is available, it is not possible to create
-            generators with fresh seeds (user must provide entropy)
-        -   `thread_rng`, `weak_rng` and `random` are all disabled
-        -   exponential, normal and gamma type distributions are unavailable
-            since `exp` and `log` functions are not provided in `core`
-        -   any code requiring `Vec` or `Box`
--   `alloc` can be used instead of `std` to provide `Vec` and `Box`
+    -   `OsRng` is entirely unavailable
+    -   `JitterRng` code is still present, but a nanosecond timer must be
+        provided via `JitterRng::new_with_timer`
+    -   Since no external entropy is available, it is not possible to create
+        generators with fresh seeds (user must provide entropy)
+    -   `thread_rng`, `weak_rng` and `random` are all disabled
+    -   exponential, normal and gamma type distributions are unavailable
+        since `exp` and `log` functions are not provided in `core`
+    -   any code requiring `Vec` or `Box`
 
 ## Testing
 

--- a/src/jitter.rs
+++ b/src/jitter.rs
@@ -142,6 +142,7 @@ impl JitterRng {
             // This allows the timer test to run multiple times; we don't care.
             rounds = ec.test_timer()?;
             JITTER_ROUNDS.store(rounds as usize, Ordering::Relaxed);
+            info!("JitterRng: using {} rounds per u64 output", rounds);
         }
         ec.set_rounds(rounds);
         Ok(ec)
@@ -422,6 +423,8 @@ impl JitterRng {
     }
 
     fn gen_entropy(&mut self) -> u64 {
+        trace!("JitterRng: collecting entropy");
+        
         // Prime `self.prev_time`, and run the noice sources to make sure the
         // first loop round collects the expected entropy.
         let _ = self.measure_jitter();
@@ -444,6 +447,7 @@ impl JitterRng {
     /// to collect 64 bits of entropy. Otherwise a `TimerError` with the cause
     /// of the failure will be returned.
     pub fn test_timer(&mut self) -> Result<u32, TimerError> {
+        debug!("JitterRng: testing timer ...");
         // We could add a check for system capabilities such as `clock_getres`
         // or check for `CONFIG_X86_TSC`, but it does not make much sense as the
         // following sanity checks verify that we have a high-resolution timer.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,6 +256,8 @@
 
 #[cfg(feature = "log")] #[macro_use] extern crate log;
 #[cfg(not(feature = "log"))] macro_rules! trace { ($($x:tt)*) => () }
+#[cfg(not(feature = "log"))] macro_rules! debug { ($($x:tt)*) => () }
+#[cfg(all(feature="std", not(feature = "log")))] macro_rules! info { ($($x:tt)*) => () }
 #[cfg(all(feature="std", not(feature = "log")))] macro_rules! warn { ($($x:tt)*) => () }
 
 

--- a/src/reseeding.rs
+++ b/src/reseeding.rs
@@ -47,7 +47,7 @@ impl<R: Rng, Rsdr: Reseeder<R>> ReseedingRng<R, Rsdr> {
     /// generated exceed the threshold.
     pub fn reseed_if_necessary(&mut self) {
         if self.bytes_generated >= self.generation_threshold {
-            trace!("Reseeding RNG");
+            trace!("Reseeding RNG after {} bytes", self.bytes_generated);
             self.reseeder.reseed(&mut self.rng).unwrap();
             self.bytes_generated = 0;
         }

--- a/src/reseeding.rs
+++ b/src/reseeding.rs
@@ -47,6 +47,7 @@ impl<R: Rng, Rsdr: Reseeder<R>> ReseedingRng<R, Rsdr> {
     /// generated exceed the threshold.
     pub fn reseed_if_necessary(&mut self) {
         if self.bytes_generated >= self.generation_threshold {
+            trace!("Reseeding RNG");
             self.reseeder.reseed(&mut self.rng).unwrap();
             self.bytes_generated = 0;
         }


### PR DESCRIPTION
Yet another optional feature (effectively 2×2×2×3 = 24 combinations, since *nightly = i128_support* and *alloc* only does anything without *std*).

The main motivation is to allow reporting of errors which are handled internally (via retry or fallback), and also to explain why `OsRng` delays (when `NotReady`).

This has the disadvantage of complicating the feature matrix and documentation, but probably on the whole is worth adding?