### PR TITLE
Implement various Clippy suggestions

### DIFF
--- a/benches/distributions.rs
+++ b/benches/distributions.rs
@@ -43,7 +43,7 @@ macro_rules! distr_float {
                 let mut accum = 0.0;
                 for _ in 0..::RAND_BENCH_N {
                     let x: $ty = distr.sample(&mut rng);
-                    accum = accum + x;
+                    accum += x;
                 }
                 black_box(accum);
             });

--- a/examples/monty-hall.rs
+++ b/examples/monty-hall.rs
@@ -58,7 +58,7 @@ fn simulate<R: Rng>(random_door: &Range<RangeInt<u32>>, rng: &mut R)
         choice = switch_door(choice, open);
     }
 
-    SimulationResult { win: choice == car, switch: switch }
+    SimulationResult { win: choice == car, switch }
 }
 
 // Returns the door the game host opens given our choice and knowledge of

--- a/src/distributions/binomial.rs
+++ b/src/distributions/binomial.rs
@@ -41,7 +41,7 @@ impl Binomial {
     pub fn new(n: u64, p: f64) -> Binomial {
         assert!(p > 0.0, "Binomial::new called with p <= 0");
         assert!(p < 1.0, "Binomial::new called with p >= 1");
-        Binomial { n: n, p: p }
+        Binomial { n, p }
     }
 }
 

--- a/src/distributions/float.rs
+++ b/src/distributions/float.rs
@@ -25,7 +25,6 @@ pub(crate) trait IntoFloat {
     /// The resulting value will fall in a range that depends on the exponent.
     /// As an example the range with exponent 0 will be
     /// [2<sup>0</sup>..2<sup>1</sup>), which is [1..2).
-    #[inline(always)]
     fn into_float_with_exponent(self, exponent: i32) -> Self::F;
 }
 

--- a/src/distributions/gamma.rs
+++ b/src/distributions/gamma.rs
@@ -109,7 +109,7 @@ impl Gamma {
         } else {
             Large(GammaLargeShape::new_raw(shape, scale))
         };
-        Gamma { repr: repr }
+        Gamma { repr }
     }
 }
 
@@ -126,9 +126,9 @@ impl GammaLargeShape {
     fn new_raw(shape: f64, scale: f64) -> GammaLargeShape {
         let d = shape - 1. / 3.;
         GammaLargeShape {
-            scale: scale,
+            scale,
             c: 1. / (9. * d).sqrt(),
-            d: d
+            d
         }
     }
 }
@@ -211,7 +211,7 @@ impl ChiSquared {
             assert!(k > 0.0, "ChiSquared::new called with `k` < 0");
             DoFAnythingElse(Gamma::new(0.5 * k, 2.0))
         };
-        ChiSquared { repr: repr }
+        ChiSquared { repr }
     }
 }
 impl Distribution<f64> for ChiSquared {

--- a/src/distributions/log_gamma.rs
+++ b/src/distributions/log_gamma.rs
@@ -39,13 +39,13 @@ pub fn log_gamma(x: f64) -> f64 {
     // the first few terms of the series for Ag(x)
     let mut a = 1.000000000190015;
     let mut denom = x;
-    for j in 0..6 {
+    for coeff in &coefficients {
         denom += 1.0;
-        a += coefficients[j] / denom;
+        a += coeff / denom;
     }
 
     // get everything together
     // a is Ag(x)
     // 2.5066... is sqrt(2pi)
-    return log + (2.5066282746310005 * a / x).ln();
+    log + (2.5066282746310005 * a / x).ln()
 }

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -273,7 +273,7 @@ impl<'a, T: Clone> WeightedChoice<'a, T> {
         assert!(running_total != 0, "WeightedChoice::new called with a total weight of 0");
 
         WeightedChoice {
-            items: items,
+            items,
             // we're likely to be generating numbers in this range
             // relatively often, so might as well cache it
             weight_range: Range::new(0, running_total)
@@ -320,7 +320,7 @@ impl<'a, T: Clone> Distribution<T> for WeightedChoice<'a, T> {
             }
             modifier /= 2;
         }
-        return self.items[idx + 1].item.clone();
+        self.items[idx + 1].item.clone()
     }
 }
 

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -104,8 +104,8 @@ impl Normal {
     pub fn new(mean: f64, std_dev: f64) -> Normal {
         assert!(std_dev >= 0.0, "Normal::new called with `std_dev` < 0");
         Normal {
-            mean: mean,
-            std_dev: std_dev
+            mean,
+            std_dev
         }
     }
 }

--- a/src/distributions/other.rs
+++ b/src/distributions/other.rs
@@ -58,7 +58,7 @@ impl Distribution<char> for Uniform {
 impl Distribution<char> for Alphanumeric {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> char {
         const RANGE: u32 = 26 + 26 + 10;
-        const GEN_ASCII_STR_CHARSET: &'static [u8] =
+        const GEN_ASCII_STR_CHARSET: &[u8] =
             b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
                 abcdefghijklmnopqrstuvwxyz\
                 0123456789";

--- a/src/distributions/poisson.rs
+++ b/src/distributions/poisson.rs
@@ -46,9 +46,9 @@ impl Poisson {
         assert!(lambda > 0.0, "Poisson::new called with lambda <= 0");
         let log_lambda = lambda.ln();
         Poisson {
-            lambda: lambda,
+            lambda,
             exp_lambda: (-lambda).exp(),
-            log_lambda: log_lambda,
+            log_lambda,
             sqrt_2lambda: (2.0 * lambda).sqrt(),
             magic_val: lambda * log_lambda - log_gamma(1.0 + lambda),
         }

--- a/src/entropy_rng.rs
+++ b/src/entropy_rng.rs
@@ -55,6 +55,12 @@ impl EntropyRng {
     }
 }
 
+impl Default for EntropyRng {
+    fn default() -> Self {
+        EntropyRng::new()
+    }
+}
+
 impl RngCore for EntropyRng {
     fn next_u32(&mut self) -> u32 {
         impls::next_u32_via_fill(self)

--- a/src/jitter.rs
+++ b/src/jitter.rs
@@ -196,7 +196,7 @@ impl JitterRng {
         JitterRng {
             data: 0,
             rounds: 64,
-            timer: timer,
+            timer,
             mem_prev_index: 0,
             data_half_used: false,
         }
@@ -238,7 +238,7 @@ impl JitterRng {
         let mask = (1 << n_bits) - 1;
         for _ in 0..folds {
             rounds ^= time & mask;
-            time = time >> n_bits;
+            time >>= n_bits;
         }
 
         rounds as u32
@@ -259,7 +259,7 @@ impl JitterRng {
         fn lfsr(mut data: u64, time: u64) -> u64{
             for i in 1..65 {
                 let mut tmp = time << (64 - i);
-                tmp = tmp >> (64 - 1);
+                tmp >>= 64 - 1;
 
                 // Fibonacci LSFR with polynomial of
                 // x^64 + x^61 + x^56 + x^31 + x^28 + x^23 + 1 which is

--- a/src/os.rs
+++ b/src/os.rs
@@ -330,13 +330,13 @@ mod imp {
                     .read(true)
                     .custom_flags(libc::O_NONBLOCK)
                     .open("/dev/random")
-                    .map_err(|err| map_err(err))?;
+                    .map_err(map_err)?;
                 let mut buf = [0u8; 1];
-                file.read_exact(&mut buf).map_err(|err| map_err(err))?;
+                file.read_exact(&mut buf).map_err(map_err)?;
             }
 
             info!("OsRng: opening random device /dev/urandom");
-            let file = File::open("/dev/urandom").map_err(|err| map_err(err))?;
+            let file = File::open("/dev/urandom").map_err(map_err)?;
             *guard = Some(file);
         };
         Ok(())

--- a/src/prng/chacha.rs
+++ b/src/prng/chacha.rs
@@ -95,7 +95,7 @@ impl SeedableRng for ChaChaRng {
     }
 
     fn from_rng<R: RngCore>(rng: R) -> Result<Self, Error> {
-        BlockRng::<ChaChaCore>::from_rng(rng).map(|result| ChaChaRng(result))
+        BlockRng::<ChaChaCore>::from_rng(rng).map(ChaChaRng)
     }
 }
 

--- a/src/prng/hc128.rs
+++ b/src/prng/hc128.rs
@@ -92,7 +92,7 @@ impl SeedableRng for Hc128Rng {
     }
 
     fn from_rng<R: RngCore>(rng: R) -> Result<Self, Error> {
-        BlockRng::<Hc128Core>::from_rng(rng).map(|result| Hc128Rng(result))
+        BlockRng::<Hc128Core>::from_rng(rng).map(Hc128Rng)
     }
 }
 
@@ -303,7 +303,7 @@ impl Hc128Core {
                    .wrapping_add(t[i-16]).wrapping_add(256 + i as u32);
         }
 
-        let mut core = Self { t: t, counter1024: 0 };
+        let mut core = Self { t, counter1024: 0 };
 
         // run the cipher 1024 steps
         for _ in 0..64 { core.sixteen_steps() };

--- a/src/prng/isaac.rs
+++ b/src/prng/isaac.rs
@@ -260,7 +260,7 @@ impl RngCore for IsaacRng {
 /// Creates a new ISAAC random number generator.
 ///
 /// The author Bob Jenkins describes how to best initialize ISAAC here:
-/// https://rt.cpan.org/Public/Bug/Display.html?id=64324
+/// <https://rt.cpan.org/Public/Bug/Display.html?id=64324>
 /// The answer is included here just in case:
 ///
 /// "No, you don't need a full 8192 bits of seed data. Normal key sizes will do
@@ -315,7 +315,7 @@ fn init(mut mem: [w32; RAND_SIZE], rounds: u32) -> IsaacRng {
 
     let mut rng = IsaacRng {
         rsl: [0; RAND_SIZE],
-        mem: mem,
+        mem,
         a: w(0),
         b: w(0),
         c: w(0),

--- a/src/prng/isaac64.rs
+++ b/src/prng/isaac64.rs
@@ -64,10 +64,11 @@ const RAND_SIZE: usize = 1 << RAND_SIZE_LEN;
 /// }
 /// ```
 ///
-/// See for more information the description in rand::prng::IsaacRng.
+/// See for more information the documentation of [`IsaacRng`].
 ///
 /// [1]: Bob Jenkins, [*ISAAC and RC4*](
 ///      http://burtleburtle.net/bob/rand/isaac.html)
+/// [`IsaacRng`]: prng/isaac/struct.IsaacRng.html
 #[cfg_attr(feature="serde-1", derive(Serialize,Deserialize))]
 pub struct Isaac64Rng {
     #[cfg_attr(feature="serde-1",serde(with="super::isaac_serde::rand_size_serde"))]
@@ -294,7 +295,7 @@ fn init(mut mem: [w64; RAND_SIZE], rounds: u32) -> Isaac64Rng {
 
     Isaac64Rng {
         rsl: [0; RAND_SIZE],
-        mem: mem,
+        mem,
         a: w(0),
         b: w(0),
         c: w(0),

--- a/src/reseeding.rs
+++ b/src/reseeding.rs
@@ -77,7 +77,7 @@ where R: BlockRngCore + SeedableRng,
             BlockRng {
                 core: ReseedingCore {
                     inner: rng,
-                    reseeder: reseeder,
+                    reseeder,
                     threshold: threshold as i64,
                     bytes_until_reseed: threshold as i64,
                 },

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -163,8 +163,8 @@ pub fn sample_indices<R>(rng: &mut R, length: usize, amount: usize) -> Vec<usize
 /// This allocates the entire `length` of indices and randomizes only the first `amount`.
 /// It then truncates to `amount` and returns.
 ///
-/// This is better than using a HashMap "cache" when `amount >= length / 2` since it does not
-/// require allocating an extra cache and is much faster.
+/// This is better than using a `HashMap` "cache" when `amount >= length / 2`
+/// since it does not require allocating an extra cache and is much faster.
 fn sample_indices_inplace<R>(rng: &mut R, length: usize, amount: usize) -> Vec<usize>
     where R: Rng + ?Sized,
 {
@@ -173,9 +173,7 @@ fn sample_indices_inplace<R>(rng: &mut R, length: usize, amount: usize) -> Vec<u
     indices.extend(0..length);
     for i in 0..amount {
         let j: usize = rng.gen_range(i, length);
-        let tmp = indices[i];
-        indices[i] = indices[j];
-        indices[j] = tmp;
+        indices.swap(i, j);
     }
     indices.truncate(amount);
     debug_assert_eq!(indices.len(), amount);
@@ -183,11 +181,11 @@ fn sample_indices_inplace<R>(rng: &mut R, length: usize, amount: usize) -> Vec<u
 }
 
 
-/// This method performs a partial fisher-yates on a range of indices using a HashMap
-/// as a cache to record potential collisions.
+/// This method performs a partial fisher-yates on a range of indices using a
+/// `HashMap` as a cache to record potential collisions.
 ///
 /// The cache avoids allocating the entire `length` of values. This is especially useful when
-/// `amount <<< length`, i.e. select 3 non-repeating from 1_000_000
+/// `amount <<< length`, i.e. select 3 non-repeating from `1_000_000`
 fn sample_indices_cache<R>(
     rng: &mut R,
     length: usize,


### PR DESCRIPTION
Many lints were disabled due to low or nil utility, and a few suggestions
ignored in the interests of readability or correctness. Command:

~/.cargo/bin/cargo-clippy --features=log,nightly,serde-1 -- -A inline_always -A approx_constant -A unreadable_literal -A cast_lossless -A len_zero -A unit_arg -A many_single_char_names -A doc_markdown -A single_match -A transmute_int_to_float -A float_cmp -A identity_op -A too_many_arguments -A new_ret_no_self