### PR TITLE
Suggest `gen_range` as alternative for [0, 1)

### DIFF
--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -248,7 +248,7 @@ impl<'a, T, D: Distribution<T>> Distribution<T> for &'a D {
 /// let mut rng = thread_rng();
 /// let erased_rng: &mut RngCore = &mut rng;
 /// let val: f32 = erased_rng.sample(Standard);
-/// println!("f32 from (0,1): {}", val);
+/// println!("f32 from (0, 1): {}", val);
 /// ```
 ///
 /// # Open interval for floats
@@ -270,6 +270,17 @@ impl<'a, T, D: Distribution<T>> Distribution<T> for &'a D {
 /// In other words, the guarantee some value *could* be generated is less useful
 /// than the guarantee some value (`0.0`) is never generated. That makes an open
 /// interval a nicer choice.
+///
+/// Consider using `Rng::gen_range` if you really need a half-open interval (as
+/// the ranges use a half-open interval). It has the same performance. Example:
+///
+/// ```
+/// use rand::{thread_rng, Rng};
+///
+/// let mut rng = thread_rng();
+/// let val = rng.gen_range(0.0f32, 1.0);
+/// println!("f32 from [0, 1): {}", val);
+/// ```
 ///
 /// [`Exp1`]: struct.Exp1.html
 /// [`StandardNormal`]: struct.StandardNormal.html

--- a/src/distributions/range.rs
+++ b/src/distributions/range.rs
@@ -287,8 +287,8 @@ macro_rules! range_int_impl {
             }
 
             fn sample_single<R: Rng + ?Sized>(low: Self::X,
-                                                  high: Self::X,
-                                                  rng: &mut R) -> Self::X
+                                              high: Self::X,
+                                              rng: &mut R) -> Self::X
             {
                 let range = (high as $u_large)
                             .wrapping_sub(low as $u_large);
@@ -457,6 +457,19 @@ macro_rules! range_float_impl {
                 // Doing multiply before addition allows some architectures to
                 // use a single instruction.
                 value1_2 * self.scale + self.offset
+            }
+
+            fn sample_single<R: Rng + ?Sized>(low: Self::X,
+                                              high: Self::X,
+                                              rng: &mut R) -> Self::X {
+                let scale = high - low;
+                let offset = low - scale;
+                // Generate a value in the range [1, 2)
+                let value1_2 = (rng.$next_u() >> $bits_to_discard)
+                               .into_float_with_exponent(0);
+                // Doing multiply before addition allows some architectures to
+                // use a single instruction.
+                value1_2 * scale + offset
             }
         }
     }


### PR DESCRIPTION
I needed to inline things into `sample_single` to get LLVM to optimize out the multiply and addition.