### PR TITLE
Log error details via Display instead of Debug

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -125,13 +125,13 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         #[cfg(feature="std")] {
             if let Some(ref cause) = self.cause {
-                return write!(f, "RNG error [{}]: {}; cause: {}",
-                        self.kind.description(),
+                return write!(f, "{} ({}); cause: {}",
                         self.msg(),
+                        self.kind.description(),
                         cause);
             }
         }
-        write!(f, "RNG error [{}]: {}", self.kind.description(), self.msg())
+        write!(f, "{} ({})", self.msg(), self.kind.description())
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,7 +52,7 @@ impl ErrorKind {
     /// A description of this error kind
     pub fn description(self) -> &'static str {
         match self {
-            ErrorKind::Unavailable => "permanent failure or unavailable",
+            ErrorKind::Unavailable => "permanent failure",
             ErrorKind::Transient => "transient failure",
             ErrorKind::NotReady => "not ready yet",
             ErrorKind::Other => "uncategorised",
@@ -123,6 +123,14 @@ impl Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        #[cfg(feature="std")] {
+            if let Some(ref cause) = self.cause {
+                return write!(f, "RNG error [{}]: {}; cause: {}",
+                        self.kind.description(),
+                        self.msg(),
+                        cause);
+            }
+        }
         write!(f, "RNG error [{}]: {}", self.kind.description(), self.msg())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -856,9 +856,9 @@ impl<R: SeedableRng> NewRng for R {
 
         trace!("Seeding new RNG");
         new_os().or_else(|e1| {
-            warn!("OsRng failed [falling back to JitterRng]: {:?}", e1);
+            warn!("OsRng failed [falling back to JitterRng]: {}", e1);
             new_jitter().map_err(|_e2| {
-                warn!("JitterRng failed: {:?}", _e2);
+                warn!("JitterRng failed: {}", _e2);
                 // TODO: can we somehow return both error sources?
                 Error::with_cause(
                     ErrorKind::Unavailable,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -950,8 +950,8 @@ thread_local!(
     static THREAD_RNG_KEY: Rc<RefCell<ReseedingRng<StdRng, EntropyRng>>> = {
         const THREAD_RNG_RESEED_THRESHOLD: u64 = 32_768;
         let mut entropy_source = EntropyRng::new();
-        let r = StdRng::from_rng(&mut entropy_source)
-            .expect("could not initialize thread_rng");
+        let r = StdRng::from_rng(&mut entropy_source).unwrap_or_else(|err|
+                panic!("could not initialize thread_rng: {}", err));
         let rng = ReseedingRng::new(r,
                                     THREAD_RNG_RESEED_THRESHOLD,
                                     entropy_source);
@@ -1041,7 +1041,8 @@ impl Rng for EntropyRng {
     }
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {
-        self.try_fill_bytes(dest).unwrap();
+        self.try_fill_bytes(dest).unwrap_or_else(|err|
+                panic!("all entropy sources failed; first error: {}", err))
     }
 
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
@@ -1065,6 +1066,7 @@ impl Rng for EntropyRng {
                 let os_rng_result = try_os_new(dest);
                 match os_rng_result {
                     Ok(os_rng) => {
+                        debug!("EntropyRng: using OsRng");
                         switch_rng = Some(EntropySource::Os(os_rng));
                     }
                     Err(os_rng_error) => {
@@ -1072,6 +1074,7 @@ impl Rng for EntropyRng {
                               os_rng_error);
                         match try_jitter_new(dest) {
                             Ok(jitter_rng) => {
+                                debug!("EntropyRng: using JitterRng");
                                 switch_rng = Some(EntropySource::Jitter(jitter_rng));
                             }
                             Err(_jitter_error) => {
@@ -1090,6 +1093,7 @@ impl Rng for EntropyRng {
                           os_rng_error);
                     match try_jitter_new(dest) {
                         Ok(jitter_rng) => {
+                            debug!("EntropyRng: using JitterRng");
                             switch_rng = Some(EntropySource::Jitter(jitter_rng));
                         }
                         Err(_jitter_error) => {
@@ -1102,7 +1106,7 @@ impl Rng for EntropyRng {
             }
             EntropySource::Jitter(ref mut rng) => {
                 if let Ok(os_rng) = try_os_new(dest) {
-                    info!("EntropyRng: OsRng available [switching back from JitterRng]");
+                    debug!("EntropyRng: using OsRng");
                     switch_rng = Some(EntropySource::Os(os_rng));
                 } else {
                     return rng.try_fill_bytes(dest); // use JitterRng
@@ -1194,7 +1198,7 @@ pub fn sample<T, I, R>(rng: &mut R, iterable: I, amount: usize) -> Vec<T>
 mod test {
     use impls;
     #[cfg(feature="std")]
-    use super::{random, thread_rng};
+    use super::{random, thread_rng, EntropyRng};
     use super::{Rng, SeedableRng, StdRng};
     #[cfg(feature="alloc")]
     use alloc::boxed::Box;
@@ -1239,6 +1243,13 @@ mod test {
         fn fill_bytes(&mut self, dest: &mut [u8]) {
             impls::fill_bytes_via_u64(self, dest)
         }
+    }
+    
+    #[test]
+    #[cfg(feature="std")]
+    fn test_entropy() {
+        let mut rng = EntropyRng::new();
+        rng.next_u32();
     }
 
     #[test]

--- a/src/os.rs
+++ b/src/os.rs
@@ -74,7 +74,7 @@ impl Rng for OsRng {
         loop {
             if let Err(e) = self.try_fill_bytes(dest) {
                 if log_err == 0 {
-                    warn!("OsRng failed: {:?}", e);
+                    warn!("OsRng failed: {}", e);
                 }
                 
                 if e.kind().should_retry() {

--- a/src/os.rs
+++ b/src/os.rs
@@ -78,14 +78,14 @@ impl Rng for OsRng {
         loop {
             if let Err(e) = self.try_fill_bytes(dest) {
                 if err_count >= RETRY_LIMIT {
-                    error!("OsRng failed too many times; last error: {:?}", e);
-                    panic!("OsRng failed too many times; last error: {:?}", e);
+                    error!("OsRng failed too many times; last error: {}", e);
+                    panic!("OsRng failed too many times; last error: {}", e);
                 }
 
                 match e.kind() {
                     ErrorKind::Transient => {
                         if !error_logged {
-                            warn!("OsRng failed; retrying up to {} times. Error: {:?}",
+                            warn!("OsRng failed; retrying up to {} times. Error: {}",
                                     TRANSIENT_RETRIES, e);
                             error_logged = true;
                         }
@@ -95,7 +95,7 @@ impl Rng for OsRng {
                     }
                     ErrorKind::NotReady => {
                         if !error_logged {
-                            warn!("OsRng failed; waiting up to {}s and retrying. Error: {:?}",
+                            warn!("OsRng failed; waiting up to {}s and retrying. Error: {}",
                                     MAX_RETRY_PERIOD, e);
                             error_logged = true;
                         }
@@ -104,8 +104,8 @@ impl Rng for OsRng {
                         continue;
                     }
                     _ => {
-                        error!("OsRng failed: {:?}", e);
-                        panic!("OsRng fatal error: {:?}", e);
+                        error!("OsRng failed: {}", e);
+                        panic!("OsRng fatal error: {}", e);
                     }
                 }
             }

--- a/src/reseeding.rs
+++ b/src/reseeding.rs
@@ -46,7 +46,8 @@ impl<R: Rng+SeedableRng, Rsdr: Rng> ReseedingRng<R, Rsdr> {
     pub fn reseed_if_necessary(&mut self) {
         if self.bytes_generated >= self.generation_threshold {
             trace!("Reseeding RNG after {} bytes", self.bytes_generated);
-            R::from_rng(&mut self.reseeder).map(|result| self.rng = result).unwrap();
+            R::from_rng(&mut self.reseeder).map(|result| self.rng = result)
+                    .unwrap_or_else(|err| panic!("reseeding failed: {}", err));
             self.bytes_generated = 0;
         }
     }


### PR DESCRIPTION
Compare current `Debug` output:
```
 WARN 2018-01-31T18:21:22Z: rand: OsRng failed [falling back to JitterRng]: Error { kind: Unavailable, msg: "missing", cause: None }
 WARN 2018-01-31T18:21:22Z: rand: JitterRng failed: Error { kind: Unavailable, msg: "timer jitter failed basic quality tests", cause: Some(NoTimer) }
thread 'main' panicked at 'could not initialize thread_rng: Error { kind: Unavailable, msg: "seeding a new RNG failed: both OS and Jitter entropy sources failed", cause: Some(Error { kind: Unavailable, msg: "missing", cause: None }) }', /home/dhardy/rust/rand/src/lib.rs:975:22
```
verses prettier `Display` output:
```
 WARN 2018-01-31T18:21:39Z: rand: OsRng failed [falling back to JitterRng]: RNG error [permanent failure]: missing
 WARN 2018-01-31T18:21:39Z: rand: JitterRng failed: RNG error [permanent failure]: timer jitter failed basic quality tests; cause: no timer available
thread 'main' panicked at 'could not initialize thread_rng: Error { kind: Unavailable, msg: "seeding a new RNG failed: both OS and Jitter entropy sources failed", cause: Some(Error { kind: Unavailable, msg: "missing", cause: None }) }', /home/dhardy/rust/rand/src/lib.rs:975:22
```
I checked implementations of `Display` for error types in the main Rust repo and all of them covered all their state I think; but none had a situation like this with optional cause. So this `Display` implementation seems reasonable to me.

(Note that the condition is a bit funky due to `no_std` not having a cause at all.)