### PR TITLE
Parameterize range by X instead of RangeImpl

### DIFF
--- a/examples/monty-hall.rs
+++ b/examples/monty-hall.rs
@@ -34,7 +34,6 @@ extern crate rand;
 
 use rand::Rng;
 use rand::distributions::{Distribution, Range};
-use rand::distributions::range::RangeInt;
 
 struct SimulationResult {
     win: bool,
@@ -42,7 +41,7 @@ struct SimulationResult {
 }
 
 // Run a single simulation of the Monty Hall problem.
-fn simulate<R: Rng>(random_door: &Range<RangeInt<u32>>, rng: &mut R)
+fn simulate<R: Rng>(random_door: &Range<u32>, rng: &mut R)
                     -> SimulationResult {
     let car = random_door.sample(rng);
 

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -83,7 +83,7 @@ mod impls {
     use distributions::gamma::{Gamma, ChiSquared, FisherF, StudentT};
     #[cfg(feature="std")]
     use distributions::normal::{Normal, LogNormal};
-    use distributions::range::{Range, RangeImpl};
+    use distributions::range::{Range, SampleRange};
     
     impl<'a, T: Clone> Sample<T> for WeightedChoice<'a, T> {
         fn sample<R: Rng>(&mut self, rng: &mut R) -> T {
@@ -96,13 +96,13 @@ mod impls {
         }
     }
     
-    impl<T: RangeImpl> Sample<T::X> for Range<T> {
-        fn sample<R: Rng>(&mut self, rng: &mut R) -> T::X {
+    impl<T: SampleRange> Sample<T> for Range<T> {
+        fn sample<R: Rng>(&mut self, rng: &mut R) -> T {
             Distribution::sample(self, rng)
         }
     }
-    impl<T: RangeImpl> IndependentSample<T::X> for Range<T> {
-        fn ind_sample<R: Rng>(&self, rng: &mut R) -> T::X {
+    impl<T: SampleRange> IndependentSample<T> for Range<T> {
+        fn ind_sample<R: Rng>(&self, rng: &mut R) -> T {
             Distribution::sample(self, rng)
         }
     }
@@ -241,7 +241,7 @@ pub struct Weighted<T> {
 #[derive(Debug)]
 pub struct WeightedChoice<'a, T:'a> {
     items: &'a mut [Weighted<T>],
-    weight_range: Range<range::RangeInt<u32>>,
+    weight_range: Range<u32>,
 }
 
 impl<'a, T: Clone> WeightedChoice<'a, T> {

--- a/src/distributions/range.rs
+++ b/src/distributions/range.rs
@@ -52,38 +52,35 @@ use distributions::float::IntoFloat;
 /// }
 /// ```
 #[derive(Clone, Copy, Debug)]
-pub struct Range<T: RangeImpl> {
-    inner: T,
+pub struct Range<X: SampleRange> {
+    inner: X::T,
 }
 
-/// Ignore the `RangeInt<i32>` parameterisation; these non-member functions are
-/// available to all range types. (Rust requires a type, and won't accept
-/// `T: RangeImpl`. Consider this a minor language issue.)
-impl Range<RangeInt<i32>> {
+impl<X: SampleRange> Range<X> {
     /// Create a new `Range` instance which samples uniformly from the half
     /// open range `[low, high)` (excluding `high`). Panics if `low >= high`.
-    pub fn new<X: SampleRange>(low: X, high: X) -> Range<X::T> {
+    pub fn new(low: X, high: X) -> Range<X> {
         assert!(low < high, "Range::new called with `low >= high`");
-        Range { inner: RangeImpl::new(low, high) }
+        Range { inner: X::T::new(low, high) }
     }
 
     /// Create a new `Range` instance which samples uniformly from the closed
     /// range `[low, high]` (inclusive). Panics if `low >= high`.
-    pub fn new_inclusive<X: SampleRange>(low: X, high: X) -> Range<X::T> {
+    pub fn new_inclusive(low: X, high: X) -> Range<X> {
         assert!(low < high, "Range::new called with `low >= high`");
-        Range { inner: RangeImpl::new_inclusive(low, high) }
+        Range { inner: X::T::new_inclusive(low, high) }
     }
 
     /// Sample a single value uniformly from `[low, high)`.
     /// Panics if `low >= high`.
-    pub fn sample_single<X: SampleRange, R: Rng + ?Sized>(low: X, high: X, rng: &mut R) -> X {
+    pub fn sample_single<R: Rng + ?Sized>(low: X, high: X, rng: &mut R) -> X {
         assert!(low < high, "Range::sample_single called with low >= high");
         X::T::sample_single(low, high, rng)
     }
 }
 
-impl<T: RangeImpl> Distribution<T::X> for Range<T> {
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> T::X {
+impl<X: SampleRange> Distribution<X> for Range<X> {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> X {
         self.inner.sample(rng)
     }
 }


### PR DESCRIPTION
This implements the suggestion from @huonw in https://www.reddit.com/r/rust/comments/87hq5a/rand_05_prerelease_is_available_for_testing/dwe9w38/.

Requiring `RangeImpl` in the parameterization of `Range` was ugly, and a breaking change. I believe his solution is much nicer.

It looks ok to me, but as always I am a hopeless novice when it comes to traits etc.

If you think this is correct, this is something I would really like to see in 0.5 :smile:.