### PR TITLE
Extra tests

### DIFF
--- a/src/distributions/binomial.rs
+++ b/src/distributions/binomial.rs
@@ -129,17 +129,32 @@ mod test {
     use distributions::Distribution;
     use super::Binomial;
 
+    fn test_binomial_mean_and_variance(n: u64, p: f64) {
+        let binomial = Binomial::new(n, p);
+        let mut rng = ::test::rng(123);
+
+        let expected_mean = n as f64 * p;
+        let expected_variance = n as f64 * p * (1.0 - p);
+
+        let mut results = [0.0; 1000];
+        for i in results.iter_mut() { *i = binomial.sample(&mut rng) as f64; }
+
+        let mean = results.iter().sum::<f64>() / results.len() as f64;
+        assert!((mean as f64 - expected_mean).abs() < expected_mean / 50.0);
+
+        let variance =
+            results.iter().map(|x| (x - mean) * (x - mean)).sum::<f64>()
+            / (results.len() - 1) as f64;
+        assert!((variance - expected_variance).abs() < expected_variance / 10.0);
+    }
+
     #[test]
     fn test_binomial() {
-        let binomial = Binomial::new(150, 0.1);
-        let mut rng = ::test::rng(123);
-        let mut sum = 0;
-        for _ in 0..1000 {
-            sum += binomial.sample(&mut rng);
-        }
-        let avg = (sum as f64) / 1000.0;
-        println!("Binomial average: {}", avg);
-        assert!((avg - 15.0).abs() < 0.5); // not 100% certain, but probable enough
+        test_binomial_mean_and_variance(150, 0.1);
+        test_binomial_mean_and_variance(70, 0.6);
+        test_binomial_mean_and_variance(40, 0.5);
+        test_binomial_mean_and_variance(20, 0.7);
+        test_binomial_mean_and_variance(20, 0.5);
     }
 
     #[test]

--- a/src/distributions/binomial.rs
+++ b/src/distributions/binomial.rs
@@ -126,35 +126,36 @@ impl Distribution<u64> for Binomial {
 
 #[cfg(test)]
 mod test {
+    use Rng;
     use distributions::Distribution;
     use super::Binomial;
 
-    fn test_binomial_mean_and_variance(n: u64, p: f64) {
+    fn test_binomial_mean_and_variance<R: Rng>(n: u64, p: f64, rng: &mut R) {
         let binomial = Binomial::new(n, p);
-        let mut rng = ::test::rng(123);
 
         let expected_mean = n as f64 * p;
         let expected_variance = n as f64 * p * (1.0 - p);
 
         let mut results = [0.0; 1000];
-        for i in results.iter_mut() { *i = binomial.sample(&mut rng) as f64; }
+        for i in results.iter_mut() { *i = binomial.sample(rng) as f64; }
 
         let mean = results.iter().sum::<f64>() / results.len() as f64;
         assert!((mean as f64 - expected_mean).abs() < expected_mean / 50.0);
 
         let variance =
             results.iter().map(|x| (x - mean) * (x - mean)).sum::<f64>()
-            / (results.len() - 1) as f64;
+            / results.len() as f64;
         assert!((variance - expected_variance).abs() < expected_variance / 10.0);
     }
 
     #[test]
     fn test_binomial() {
-        test_binomial_mean_and_variance(150, 0.1);
-        test_binomial_mean_and_variance(70, 0.6);
-        test_binomial_mean_and_variance(40, 0.5);
-        test_binomial_mean_and_variance(20, 0.7);
-        test_binomial_mean_and_variance(20, 0.5);
+        let mut rng = ::test::rng(123);
+        test_binomial_mean_and_variance(150, 0.1, &mut rng);
+        test_binomial_mean_and_variance(70, 0.6, &mut rng);
+        test_binomial_mean_and_variance(40, 0.5, &mut rng);
+        test_binomial_mean_and_variance(20, 0.7, &mut rng);
+        test_binomial_mean_and_variance(20, 0.5, &mut rng);
     }
 
     #[test]

--- a/src/distributions/integer.rs
+++ b/src/distributions/integer.rs
@@ -10,19 +10,13 @@
 
 //! The implementations of the `Uniform` distribution for integer types.
 
-use core::mem;
-
 use {Rng};
 use distributions::{Distribution, Uniform};
 
 impl Distribution<isize> for Uniform {
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> isize {
-        if mem::size_of::<isize>() == 4 {
-            rng.gen::<i32>() as isize
-        } else {
-            rng.gen::<i64>() as isize
-        }
+        rng.gen::<usize>() as isize
     }
 }
 
@@ -64,12 +58,15 @@ impl Distribution<i128> for Uniform {
 
 impl Distribution<usize> for Uniform {
     #[inline]
+    #[cfg(any(target_pointer_width = "32", target_pointer_width = "16"))]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> usize {
-        if mem::size_of::<usize>() == 4 {
-            rng.gen::<u32>() as usize
-        } else {
-            rng.gen::<u64>() as usize
-        }
+        rng.next_u32() as usize
+    }
+
+    #[inline]
+    #[cfg(target_pointer_width = "64")]
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> usize {
+        rng.next_u64() as usize
     }
 }
 

--- a/src/distributions/other.rs
+++ b/src/distributions/other.rs
@@ -67,7 +67,7 @@ impl Distribution<char> for Alphanumeric {
         // rejection sampling. We do not use a bitmask, because for small RNGs
         // the most significant bits are usually of higher quality.
         loop {
-            let var = rng.next_u32() >> 26;
+            let var = rng.next_u32() >> (32 - 6);
             if var < RANGE {
                 return GEN_ASCII_STR_CHARSET[var as usize] as char
             }

--- a/src/distributions/other.rs
+++ b/src/distributions/other.rs
@@ -62,6 +62,10 @@ impl Distribution<char> for Alphanumeric {
             b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
                 abcdefghijklmnopqrstuvwxyz\
                 0123456789";
+        // We can pick from 62 characters. This is so close to a power of 2, 64,
+        // that we can do better than `Range`. Use a simple bitshift and
+        // rejection sampling. We do not use a bitmask, because for small RNGs
+        // the most significant bits are usually of higher quality.
         loop {
             let var = rng.next_u32() >> 26;
             if var < RANGE {
@@ -161,8 +165,9 @@ impl<T> Distribution<Option<T>> for Uniform where Uniform: Distribution<T> {
 #[cfg(test)]
 mod tests {
     use {Rng, RngCore, Uniform};
+    use distributions::Alphanumeric;
     #[cfg(all(not(feature="std"), feature="alloc"))] use alloc::String;
-    
+
     #[test]
     fn test_misc() {
         let rng: &mut RngCore = &mut ::test::rng(820);
@@ -175,14 +180,28 @@ mod tests {
     #[test]
     fn test_chars() {
         use core::iter;
-        use distributions::Alphanumeric;
         let mut rng = ::test::rng(805);
-        
-        let c = rng.sample(Alphanumeric);
-        assert!((c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z'));
-        
+
+        // Test by generating a relatively large number of chars, so we also
+        // take the rejection sampling path.
         let word: String = iter::repeat(())
-                .map(|()| rng.sample(Alphanumeric)).take(5).collect();
-        assert_eq!(word.len(), 5);
+                .map(|()| rng.gen::<char>()).take(1000).collect();
+        assert!(word.len() != 0);
+    }
+
+    #[test]
+    fn test_alphanumeric() {
+        let mut rng = ::test::rng(806);
+
+        // Test by generating a relatively large number of chars, so we also
+        // take the rejection sampling path.
+        let mut incorrect = false;
+        for _ in 0..100 {
+            let c = rng.sample(Alphanumeric);
+            incorrect |= !((c >= '0' && c <= '9') ||
+                           (c >= 'A' && c <= 'Z') ||
+                           (c >= 'a' && c <= 'z') );
+        }
+        assert!(incorrect == false);
     }
 }

--- a/src/distributions/poisson.rs
+++ b/src/distributions/poisson.rs
@@ -117,7 +117,7 @@ mod test {
     use super::Poisson;
 
     #[test]
-    fn test_poisson() {
+    fn test_poisson_10() {
         let poisson = Poisson::new(10.0);
         let mut rng = ::test::rng(123);
         let mut sum = 0;
@@ -127,6 +127,20 @@ mod test {
         let avg = (sum as f64) / 1000.0;
         println!("Poisson average: {}", avg);
         assert!((avg - 10.0).abs() < 0.5); // not 100% certain, but probable enough
+    }
+
+    #[test]
+    fn test_poisson_15() {
+        // Take the 'high expected values' path
+        let poisson = Poisson::new(15.0);
+        let mut rng = ::test::rng(123);
+        let mut sum = 0;
+        for _ in 0..1000 {
+            sum += poisson.sample(&mut rng);
+        }
+        let avg = (sum as f64) / 1000.0;
+        println!("Poisson average: {}", avg);
+        assert!((avg - 15.0).abs() < 0.5); // not 100% certain, but probable enough
     }
 
     #[test]

--- a/src/distributions/range.rs
+++ b/src/distributions/range.rs
@@ -500,6 +500,17 @@ mod tests {
                             let v: $ty = rng.sample(my_range);
                             assert!(low <= v && v < high);
                         }
+
+                        let my_range = Range::new_inclusive(low, high);
+                        for _ in 0..1000 {
+                            let v: $ty = rng.sample(my_range);
+                            assert!(low <= v && v <= high);
+                        }
+
+                        for _ in 0..1000 {
+                            let v: $ty = Range::sample_single(low, high, &mut rng);
+                            assert!(low <= v && v < high);
+                        }
                     }
                  )*
             }}

--- a/src/jitter.rs
+++ b/src/jitter.rs
@@ -802,10 +802,6 @@ mod test_jitter_init {
             Ok(ref mut rng) => {
                 // false positives are possible, but extremely unlikely
                 assert!(rng.next_u32() | rng.next_u32() != 0);
-                assert!(rng.next_u64() != 0);
-                let mut buf = [0u8; 6];
-                rng.try_fill_bytes(&mut buf).unwrap();
-                assert!(!buf.iter().all(|&x| x == 0));
             },
             Err(_) => {},
         }

--- a/src/jitter.rs
+++ b/src/jitter.rs
@@ -785,5 +785,36 @@ impl RngCore for JitterRng {
 
 impl CryptoRng for JitterRng {}
 
-// There are no tests included because (1) this is an "external" RNG, so output
-// is not reproducible and (2) `test_timer` *will* fail on some platforms.
+#[cfg(test)]
+mod test_jitter_init {
+    use JitterRng;
+
+    #[cfg(feature="std")]
+    #[test]
+    fn test_jitter_init() {
+        use RngCore;
+        // Because this is a debug build, measurements here are not representive
+        // of the final release build.
+        // Don't fail this test if initializing `JitterRng` fails because of a
+        // bad timer (the timer from the standard library may not have enough
+        // accuracy on all platforms).
+        match JitterRng::new() {
+            Ok(ref mut rng) => {
+                // false positives are possible, but extremely unlikely
+                assert!(rng.next_u32() | rng.next_u32() != 0);
+                assert!(rng.next_u64() != 0);
+                let mut buf = [0u8; 6];
+                rng.try_fill_bytes(&mut buf).unwrap();
+                assert!(!buf.iter().all(|&x| x == 0));
+            },
+            Err(_) => {},
+        }
+    }
+
+    #[test]
+    fn test_jitter_bad_timer() {
+        fn bad_timer() -> u64 { 0 }
+        let mut rng = JitterRng::new_with_timer(bad_timer);
+        assert!(rng.test_timer().is_err());
+    }
+}

--- a/src/prng/hc128.rs
+++ b/src/prng/hc128.rs
@@ -434,7 +434,7 @@ mod test {
         // filling the remainder of the buffer.
         let mut buffer = [0u8; 16*4*2];
         // Consume a value so that we have a remainder.
-        let _ = rng.next_u64();
+        assert!(rng.next_u64() == 0x04b4930a518251a4);
         rng.fill_bytes(&mut buffer);
 
         // [u8; 128] doesn't implement PartialEq

--- a/src/thread_rng.rs
+++ b/src/thread_rng.rs
@@ -171,12 +171,10 @@ pub fn random<T>() -> T where Uniform: Distribution<T> {
 
 #[cfg(test)]
 mod test {
-    use Rng;
-
     #[test]
-    #[cfg(feature="std")]
     #[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
     fn test_thread_rng() {
+        use Rng;
         let mut r = ::thread_rng();
         r.gen::<i32>();
         let mut v = [1, 1, 1];


### PR DESCRIPTION
I have been playing around with `kcov` to measure code coverage. I realize that good testing is much more than code coverage, but it showed some places that could use some easy better tests.
- In the binomial distribution, test both code paths, and not only mean but also variance. Fixes https://github.com/rust-lang-nursery/rand/issues/310.
- In the Poisson distribution, test both code paths.
- Better tests for the `char` `Uniform` and `Alphanumeric` distributions.
- Test `Range::new_inclusive` and `Range::sample_single`.
- Basic tests for `JitterRng` (to catch integer overflow etc.)

Finally there was one change I was missing. In https://github.com/dhardy/rand/pull/71#discussion_r156937619 you made `usize` support for 16-bit better.

B.t.w. our code coverage is now 92.9%. The remaining percentages are not really testable, they are the error handling in `OsRng`, `JitterRng`, `EntropyRng`, `ReseedingRng`, and in `error.rs`.