### PR TITLE
Hide "The i128_type feature is now stable" warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,6 +178,7 @@
 
 #![cfg_attr(not(feature="std"), no_std)]
 #![cfg_attr(all(feature="alloc", not(feature="std")), feature(alloc))]
+#![cfg_attr(feature = "i128_support", allow(stable_features))] // stable since 2018-03-27
 #![cfg_attr(feature = "i128_support", feature(i128_type, i128))]
 #![cfg_attr(feature = "stdweb", recursion_limit="128")]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,8 +178,8 @@
 
 #![cfg_attr(not(feature="std"), no_std)]
 #![cfg_attr(all(feature="alloc", not(feature="std")), feature(alloc))]
-#![cfg_attr(feature = "i128_support", allow(stable_features))] // stable since 2018-03-27
-#![cfg_attr(feature = "i128_support", feature(i128_type, i128))]
+#![cfg_attr(all(feature="i128_support", feature="nightly"), allow(stable_features))] // stable since 2018-03-27
+#![cfg_attr(all(feature="i128_support", feature="nightly"), feature(i128_type, i128))]
 #![cfg_attr(feature = "stdweb", recursion_limit="128")]
 
 #[cfg(feature="std")] extern crate std as core;


### PR DESCRIPTION
See https://github.com/rust-lang-nursery/rand/pull/346.