### PR TITLE
Add fill and try_fill methods to Rng

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -508,9 +508,9 @@ pub trait RngCore {
 /// 
 /// [`RngCore`]: trait.RngCore.html
 pub trait Rng: RngCore + Sized {
-    /// Fill `dest` entirely with random bytes, where `dest` is any type
-    /// supporting [`AsByteSliceMut`], namely slices over primitive integer
-    /// types (`i8`, `i16`, `u32`, etc.).
+    /// Fill `dest` entirely with random bytes (uniform value distribution),
+    /// where `dest` is any type supporting [`AsByteSliceMut`], namely slices
+    /// and arrays over primitive integer types (`i8`, `i16`, `u32`, etc.).
     /// 
     /// On big-endian platforms this performs byte-swapping to ensure
     /// portability of results from reproducible generators.
@@ -536,9 +536,9 @@ pub trait Rng: RngCore + Sized {
         dest.to_le();
     }
     
-    /// Fill `dest` entirely with random bytes, where `dest` is any type
-    /// supporting [`AsByteSliceMut`], namely slices over primitive integer
-    /// types (`i8`, `i16`, `u32`, etc.).
+    /// Fill `dest` entirely with random bytes (uniform value distribution),
+    /// where `dest` is any type supporting [`AsByteSliceMut`], namely slices
+    /// and arrays over primitive integer types (`i8`, `i16`, `u32`, etc.).
     /// 
     /// On big-endian platforms this performs byte-swapping to ensure
     /// portability of results from reproducible generators.
@@ -866,6 +866,24 @@ impl_as_byte_slice!(i32);
 impl_as_byte_slice!(i64);
 #[cfg(feature="i128_support")] impl_as_byte_slice!(i128);
 impl_as_byte_slice!(isize);
+
+macro_rules! impl_as_byte_slice_arrays {
+    ($n:expr,) => {};
+    ($n:expr, $N:ident, $($NN:ident,)*) => {
+        impl_as_byte_slice_arrays!($n - 1, $($NN,)*);
+        
+        impl<T> AsByteSliceMut for [T; $n] where [T]: AsByteSliceMut {
+            fn as_byte_slice_mut<'a>(&'a mut self) -> &'a mut [u8] {
+                self[..].as_byte_slice_mut()
+            }
+            
+            fn to_le(&mut self) {
+                self[..].to_le()
+            }
+        }
+    };
+}
+impl_as_byte_slice_arrays!(32, N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,);
 
 /// Iterator which will generate a stream of random items.
 ///

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -227,7 +227,7 @@ fn sample_indices_cache<R>(
 #[cfg(test)]
 mod test {
     use super::*;
-    use {XorShiftRng, RngCore, SeedableRng};
+    use {XorShiftRng, Rng, SeedableRng};
     #[cfg(not(feature="std"))]
     use alloc::Vec;
 
@@ -304,7 +304,7 @@ mod test {
         for length in 1usize..max_range {
             let amount = r.gen_range(0, length);
             let mut seed = [0u8; 16];
-            r.fill_bytes(&mut seed);
+            r.fill(&mut seed);
 
             // assert that the two index methods give exactly the same result
             let inplace = sample_indices_inplace(


### PR DESCRIPTION
This was suggested a couple of times. It's perhaps more useful with #244 since then `fill_bytes` and `try_fill_bytes` are not available in `SampleRng`.

I'm not entirely happy with the code organisation; this adds a generic-sounding trait name, but perhaps it should be renamed `AsByteSliceMut` and not have `fn to_le` to meet what would be expected from the name. From our point of view those are needless complications however.

This also adds more unsafe code but I don't think that's avoidable.