### PR TITLE
Rename NewRng::new → FromEntropy::from_entropy

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -77,14 +77,14 @@ A few methods from the old `Rng` have been removed or deprecated:
 
 ##### New randomly-initialised PRNGs
 
-A new trait has been added: `NewRng`. This is automatically implemented for any
-type supporting `SeedableRng`, and provides construction from fresh, strong
+A new trait has been added: `FromEntropy`. This is automatically implemented for
+any type supporting `SeedableRng`, and provides construction from fresh, strong
 entropy:
 
 ```rust
-use rand::{ChaChaRng, NewRng};
+use rand::{ChaChaRng, FromEntropy};
 
-let mut rng = ChaChaRng::new();
+let mut rng = ChaChaRng::from_entropy();
 ```
 
 ##### Seeding PRNGs
@@ -142,7 +142,7 @@ The following use the new error type:
 -   `RngCore::try_fill_bytes`
 -   `Rng::try_fill`
 -   `OsRng::new`
--   `jitter::new`
+-   `JitterRng::new`
 
 ### External generators
 
@@ -150,7 +150,7 @@ We have a new generator, `EntropyRng`, which wraps `OsRng` and `JitterRng`
 (preferring to use the former, but falling back to the latter if necessary).
 This allows easy construction with fallback via `SeedableRng::from_rng`,
 e.g. `IsaacRng::from_rng(EntropyRng::new())?`. This is equivalent to using
-`NewRng` except for error handling.
+`FromEntropy` except for error handling.
 
 It is recommended to use `EntropyRng` over `OsRng` to avoid errors on platforms
 with broken system generator, but it should be noted that the `JitterRng`
@@ -205,7 +205,7 @@ The `random()` function has been removed; users may simply use
 `thread_rng().gen()` instead or may choose to cache
 `let mut rng = thread_rng();` locally, or even use a different generator.
 
-`weak_rng()` has been deprecated; use `SmallRng::new()` instead.
+`weak_rng()` has been deprecated; use `SmallRng::from_entropy()` instead.
 
 ### Distributions
 

--- a/benches/distributions.rs
+++ b/benches/distributions.rs
@@ -9,14 +9,14 @@ const RAND_BENCH_N: u64 = 1000;
 use std::mem::size_of;
 use test::{black_box, Bencher};
 
-use rand::{Rng, NewRng, XorShiftRng};
+use rand::{Rng, FromEntropy, XorShiftRng};
 use rand::distributions::*;
 
 macro_rules! distr_int {
     ($fnn:ident, $ty:ty, $distr:expr) => {
         #[bench]
         fn $fnn(b: &mut Bencher) {
-            let mut rng = XorShiftRng::new();
+            let mut rng = XorShiftRng::from_entropy();
             let distr = $distr;
 
             b.iter(|| {
@@ -36,7 +36,7 @@ macro_rules! distr_float {
     ($fnn:ident, $ty:ty, $distr:expr) => {
         #[bench]
         fn $fnn(b: &mut Bencher) {
-            let mut rng = XorShiftRng::new();
+            let mut rng = XorShiftRng::from_entropy();
             let distr = $distr;
 
             b.iter(|| {
@@ -56,7 +56,7 @@ macro_rules! distr {
     ($fnn:ident, $ty:ty, $distr:expr) => {
         #[bench]
         fn $fnn(b: &mut Bencher) {
-            let mut rng = XorShiftRng::new();
+            let mut rng = XorShiftRng::from_entropy();
             let distr = $distr;
 
             b.iter(|| {
@@ -111,7 +111,7 @@ macro_rules! gen_range_int {
     ($fnn:ident, $ty:ident, $low:expr, $high:expr) => {
         #[bench]
         fn $fnn(b: &mut Bencher) {
-            let mut rng = XorShiftRng::new();
+            let mut rng = XorShiftRng::from_entropy();
 
             b.iter(|| {
                 let mut high = $high;
@@ -137,7 +137,7 @@ gen_range_int!(gen_range_i128, i128, -12345678901234i128, 123_456_789_123_456_78
 
 #[bench]
 fn dist_iter(b: &mut Bencher) {
-    let mut rng = XorShiftRng::new();
+    let mut rng = XorShiftRng::from_entropy();
     let distr = Normal::new(-2.71828, 3.14159);
     let mut iter = distr.sample_iter(&mut rng);
 

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -98,7 +98,7 @@ pub mod le;
 ///   original (i.e. all deterministic PRNGs but not external generators)
 /// - *never* implement `Copy` (accidental copies may cause repeated values)
 /// - also *do not* implement `Default`, but instead implement `SeedableRng`
-///   thus allowing use of `rand::NewRng` (which is automatically implemented)
+///   thus allowing use of `rand::FromEntropy` (which is automatically implemented)
 /// - `Eq` and `PartialEq` could be implemented, but are probably not useful
 /// 
 /// # Example
@@ -270,10 +270,11 @@ pub trait CryptoRng {}
 /// This trait encapsulates the low-level functionality common to all
 /// pseudo-random number generators (PRNGs, or algorithmic generators).
 /// 
-/// The [`rand::NewRng`] trait is automatically implemented for every type
-/// implementing `SeedableRng`, providing a convenient `new()` method.
+/// The [`rand::FromEntropy`] trait is automatically implemented for every type
+/// implementing `SeedableRng`, providing a convenient `from_entropy()`
+/// constructor.
 /// 
-/// [`rand::NewRng`]: ../rand/trait.NewRng.html
+/// [`rand::FromEntropy`]: ../rand/trait.FromEntropy.html
 pub trait SeedableRng: Sized {
     /// Seed type, which is restricted to types mutably-dereferencable as `u8`
     /// arrays (we recommend `[u8; N]` for some `N`).
@@ -348,7 +349,8 @@ pub trait SeedableRng: Sized {
     /// Create a new PRNG seeded from another `Rng`.
     ///
     /// This is the recommended way to initialize PRNGs with fresh entropy. The
-    /// [`NewRng`] trait provides a convenient new method based on `from_rng`.
+    /// [`FromEntropy`] trait provides a convenient `from_entropy` method
+    /// based on `from_rng`.
     /// 
     /// Usage of this method is not recommended when reproducibility is required
     /// since implementing PRNGs are not required to fix Endianness and are
@@ -374,7 +376,7 @@ pub trait SeedableRng: Sized {
     /// PRNG implementations are allowed to assume that a good RNG is provided
     /// for seeding, and that it is cryptographically secure when appropriate.
     /// 
-    /// [`NewRng`]: ../rand/trait.NewRng.html
+    /// [`FromEntropy`]: ../rand/trait.FromEntropy.html
     /// [`OsRng`]: ../rand/os/struct.OsRng.html
     fn from_rng<R: RngCore>(mut rng: R) -> Result<Self, Error> {
         let mut seed = Self::Seed::default();

--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -30,10 +30,10 @@ use distributions::{ziggurat, ziggurat_tables, Distribution};
 ///
 /// # Example
 /// ```rust
-/// use rand::{NewRng, SmallRng, Rng};
+/// use rand::{FromEntropy, SmallRng, Rng};
 /// use rand::distributions::Exp1;
 ///
-/// let val: f64 = SmallRng::new().sample(Exp1);
+/// let val: f64 = SmallRng::from_entropy().sample(Exp1);
 /// println!("{}", val);
 /// ```
 #[derive(Clone, Copy, Debug)]

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -244,10 +244,10 @@ impl<'a, T, D: Distribution<T>> Distribution<T> for &'a D {
 ///
 /// # Example
 /// ```rust
-/// use rand::{NewRng, SmallRng, Rng};
+/// use rand::{FromEntropy, SmallRng, Rng};
 /// use rand::distributions::Standard;
 ///
-/// let val: f32 = SmallRng::new().sample(Standard);
+/// let val: f32 = SmallRng::from_entropy().sample(Standard);
 /// println!("f32 from (0,1): {}", val);
 /// ```
 ///

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -28,10 +28,10 @@ use distributions::{ziggurat, ziggurat_tables, Distribution};
 ///
 /// # Example
 /// ```rust
-/// use rand::{NewRng, SmallRng, Rng};
+/// use rand::{FromEntropy, SmallRng, Rng};
 /// use rand::distributions::StandardNormal;
 ///
-/// let val: f64 = SmallRng::new().sample(StandardNormal);
+/// let val: f64 = SmallRng::from_entropy().sample(StandardNormal);
 /// println!("{}", val);
 /// ```
 #[derive(Clone, Copy, Debug)]

--- a/src/prng/chacha.rs
+++ b/src/prng/chacha.rs
@@ -124,7 +124,7 @@ impl ChaChaRng {
     ///
     /// - 2917185654
     /// - 2419978656
-    #[deprecated(since="0.5.0", note="use the NewRng or SeedableRng trait")]
+    #[deprecated(since="0.5.0", note="use the FromEntropy or SeedableRng trait")]
     pub fn new_unseeded() -> ChaChaRng {
         ChaChaRng::from_seed([0; SEED_WORDS*4])
     }
@@ -145,7 +145,7 @@ impl ChaChaRng {
     /// ```rust
     /// use rand::{ChaChaRng, RngCore, SeedableRng};
     ///
-    /// // Note: Use `NewRng` or `ChaChaRng::from_rng()` outside of testing.
+    /// // Note: Use `FromEntropy` or `ChaChaRng::from_rng()` outside of testing.
     /// let mut rng1 = ChaChaRng::from_seed([0; 32]);
     /// let mut rng2 = rng1.clone();
     ///
@@ -172,7 +172,7 @@ impl ChaChaRng {
     /// ```rust
     /// use rand::{ChaChaRng, RngCore, SeedableRng};
     ///
-    /// // Note: Use `NewRng` or `ChaChaRng::from_rng()` outside of testing.
+    /// // Note: Use `FromEntropy` or `ChaChaRng::from_rng()` outside of testing.
     /// let mut rng = ChaChaRng::from_seed([0; 32]);
     /// rng.set_rounds(8);
     ///

--- a/src/prng/isaac.rs
+++ b/src/prng/isaac.rs
@@ -127,7 +127,7 @@ impl IsaacRng {
     /// fixed seed.
     ///
     /// DEPRECATED. `IsaacRng::new_from_u64(0)` will produce identical results.
-    #[deprecated(since="0.5.0", note="use the NewRng or SeedableRng trait")]
+    #[deprecated(since="0.5.0", note="use the FromEntropy or SeedableRng trait")]
     pub fn new_unseeded() -> Self {
         Self::new_from_u64(0)
     }

--- a/src/prng/isaac64.rs
+++ b/src/prng/isaac64.rs
@@ -117,7 +117,7 @@ impl Isaac64Rng {
     /// default fixed seed.
     ///
     /// DEPRECATED. `Isaac64Rng::new_from_u64(0)` will produce identical results.
-    #[deprecated(since="0.5.0", note="use the NewRng or SeedableRng trait")]
+    #[deprecated(since="0.5.0", note="use the FromEntropy or SeedableRng trait")]
     pub fn new_unseeded() -> Self {
         Self::new_from_u64(0)
     }

--- a/src/prng/xorshift.rs
+++ b/src/prng/xorshift.rs
@@ -47,7 +47,7 @@ impl XorShiftRng {
     /// by this function will yield the same stream of random numbers. It is
     /// highly recommended that this is created through `SeedableRng` instead of
     /// this function
-    #[deprecated(since="0.5.0", note="use the NewRng or SeedableRng trait")]
+    #[deprecated(since="0.5.0", note="use the FromEntropy or SeedableRng trait")]
     pub fn new_unseeded() -> XorShiftRng {
         XorShiftRng {
             x: w(0x193a6754),


### PR DESCRIPTION
Implement #360.

I wanted to try this, but personally I'm not so keen.

Advantage:

- it's clearer what `SmallRng::from_entropy()` does than `SmallRng::new()`

Disadvantages:

- inconsistent with `OsRng::new()?`
- `from_entropy` is a little long

Alternatives:

- `SmallRng::from_rng(entropy_rng())?` — but this is longer and has error handling
- `NewRng::new_fresh()` — just a rename