### PR TITLE
Make the std feature require the alloc feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ categories = ["algorithms"]
 default = ["std"]
 nightly = ["i128_support"] # enables all features requiring nightly rust
 
-std = ["rand_core/std", "winapi", "libc"] # default feature; without this rand uses libcore
-alloc = ["rand_core/alloc"]  # enables Vec and Box support without std
+std = ["rand_core/std", "winapi", "libc", "alloc"] # default feature; without this rand uses libcore
+alloc = ["rand_core/alloc"]  # enables Vec and Box support (without std)
 
 i128_support = [] # enables i128 and u128 support
 

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -361,7 +361,7 @@ impl<'a, R: RngCore + ?Sized> RngCore for &'a mut R {
     }
 }
 
-#[cfg(any(feature="std", feature="alloc"))]
+#[cfg(feature="alloc")]
 impl<R: RngCore + ?Sized> RngCore for Box<R> {
     #[inline(always)]
     fn next_u32(&mut self) -> u32 {

--- a/src/distributions/other.rs
+++ b/src/distributions/other.rs
@@ -171,7 +171,7 @@ mod tests {
         rng.sample::<bool, _>(Uniform);
     }
     
-    #[cfg(any(feature="std", feature="alloc"))]
+    #[cfg(feature="alloc")]
     #[test]
     fn test_chars() {
         use core::iter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,7 +234,7 @@ pub mod mock;
 #[cfg(feature="std")] pub mod os;
 #[cfg(feature="std")] pub mod read;
 pub mod reseeding;
-#[cfg(any(feature="std", feature = "alloc"))] pub mod seq;
+#[cfg(feature = "alloc")] pub mod seq;
 
 // These tiny modules are here to avoid API breakage, probably only temporarily
 pub mod chacha {
@@ -1123,7 +1123,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(any(feature="std", feature="alloc"))]
+    #[cfg(feature="alloc")]
     fn test_rng_boxed_trait() {
         use distributions::{Distribution, Uniform};
         let rng = rng(110);


### PR DESCRIPTION
A tiny change: Make the `std` feature a superset of `alloc`, instead of an alternative. Seems slightly neater to me.