### PR TITLE
Deprecate `new_unseeded` functions

### DIFF
--- a/src/prng/chacha.rs
+++ b/src/prng/chacha.rs
@@ -121,6 +121,7 @@ impl ChaChaRng {
     ///
     /// - 2917185654
     /// - 2419978656
+    #[deprecated(since="0.5.0", note="use the NewRng or SeedableRng trait")]
     pub fn new_unseeded() -> ChaChaRng {
         ChaChaRng::from_seed([0; SEED_WORDS*4])
     }

--- a/src/prng/isaac.rs
+++ b/src/prng/isaac.rs
@@ -121,6 +121,9 @@ impl fmt::Debug for IsaacRng {
 impl IsaacRng {
     /// Create an ISAAC random number generator using the default
     /// fixed seed.
+    ///
+    /// DEPRECATED. `IsaacRng::new_from_u64(0)` will produce identical results.
+    #[deprecated(since="0.5.0", note="use the NewRng or SeedableRng trait")]
     pub fn new_unseeded() -> IsaacRng {
         Self::new_from_u64(0)
     }

--- a/src/prng/isaac64.rs
+++ b/src/prng/isaac64.rs
@@ -107,6 +107,9 @@ impl fmt::Debug for Isaac64Rng {
 impl Isaac64Rng {
     /// Create a 64-bit ISAAC random number generator using the
     /// default fixed seed.
+    ///
+    /// DEPRECATED. `Isaac64Rng::new_from_u64(0)` will produce identical results.
+    #[deprecated(since="0.5.0", note="use the NewRng or SeedableRng trait")]
     pub fn new_unseeded() -> Isaac64Rng {
         Self::new_from_u64(0)
     }

--- a/src/prng/xorshift.rs
+++ b/src/prng/xorshift.rs
@@ -47,6 +47,7 @@ impl XorShiftRng {
     /// by this function will yield the same stream of random numbers. It is
     /// highly recommended that this is created through `SeedableRng` instead of
     /// this function
+    #[deprecated(since="0.5.0", note="use the NewRng or SeedableRng trait")]
     pub fn new_unseeded() -> XorShiftRng {
         XorShiftRng {
             x: w(0x193a6754),


### PR DESCRIPTION
Not a good idea to use these.