### PR TITLE
rand_core: std depends on alloc, as for rand

### DIFF
--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -16,5 +16,5 @@ categories = ["algorithms"]
 [features]
 # Bug: https://github.com/rust-lang/cargo/issues/4361
 # default = ["std"]
-std = []    # use std library; should be default but for above bug
+std = ["alloc"]    # use std library; should be default but for above bug
 alloc = []  # enables Vec and Box support without std


### PR DESCRIPTION
I'm not entirely sure why but this appears to cause no issues, unlike the commented `default` feature rule above (fails: `cargo +nightly test --tests --no-default-features --features=alloc --all`).