### PR TITLE
Remove unnecessary mut

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -812,7 +812,7 @@ macro_rules! impl_as_byte_slice {
             }
             
             fn to_le(&mut self) {
-                for mut x in self {
+                for x in self {
                     *x = x.to_le();
                 }
             }


### PR DESCRIPTION
This gives a warning on rust 1.22.0. Somehow not on later versions, but I have encountered other cases before where rust's detection of unused `mut`'s regressed.