### PR TITLE
Osrng doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,6 @@ You may also find the [Update Guide](UPDATING.md) useful.
 - All PRNGs are now portable across big- and little-endian architectures. (#209)
 - `Isaac64Rng::next_u32` no longer throws away half the results. (#209)
 - Add `IsaacRng::new_from_u64` and `Isaac64Rng::new_from_u64`. (#209)
-- Remove `IsaacWordRng` wrapper. (#277)
 - Add the HC-128 CSPRNG `Hc128Rng`. (#210)
 - Add `ChaChaRng::set_rounds` method. (#243)
 - Changes to `JitterRng` to get its size down from 2112 to 24 bytes. (#251)
@@ -71,6 +70,7 @@ You may also find the [Update Guide](UPDATING.md) useful.
 - Remove support for NaCl. (#225)
 - WASM support for `OsRng` via stdweb, behind the `stdweb` feature. (#272, #336)
 - Use `getrandom` on more platforms for Linux, and on Android. (#338)
+- Use the `SecRandomCopyBytes` interface on macOS. (#322)
 - On systems that do not have a syscall interface, only keep a single file descriptor open for `OsRng`. (#239)
 - On Unix, first try a single read from `/dev/random`, then `/dev/urandom`. (#338)
 - Better error handling and reporting in `OsRng` (using new error type). (#225)
@@ -90,7 +90,6 @@ You may also find the [Update Guide](UPDATING.md) useful.
 - Use widening multiply method for much faster integer range reduction. (#274)
 - `Uniform` distributions for `bool` uses `Range`. (#274)
 - `Uniform` distributions for `bool` uses sign test. (#274)
-- Add `HighPrecision01` distribution. (#320)
 
 
 ## [0.4.2] - 2018-01-06

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -226,18 +226,14 @@ distribution).
 
 The `Open01` and `Closed01` wrappers have been removed. `Rng::gen()` (via
 `Uniform`) now yields samples from `(0, 1)` for floats; i.e. the same as the old
-`Open01`. This is considered sufficient for most uses. If you require more
-precision, use the `HighPrecision01` distribution.
+`Open01`. This is considered sufficient for most uses.
 
 #### Uniform distributions
 
-Three new distributions are available:
+Two new distributions are available:
 
 -   `Uniform` produces uniformly-distributed samples for many different types,
     and acts as a replacement for `Rand`
--   `HighPrecision01` generates floating-point numbers in the range `[0, 1)`
-    (similar to `Uniform`) but with as much precision as the floating point
-    format can represent
 -   `Alphanumeric` samples `char`s from the ranges `a-z A-Z 0-9`
 
 ##### Ranges

--- a/src/os.rs
+++ b/src/os.rs
@@ -15,9 +15,9 @@ use std::fmt;
 use rand_core::{RngCore, Error, impls};
 
 /// A random number generator that retrieves randomness straight from the
-/// operating system. This is the preferred external source of randomness for
-/// most applications. Commonly it is used to initialize a user-space RNG, which
-/// can then be used with much lower overhead.
+/// operating system. This is the preferred external source of entropy for most
+/// applications. Commonly it is used to initialize a user-space RNG, which can
+/// then be used to generate random values with much less overhead than `OsRng`.
 ///
 /// You may prefer to use [`EntropyRng`] instead of `OsRng`. Is is unlikely, but
 /// not entirely theoretical, for `OsRng` to fail. In such cases `EntropyRng`


### PR DESCRIPTION
Based on top of https://github.com/rust-lang-nursery/rand/pull/328.

I took a stab at improving the documentation of `OsRng`.

Somewhere in a long paragraph it mentioned the problem with `/dev/urandom` during early boot. Instead of making things complicated for users, I think this is something we can handle, especially now that we only keep a single handle to `/dev/urandom` open. Opened https://github.com/rust-lang-nursery/rand/issues/332 for that and other possible improvements to `OsRng`.

Also updated the changelog with `SecRandomCopyBytes`(https://github.com/rust-lang-nursery/rand/pull/322), https://github.com/rust-lang-nursery/rand/pull/321#discussion_r176403635, and removed `HighPrecision01` (maybe want to think things through a bit more for that one?).