### PR TITLE
StepRng

### DIFF
--- a/src/distributions/float.rs
+++ b/src/distributions/float.rs
@@ -98,73 +98,58 @@ float_impls! { f32_rand_impls, f32, 23, next_f32 }
 
 #[cfg(test)]
 mod tests {
-    use {Rng, RngCore, impls};
+    use Rng;
+    use mock::StepRng;
     use distributions::{Open01, Closed01};
 
     const EPSILON32: f32 = ::core::f32::EPSILON;
     const EPSILON64: f64 = ::core::f64::EPSILON;
 
-    struct ConstantRng(u64);
-    impl RngCore for ConstantRng {
-        fn next_u32(&mut self) -> u32 {
-            let ConstantRng(v) = *self;
-            v as u32
-        }
-        fn next_u64(&mut self) -> u64 {
-            let ConstantRng(v) = *self;
-            v
-        }
-        
-        fn fill_bytes(&mut self, dest: &mut [u8]) {
-            impls::fill_bytes_via_u64(self, dest)
-        }
-    }
-
     #[test]
     fn floating_point_edge_cases() {
-        let mut zeros = ConstantRng(0);
+        let mut zeros = StepRng::new(0, 0);
         assert_eq!(zeros.gen::<f32>(), 0.0);
         assert_eq!(zeros.gen::<f64>(), 0.0);
         
-        let mut one = ConstantRng(1);
+        let mut one = StepRng::new(1, 0);
         assert_eq!(one.gen::<f32>(), EPSILON32);
         assert_eq!(one.gen::<f64>(), EPSILON64);
         
-        let mut max = ConstantRng(!0);
+        let mut max = StepRng::new(!0, 0);
         assert_eq!(max.gen::<f32>(), 1.0 - EPSILON32);
         assert_eq!(max.gen::<f64>(), 1.0 - EPSILON64);
     }
 
     #[test]
     fn fp_closed_edge_cases() {
-        let mut zeros = ConstantRng(0);
+        let mut zeros = StepRng::new(0, 0);
         assert_eq!(zeros.sample::<f32, _>(Closed01), 0.0);
         assert_eq!(zeros.sample::<f64, _>(Closed01), 0.0);
         
-        let mut one = ConstantRng(1);
+        let mut one = StepRng::new(1, 0);
         let one32 = one.sample::<f32, _>(Closed01);
         let one64 = one.sample::<f64, _>(Closed01);
         assert!(EPSILON32 < one32 && one32 < EPSILON32 * 1.01);
         assert!(EPSILON64 < one64 && one64 < EPSILON64 * 1.01);
         
-        let mut max = ConstantRng(!0);
+        let mut max = StepRng::new(!0, 0);
         assert_eq!(max.sample::<f32, _>(Closed01), 1.0);
         assert_eq!(max.sample::<f64, _>(Closed01), 1.0);
     }
 
     #[test]
     fn fp_open_edge_cases() {
-        let mut zeros = ConstantRng(0);
+        let mut zeros = StepRng::new(0, 0);
         assert_eq!(zeros.sample::<f32, _>(Open01), 0.0 + EPSILON32 / 2.0);
         assert_eq!(zeros.sample::<f64, _>(Open01), 0.0 + EPSILON64 / 2.0);
         
-        let mut one = ConstantRng(1);
+        let mut one = StepRng::new(1, 0);
         let one32 = one.sample::<f32, _>(Open01);
         let one64 = one.sample::<f64, _>(Open01);
         assert!(EPSILON32 < one32 && one32 < EPSILON32 * 2.0);
         assert!(EPSILON64 < one64 && one64 < EPSILON64 * 2.0);
         
-        let mut max = ConstantRng(!0);
+        let mut max = StepRng::new(!0, 0);
         assert_eq!(max.sample::<f32, _>(Open01), 1.0 - EPSILON32 / 2.0);
         assert_eq!(max.sample::<f64, _>(Open01), 1.0 - EPSILON64 / 2.0);
     }

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -386,25 +386,9 @@ fn ziggurat<R: Rng + ?Sized, P, Z>(
 
 #[cfg(test)]
 mod tests {
-    use {Rng, RngCore};
-    use impls;
+    use Rng;
+    use mock::StepRng;
     use super::{WeightedChoice, Weighted, Distribution};
-
-    // 0, 1, 2, 3, ...
-    struct CountingRng { i: u32 }
-    impl RngCore for CountingRng {
-        fn next_u32(&mut self) -> u32 {
-            self.i += 1;
-            self.i - 1
-        }
-        fn next_u64(&mut self) -> u64 {
-            self.next_u32() as u64
-        }
-
-        fn fill_bytes(&mut self, dest: &mut [u8]) {
-            impls::fill_bytes_via_u32(self, dest)
-        }
-    }
 
     #[test]
     fn test_weighted_choice() {
@@ -419,7 +403,7 @@ mod tests {
                 let wc = WeightedChoice::new(&mut items);
                 let expected = $expected;
 
-                let mut rng = CountingRng { i: 0 };
+                let mut rng = StepRng::new(0, 1);
 
                 for &val in expected.iter() {
                     assert_eq!(wc.sample(&mut rng), val)

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,0 +1,61 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// https://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Mock random number generator
+
+use {RngCore, Error, impls};
+
+/// A simple implementation of `RngCore` for testing purposes.
+/// 
+/// This generates an arithmetic sequence (i.e. adds a constant each step)
+/// over a `u64` number, using wrapping arithmetic. If the increment is 0
+/// the generator yields a constant.
+/// 
+/// ```rust
+/// use rand::Rng;
+/// use rand::mock::StepRng;
+/// 
+/// let mut my_rng = StepRng::new(2, 1);
+/// let sample: [u64; 3] = my_rng.gen();
+/// assert_eq!(sample, [2, 3, 4]);
+/// ```
+#[derive(Debug, Clone)]
+pub struct StepRng {
+    v: u64,
+    a: u64,
+}
+
+impl StepRng {
+    /// Create a `StepRng`, yielding an arithmetic sequence starting with
+    /// `initial` and incremented by `increment` each time.
+    pub fn new(initial: u64, increment: u64) -> Self {
+        StepRng { v: initial, a: increment }
+    }
+}
+
+impl RngCore for StepRng {
+    fn next_u32(&mut self) -> u32 {
+        self.next_u64() as u32
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let result = self.v;
+        self.v = self.v.wrapping_add(self.a);
+        result
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        impls::fill_bytes_via_u64(self, dest);
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+        Ok(self.fill_bytes(dest))
+    }
+}


### PR DESCRIPTION
Port MockAddRng from my branch, but without SeedingRng impl and slightly different tests

I'm not quite sure on the name or whether it should be seedable, but amazingly this saves 5 independent implementations of `RngCore` in tests.