### PR TITLE
Deprecate rand_derive sub-crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ matrix:
       script:
         - cargo test
         - cargo build --no-default-features # we cannot exclude doc tests
-        - cargo test --manifest-path rand-derive/Cargo.toml
     - rust: stable
     - rust: stable
       os: osx
@@ -30,7 +29,6 @@ script:
   - cargo test --tests --no-default-features
   - cargo test --features serde-1,log
   - cargo test --tests --no-default-features --features=serde-1
-  - cargo test --manifest-path rand-derive/Cargo.toml
 
 env:
   global:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,6 @@ serde_derive = {version="1", optional=true}
 # see: https://github.com/rust-lang/cargo/issues/1596
 bincode = "0.9"
 
-[workspace]
-members = ["rand-derive"]
-
 [target.'cfg(target_os = "cloudabi")'.dependencies]
 cloudabi = "0.0.3"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,4 +38,3 @@ test_script:
   - cargo test --features nightly
   - cargo test --tests --no-default-features --features=alloc
   - cargo test --tests --no-default-features --features=serde-1
-  - cargo test --manifest-path rand-derive/Cargo.toml


### PR DESCRIPTION
See https://github.com/dhardy/rand/issues/83
Required for following changes affecting Rand