### PR TITLE
Restrict the stdweb feature to the wasm32-unknown-unknown target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ rand_core = { version = '0.1.0-pre.0', default-features = false }
 log = { version = "0.4", optional = true }
 serde = { version = "1", optional = true }
 serde_derive = { version = "1", optional = true }
-stdweb = { version = "0.4", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2", optional = true }
@@ -46,6 +45,10 @@ cloudabi = { version = "0.0.3", optional = true }
 
 [target.'cfg(target_os = "fuchsia")'.dependencies]
 fuchsia-zircon = { version = "0.3.2", optional = true }
+
+[target.wasm32-unknown-unknown.dependencies]
+# use with `--target wasm32-unknown-unknown --features=stdweb`
+stdweb = { version = "0.4", optional = true }
 
 [dev-dependencies]
 # This is for testing serde, unfortunately we can't specify feature-gated dev

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,7 @@
 #[cfg(feature="serde-1")] extern crate serde;
 #[cfg(feature="serde-1")] #[macro_use] extern crate serde_derive;
 
-#[cfg(feature = "stdweb")]
+#[cfg(all(target_arch = "wasm32", feature = "stdweb"))]
 #[macro_use]
 extern crate stdweb;
 


### PR DESCRIPTION
See https://travis-ci.org/rust-lang-nursery/rand/jobs/359227191.

Building with `--all-features` tries to use stdweb, even when the target platform is not WASM.
For `cargo doc --no-deps --all --all-features` that makes the CI a bit less optimal.