### PR TITLE
Use imported thread_rng() in main doc example.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! use rand::{Rng, thread_rng};
 //!
 //! // thread_rng is often the most convenient source of randomness:
-//! let mut rng = rand::thread_rng();
+//! let mut rng = thread_rng();
 //! if rng.gen() { // random bool
 //!     let x: f64 = rng.gen(); // random number in range (0, 1)
 //!     println!("x is: {}", x);


### PR DESCRIPTION
The first crate example in https://doc.rust-lang.org/rand/rand/index.html imports `rand::thread_rng` but doesn't use it. I'm just proposing to remove the `rand::` in the function call, as using code like in the example would raise a compiler warning.

Thanks!