### PR TITLE
Add an iterator to `Distribution`

### DIFF
--- a/benches/distributions.rs
+++ b/benches/distributions.rs
@@ -134,3 +134,19 @@ gen_range_int!(gen_range_i32, i32, -200_000_000i32, 800_000_000);
 gen_range_int!(gen_range_i64, i64, 3i64, 123_456_789_123);
 #[cfg(feature = "i128_support")]
 gen_range_int!(gen_range_i128, i128, -12345678901234i128, 123_456_789_123_456_789);
+
+#[bench]
+fn dist_iter(b: &mut Bencher) {
+    let mut rng = XorShiftRng::new();
+    let distr = Normal::new(-2.71828, 3.14159);
+    let mut iter = distr.sample_iter(&mut rng);
+
+    b.iter(|| {
+        let mut accum = 0.0;
+        for _ in 0..::RAND_BENCH_N {
+            accum += iter.next().unwrap();
+        }
+        black_box(accum);
+    });
+    b.bytes = size_of::<f64>() as u64 * ::RAND_BENCH_N;
+}

--- a/benches/misc.rs
+++ b/benches/misc.rs
@@ -88,3 +88,47 @@ macro_rules! sample_indices {
 sample_indices!(misc_sample_indices_10_of_1k, 10, 1000);
 sample_indices!(misc_sample_indices_50_of_1k, 50, 1000);
 sample_indices!(misc_sample_indices_100_of_1k, 100, 1000);
+
+#[bench]
+fn gen_1k_iter_repeat(b: &mut Bencher) {
+    use std::iter;
+    let mut rng = SmallRng::from_rng(&mut thread_rng()).unwrap();
+    b.iter(|| {
+        let v: Vec<u64> = iter::repeat(()).map(|()| rng.gen()).take(128).collect();
+        black_box(v);
+    });
+    b.bytes = 1024;
+}
+
+#[bench]
+#[allow(deprecated)]
+fn gen_1k_gen_iter(b: &mut Bencher) {
+    let mut rng = SmallRng::from_rng(&mut thread_rng()).unwrap();
+    b.iter(|| {
+        let v: Vec<u64> = rng.gen_iter().take(128).collect();
+        black_box(v);
+    });
+    b.bytes = 1024;
+}
+
+#[bench]
+fn gen_1k_sample_iter(b: &mut Bencher) {
+    use rand::distributions::{Distribution, Uniform};
+    let mut rng = SmallRng::from_rng(&mut thread_rng()).unwrap();
+    b.iter(|| {
+        let v: Vec<u64> = Uniform.sample_iter(&mut rng).take(128).collect();
+        black_box(v);
+    });
+    b.bytes = 1024;
+}
+
+#[bench]
+fn gen_1k_fill(b: &mut Bencher) {
+    let mut rng = SmallRng::from_rng(&mut thread_rng()).unwrap();
+    let mut buf = [0u64; 128];
+    b.iter(|| {
+        rng.fill(&mut buf[..]);
+        black_box(buf);
+    });
+    b.bytes = 1024;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,6 +380,39 @@ pub trait Rng: RngCore {
     fn sample<T, D: Distribution<T>>(&mut self, distr: D) -> T {
         distr.sample(self)
     }
+
+    /// Create an iterator that generates values using the given distribution.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use rand::{thread_rng, Rng};
+    /// use rand::distributions::{Alphanumeric, Range, Uniform};
+    ///
+    /// let mut rng = thread_rng();
+    ///
+    /// // Vec of 16 x f32:
+    /// let v: Vec<f32> = thread_rng().sample_iter(&Uniform).take(16).collect();
+    ///
+    /// // String:
+    /// let s: String = rng.sample_iter(&Alphanumeric).take(7).collect();
+    ///
+    /// // Combined values
+    /// println!("{:?}", thread_rng().sample_iter(&Uniform).take(5)
+    ///                              .collect::<Vec<(f64, bool)>>());
+    ///
+    /// // Dice-rolling:
+    /// let die_range = Range::new_inclusive(1, 6);
+    /// let mut roll_die = rng.sample_iter(&die_range);
+    /// while roll_die.next().unwrap() != 6 {
+    ///     println!("Not a 6; rolling again!");
+    /// }
+    /// ```
+    fn sample_iter<'a, T, D: Distribution<T>>(&'a mut self, distr: &'a D)
+        -> distributions::DistIter<'a, D, Self, T> where Self: Sized
+    {
+        distr.sample_iter(self)
+    }
     
     /// Return a random value supporting the [`Uniform`] distribution.
     /// 
@@ -415,7 +448,7 @@ pub trait Rng: RngCore {
     ///                     .collect::<Vec<(f64, bool)>>());
     /// ```
     #[allow(deprecated)]
-    #[deprecated(since="0.5.0", note="use Distribution::sample_iter instead")]
+    #[deprecated(since="0.5.0", note="use Rng::sample_iter(&Uniform) instead")]
     fn gen_iter<T>(&mut self) -> Generator<T, &mut Self> where Uniform: Distribution<T> {
         Generator { rng: self, _marker: marker::PhantomData }
     }
@@ -500,7 +533,7 @@ pub trait Rng: RngCore {
     /// println!("{}", s);
     /// ```
     #[allow(deprecated)]
-    #[deprecated(since="0.5.0", note="use distributions::Alphanumeric instead")]
+    #[deprecated(since="0.5.0", note="use sample_iter(&Alphanumeric) instead")]
     fn gen_ascii_chars(&mut self) -> AsciiGenerator<&mut Self> {
         AsciiGenerator { rng: self }
     }
@@ -651,7 +684,7 @@ impl_as_byte_slice_arrays!(32, N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N
 /// [`Rng`]: trait.Rng.html
 #[derive(Debug)]
 #[allow(deprecated)]
-#[deprecated(since="0.5.0", note="use Distribution::sample_iter instead")]
+#[deprecated(since="0.5.0", note="use Rng::sample_iter instead")]
 pub struct Generator<T, R: RngCore> {
     rng: R,
     _marker: marker::PhantomData<fn() -> T>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,33 +299,6 @@ pub trait Rand : Sized {
 /// }
 /// ```
 /// 
-/// # Iteration
-/// 
-/// Iteration over an `Rng` can be achieved using `iter::repeat` as follows:
-/// 
-/// ```rust
-/// use std::iter;
-/// use rand::{Rng, thread_rng};
-/// use rand::distributions::{Alphanumeric, Range};
-/// 
-/// let mut rng = thread_rng();
-/// 
-/// // Vec of 16 x f32:
-/// let v: Vec<f32> = iter::repeat(()).map(|()| rng.gen()).take(16).collect();
-/// 
-/// // String:
-/// let s: String = iter::repeat(())
-///         .map(|()| rng.sample(Alphanumeric))
-///         .take(7).collect();
-/// 
-/// // Dice-rolling:
-/// let die_range = Range::new_inclusive(1, 6);
-/// let mut roll_die = iter::repeat(()).map(|()| rng.sample(die_range));
-/// while roll_die.next().unwrap() != 6 {
-///     println!("Not a 6; rolling again!");
-/// }
-/// ```
-/// 
 /// [`RngCore`]: https://docs.rs/rand_core/0.1/rand_core/trait.RngCore.html
 pub trait Rng: RngCore {
     /// Fill `dest` entirely with random bytes (uniform value distribution),
@@ -442,7 +415,7 @@ pub trait Rng: RngCore {
     ///                     .collect::<Vec<(f64, bool)>>());
     /// ```
     #[allow(deprecated)]
-    #[deprecated(since="0.5.0", note="use iter::repeat instead")]
+    #[deprecated(since="0.5.0", note="use Distribution::sample_iter instead")]
     fn gen_iter<T>(&mut self) -> Generator<T, &mut Self> where Uniform: Distribution<T> {
         Generator { rng: self, _marker: marker::PhantomData }
     }
@@ -678,7 +651,7 @@ impl_as_byte_slice_arrays!(32, N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N,N
 /// [`Rng`]: trait.Rng.html
 #[derive(Debug)]
 #[allow(deprecated)]
-#[deprecated(since="0.5.0", note="use iter::repeat instead")]
+#[deprecated(since="0.5.0", note="use Distribution::sample_iter instead")]
 pub struct Generator<T, R: RngCore> {
     rng: R,
     _marker: marker::PhantomData<fn() -> T>,


### PR DESCRIPTION
This tries to solve the same problem as https://github.com/rust-lang-nursery/rand/pull/275, having a nice way to sample from distributions using an iterator. See also https://github.com/rust-lang-nursery/rand/issues/58.

I have added a `sample_iter` method to `Distribution` for now. But I don't mind if it is a method on `Rng` instead, or on both...

With benchmarks similar to those in https://github.com/rust-lang-nursery/rand/pull/275, the results are all over the place. In all situations it is slightly slower than `iter::repeat`, but usually not by more than a couple of percent. The exception is `Uniform`, where we use that values generated by the RNG directly:
```
test gen_1k_fill                   ... bench:       1,129 ns/iter (+/- 1) = 906 MB/s
test gen_1k_gen_iter               ... bench:         729 ns/iter (+/- 1) = 1404 MB/s
test gen_1k_iter_repeat            ... bench:         372 ns/iter (+/- 0) = 2752 MB/s
test gen_1k_sample_iter            ... bench:         626 ns/iter (+/- 1) = 1635 MB/s <- new
```

Example of using `Distribution::sample_iter` instead of `Rng::gen_iter`:
```rust
use distributions::{Alphanumeric, Range, Uniform};
let rng = thread_rng();

// Vec of 16 x f32:
// old
let v: Vec<f32> = iter::repeat(()).map(|()| rng.gen()).take(16).collect();
// new
let v: Vec<f32> = Uniform.sample_iter(&mut rng).take(16).collect();

// String
// old
let s: String = rng.gen_ascii_chars().take(10).collect();
// new
let s: String = Alphanumeric.sample_iter(&mut rng).take(7).collect();

// Combined values
// old
println!("{:?}", rng.gen_iter::<(f64, bool)>().take(5)
                    .collect::<Vec<(f64, bool)>>());
// new
println!("{:?}", Uniform.sample_iter(&mut rng).take(5)
                        .collect::<Vec<(f64, bool)>>());

// Dice-rolling:
// old
let die_range = Range::new_inclusive(1, 6);
let mut roll_die = iter::repeat(()).map(|()| rng.sample(die_range));
while roll_die.next().unwrap() != 6 {
    println!("Not a 6; rolling again!");
}
// new
let die_range = Range::new_inclusive(1, 6);
let mut roll_die = die_range.sample_iter(&mut rng);
while roll_die.next().unwrap() != 6 {
    println!("Not a 6; rolling again!");
}
```