### PR TITLE
Changes to rand_core readme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = """
 Random number generators and other randomness functionality.
 """
 keywords = ["random", "rng"]
-categories = ["algorithms"]
+categories = ["algorithms", "no_std"]
 
 [badges]
 travis-ci = { repository = "rust-lang-nursery/rand" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ Random number generators and other randomness functionality.
 keywords = ["random", "rng"]
 categories = ["algorithms"]
 
+[badges]
+travis-ci = { repository = "rust-lang-nursery/rand" }
+appveyor = { repository = "alexcrichton/rand" }
+
 [features]
 default = ["std"]
 nightly = ["i128_support"] # enables all features requiring nightly rust

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
-Rand
-====
+# Rand
+
+[![Build Status](https://travis-ci.org/rust-lang-nursery/rand.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/rand)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/rust-lang-nursery/rand?svg=true)](https://ci.appveyor.com/project/alexcrichton/rand)
+[![crates.io](https://img.shields.io/crates/v/rand.svg)](https://crates.io/crates/rand)
+[![docs.rs](https://docs.rs/rand/badge.svg)](https://docs.rs/rand)
 
 A Rust library for random number generators and other randomness functionality.
 
 See also:
 
 *   [rand_core](https://crates.io/crates/rand_core)
-
-[![Build Status](https://travis-ci.org/rust-lang-nursery/rand.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/rand)
-[![Build status](https://ci.appveyor.com/api/projects/status/rm5c9o33k3jhchbw?svg=true)](https://ci.appveyor.com/project/alexcrichton/rand)
 
 Documentation:
 [master branch](https://rust-lang-nursery.github.io/rand/rand/index.html),

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -13,6 +13,10 @@ Core random number generator traits and tools for implementation.
 keywords = ["random", "rng"]
 categories = ["algorithms"]
 
+[badges]
+travis-ci = { repository = "rust-lang-nursery/rand" }
+appveyor = { repository = "alexcrichton/rand" }
+
 [features]
 # Bug: https://github.com/rust-lang/cargo/issues/4361
 # default = ["std"]

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -11,7 +11,7 @@ description = """
 Core random number generator traits and tools for implementation.
 """
 keywords = ["random", "rng"]
-categories = ["algorithms"]
+categories = ["algorithms", "no_std"]
 
 [badges]
 travis-ci = { repository = "rust-lang-nursery/rand" }

--- a/rand_core/README.md
+++ b/rand_core/README.md
@@ -1,5 +1,9 @@
-rand_core
-====
+# rand_core
+
+[![Build Status](https://travis-ci.org/rust-lang-nursery/rand.svg)](https://travis-ci.org/rust-lang-nursery/rand)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/rust-lang-nursery/rand?svg=true)](https://ci.appveyor.com/project/alexcrichton/rand)
+[![crates.io](https://img.shields.io/crates/v/rand_core.svg)](https://crates.io/crates/rand_core)
+[![docs.rs](https://docs.rs/rand_core/badge.svg)](https://docs.rs/rand_core)
 
 Core traits and error types of the [rand] library, plus tools for implementing
 RNGs.
@@ -14,7 +18,11 @@ applications (including sampling from restricted ranges, conversion to floating
 point, list permutations and secure initialisation of RNGs). Most users should
 prefer to use the main [rand] crate.
 
-[Documentation](https://docs.rs/rand_core)
+Documentation:
+[master branch](https://rust-lang-nursery.github.io/rand/rand_core/index.html),
+[by release](https://docs.rs/rand_core)
+
+[Changelog](CHANGELOG.md)
 
 [rand]: https://crates.io/crates/rand
 
@@ -36,14 +44,15 @@ The traits and error types are also available via `rand`.
 comprising `RngCore` support for `Box<R>` types where `R: RngCore`, as well as
 extensions to the `Error` type's functionality.
 
-Due to a bug in Cargo, `rand_core` is built without `std` support by default.
-Since features are unioned across the whole dependency tree, any crate using
-`rand` with its default features will also enable `std` support in `rand_core`.
+Due to [rust-lang/cargo#1596](https://github.com/rust-lang/cargo/issues/1596),
+`rand_core` is built without `std` support by default. Since features are
+unioned across the whole dependency tree, any crate using `rand` with its
+default features will also enable `std` support in `rand_core`.
 
 
 # License
 
-`rand` is primarily distributed under the terms of both the MIT
-license and the Apache License (Version 2.0).
+`rand_core` is distributed under the terms of both the MIT license and the
+Apache License (Version 2.0).
 
-See LICENSE-APACHE, and LICENSE-MIT for details.
+See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.


### PR DESCRIPTION
I looked up the pre-release of rand_core on [crates.io](https://crates.io/crates/rand_core/0.1.0-pre.0), and found some things that could improve in the readme.

Added badges, link to changelog, removed 'primarily' from licence text, added license links, and fixed broken link to Rand.

Example rendering: https://github.com/pitdicker/rand/blob/rand_core_readme/rand_core/README.md