### PR TITLE
Make NewRng::new() return Self without Result wrapper

### DIFF
--- a/benches/distributions.rs
+++ b/benches/distributions.rs
@@ -16,7 +16,7 @@ macro_rules! distr {
     ($fnn:ident, $ty:ty, $distr:expr) => {
         #[bench]
         fn $fnn(b: &mut Bencher) {
-            let mut rng = XorShiftRng::new().unwrap();
+            let mut rng = XorShiftRng::new();
             let distr = $distr;
 
             b.iter(|| {
@@ -69,7 +69,7 @@ macro_rules! gen_range_int {
     ($fnn:ident, $ty:ty, $low:expr, $high:expr) => {
         #[bench]
         fn $fnn(b: &mut Bencher) {
-            let mut rng = XorShiftRng::new().unwrap();
+            let mut rng = XorShiftRng::new();
             let high = $high;
 
             b.iter(|| {

--- a/benches/generators.rs
+++ b/benches/generators.rs
@@ -14,10 +14,10 @@ use rand::{XorShiftRng, Hc128Rng, IsaacRng, Isaac64Rng, ChaChaRng};
 use rand::reseeding::ReseedingRng;
 
 macro_rules! gen_bytes {
-    ($fnn:ident, $gen:ident) => {
+    ($fnn:ident, $gen:expr) => {
         #[bench]
         fn $fnn(b: &mut Bencher) {
-            let mut rng = $gen::new().unwrap();
+            let mut rng = $gen;
             let mut buf = [0u8; BYTES_LEN];
             b.iter(|| {
                 for _ in 0..RAND_BENCH_N {
@@ -30,18 +30,18 @@ macro_rules! gen_bytes {
     }
 }
 
-gen_bytes!(gen_bytes_xorshift, XorShiftRng);
-gen_bytes!(gen_bytes_hc128, Hc128Rng);
-gen_bytes!(gen_bytes_isaac, IsaacRng);
-gen_bytes!(gen_bytes_isaac64, Isaac64Rng);
-gen_bytes!(gen_bytes_std, StdRng);
-gen_bytes!(gen_bytes_os, OsRng);
+gen_bytes!(gen_bytes_xorshift, XorShiftRng::new());
+gen_bytes!(gen_bytes_hc128, Hc128Rng::new());
+gen_bytes!(gen_bytes_isaac, IsaacRng::new());
+gen_bytes!(gen_bytes_isaac64, Isaac64Rng::new());
+gen_bytes!(gen_bytes_std, StdRng::new());
+gen_bytes!(gen_bytes_os, OsRng::new().unwrap());
 
 macro_rules! gen_uint {
-    ($fnn:ident, $ty:ty, $gen:ident) => {
+    ($fnn:ident, $ty:ty, $gen:expr) => {
         #[bench]
         fn $fnn(b: &mut Bencher) {
-            let mut rng = $gen::new().unwrap();
+            let mut rng = $gen;
             b.iter(|| {
                 for _ in 0..RAND_BENCH_N {
                     black_box(rng.gen::<$ty>());
@@ -52,19 +52,19 @@ macro_rules! gen_uint {
     }
 }
 
-gen_uint!(gen_u32_xorshift, u32, XorShiftRng);
-gen_uint!(gen_u32_hc128, u32, Hc128Rng);
-gen_uint!(gen_u32_isaac, u32, IsaacRng);
-gen_uint!(gen_u32_isaac64, u32, Isaac64Rng);
-gen_uint!(gen_u32_std, u32, StdRng);
-gen_uint!(gen_u32_os, u32, OsRng);
+gen_uint!(gen_u32_xorshift, u32, XorShiftRng::new());
+gen_uint!(gen_u32_hc128, u32, Hc128Rng::new());
+gen_uint!(gen_u32_isaac, u32, IsaacRng::new());
+gen_uint!(gen_u32_isaac64, u32, Isaac64Rng::new());
+gen_uint!(gen_u32_std, u32, StdRng::new());
+gen_uint!(gen_u32_os, u32, OsRng::new().unwrap());
 
-gen_uint!(gen_u64_xorshift, u64, XorShiftRng);
-gen_uint!(gen_u64_hc128, u64, Hc128Rng);
-gen_uint!(gen_u64_isaac, u64, IsaacRng);
-gen_uint!(gen_u64_isaac64, u64, Isaac64Rng);
-gen_uint!(gen_u64_std, u64, StdRng);
-gen_uint!(gen_u64_os, u64, OsRng);
+gen_uint!(gen_u64_xorshift, u64, XorShiftRng::new());
+gen_uint!(gen_u64_hc128, u64, Hc128Rng::new());
+gen_uint!(gen_u64_isaac, u64, IsaacRng::new());
+gen_uint!(gen_u64_isaac64, u64, Isaac64Rng::new());
+gen_uint!(gen_u64_std, u64, StdRng::new());
+gen_uint!(gen_u64_os, u64, OsRng::new().unwrap());
 
 // Do not test JitterRng like the others by running it RAND_BENCH_N times per,
 // measurement, because it is way too slow. Only run it once.
@@ -81,7 +81,7 @@ macro_rules! init_gen {
     ($fnn:ident, $gen:ident) => {
         #[bench]
         fn $fnn(b: &mut Bencher) {
-            let mut rng = XorShiftRng::new().unwrap();
+            let mut rng = XorShiftRng::new();
             b.iter(|| {
                 let r2 = $gen::from_rng(&mut rng).unwrap();
                 black_box(r2);
@@ -107,7 +107,7 @@ macro_rules! chacha_rounds {
     ($fn1:ident, $fn2:ident, $fn3:ident, $rounds:expr) => {
         #[bench]
         fn $fn1(b: &mut Bencher) {
-            let mut rng = ChaChaRng::new().unwrap();
+            let mut rng = ChaChaRng::new();
             rng.set_rounds($rounds);
             let mut buf = [0u8; BYTES_LEN];
             b.iter(|| {
@@ -121,7 +121,7 @@ macro_rules! chacha_rounds {
 
         #[bench]
         fn $fn2(b: &mut Bencher) {
-            let mut rng = ChaChaRng::new().unwrap();
+            let mut rng = ChaChaRng::new();
             rng.set_rounds($rounds);
             b.iter(|| {
                 for _ in 0..RAND_BENCH_N {
@@ -133,7 +133,7 @@ macro_rules! chacha_rounds {
 
         #[bench]
         fn $fn3(b: &mut Bencher) {
-            let mut rng = ChaChaRng::new().unwrap();
+            let mut rng = ChaChaRng::new();
             rng.set_rounds($rounds);
             b.iter(|| {
                 for _ in 0..RAND_BENCH_N {
@@ -152,7 +152,7 @@ chacha_rounds!(gen_bytes_chacha20, gen_u32_chacha20, gen_u64_chacha20, 20);
 
 #[bench]
 fn reseeding_hc128_bytes(b: &mut Bencher) {
-    let mut rng = ReseedingRng::new(Hc128Rng::new().unwrap(),
+    let mut rng = ReseedingRng::new(Hc128Rng::new(),
                                     128*1024*1024,
                                     EntropyRng::new());
     let mut buf = [0u8; BYTES_LEN];
@@ -169,7 +169,7 @@ macro_rules! reseeding_uint {
     ($fnn:ident, $ty:ty) => {
         #[bench]
         fn $fnn(b: &mut Bencher) {
-            let mut rng = ReseedingRng::new(Hc128Rng::new().unwrap(),
+            let mut rng = ReseedingRng::new(Hc128Rng::new(),
                                             128*1024*1024,
                                             EntropyRng::new());
             b.iter(|| {

--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -33,7 +33,7 @@ use distributions::{ziggurat, ziggurat_tables, Distribution};
 /// use rand::{NewRng, SmallRng, Rng};
 /// use rand::distributions::Exp1;
 ///
-/// let val: f64 = SmallRng::new().unwrap().sample(Exp1);
+/// let val: f64 = SmallRng::new().sample(Exp1);
 /// println!("{}", val);
 /// ```
 #[derive(Clone, Copy, Debug)]

--- a/src/distributions/float.rs
+++ b/src/distributions/float.rs
@@ -52,7 +52,7 @@ macro_rules! float_impls {
             /// use rand::{NewRng, SmallRng, Rng};
             /// use rand::distributions::Uniform;
             ///
-            /// let val: f32 = SmallRng::new().unwrap().sample(Uniform);
+            /// let val: f32 = SmallRng::new().sample(Uniform);
             /// println!("f32 from (0,1): {}", val);
             /// ```
             fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $ty {

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -166,7 +166,7 @@ impl<'a, T, D: Distribution<T>> Distribution<T> for &'a D {
 /// use rand::{NewRng, SmallRng, Rng};
 /// use rand::distributions::Uniform;
 ///
-/// let val: f32 = SmallRng::new().unwrap().sample(Uniform);
+/// let val: f32 = SmallRng::new().sample(Uniform);
 /// println!("f32 from [0,1): {}", val);
 /// ```
 ///

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -31,7 +31,7 @@ use distributions::{ziggurat, ziggurat_tables, Distribution, Uniform};
 /// use rand::{NewRng, SmallRng, Rng};
 /// use rand::distributions::StandardNormal;
 ///
-/// let val: f64 = SmallRng::new().unwrap().sample(StandardNormal);
+/// let val: f64 = SmallRng::new().sample(StandardNormal);
 /// println!("{}", val);
 /// ```
 #[derive(Clone, Copy, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -756,7 +756,7 @@ impl<R: RngCore> Iterator for AsciiGenerator<R> {
 /// ```
 /// use rand::{StdRng, Rng, NewRng};
 ///
-/// let mut rng = StdRng::new().unwrap();
+/// let mut rng = StdRng::new();
 /// println!("Random die roll: {}", rng.gen_range(1, 7));
 /// ```
 ///
@@ -769,13 +769,17 @@ pub trait NewRng: SeedableRng {
     /// Normally this will use `OsRng`, but if that fails `JitterRng` will be
     /// used instead. Both should be suitable for cryptography. It is possible
     /// that both entropy sources will fail though unlikely.
-    fn new() -> Result<Self, Error>;
+    /// 
+    /// Panics on error. If error handling is desired, use
+    /// `RNG::from_rng(&mut EntropyRng::new())` instead.
+    fn new() -> Self;
 }
 
 #[cfg(feature="std")]
 impl<R: SeedableRng> NewRng for R {
-    fn new() -> Result<Self, Error> {
-        R::from_rng(&mut EntropyRng::new())
+    fn new() -> R {
+        R::from_rng(&mut EntropyRng::new()).unwrap_or_else(|err|
+            panic!("NewRng::new() failed: {}", err))
     }
 }
 
@@ -847,7 +851,7 @@ impl SeedableRng for StdRng {
 ///
 /// // Create small, cheap to initialize and fast RNG with a random seed.
 /// // The randomness is supplied by the operating system.
-/// let mut small_rng = SmallRng::new().unwrap();
+/// let mut small_rng = SmallRng::new();
 /// ```
 ///
 /// When initializing a lot of `SmallRng`, using `thread_rng` can be more


### PR DESCRIPTION
Advantage: more convenient way to call an fn which almost never fails.