### PR TITLE
Add RngCore::bytes_per_round

### DIFF
--- a/benches/distributions.rs
+++ b/benches/distributions.rs
@@ -1,5 +1,6 @@
 #![feature(test)]
-#![cfg_attr(feature = "i128_support", feature(i128_type, i128))]
+#![cfg_attr(all(feature="i128_support", feature="nightly"), allow(stable_features))] // stable since 2018-03-27
+#![cfg_attr(all(feature="i128_support", feature="nightly"), feature(i128_type, i128))]
 
 extern crate test;
 extern crate rand;

--- a/benches/generators.rs
+++ b/benches/generators.rs
@@ -1,4 +1,6 @@
 #![feature(test)]
+#![cfg_attr(all(feature="i128_support", feature="nightly"), allow(stable_features))] // stable since 2018-03-27
+#![cfg_attr(all(feature="i128_support", feature="nightly"), feature(i128_type, i128))]
 
 extern crate test;
 extern crate rand;
@@ -73,6 +75,10 @@ gen_uint!(gen_u64_isaac64, u64, Isaac64Rng::new());
 gen_uint!(gen_u64_std, u64, StdRng::new());
 gen_uint!(gen_u64_small, u64, SmallRng::new());
 gen_uint!(gen_u64_os, u64, OsRng::new().unwrap());
+
+#[cfg(feature = "i128_support")] gen_uint!(gen_u128_xorshift, u128, XorShiftRng::new());
+#[cfg(feature = "i128_support")] gen_uint!(gen_u128_hc128, u128, Hc128Rng::new());
+#[cfg(feature = "i128_support")] gen_uint!(gen_u128_os, u128, OsRng::new().unwrap());
 
 // Do not test JitterRng like the others by running it RAND_BENCH_N times per,
 // measurement, because it is way too slow. Only run it once.

--- a/benches/generators.rs
+++ b/benches/generators.rs
@@ -46,6 +46,7 @@ gen_bytes!(gen_bytes_os, OsRng::new().unwrap());
 macro_rules! gen_uint {
     ($fnn:ident, $ty:ty, $gen:expr) => {
         #[bench]
+        #[allow(unused_mut)]
         fn $fnn(b: &mut Bencher) {
             let mut rng = $gen;
             b.iter(|| {
@@ -79,6 +80,8 @@ gen_uint!(gen_u64_os, u64, OsRng::new().unwrap());
 #[cfg(feature = "i128_support")] gen_uint!(gen_u128_xorshift, u128, XorShiftRng::new());
 #[cfg(feature = "i128_support")] gen_uint!(gen_u128_hc128, u128, Hc128Rng::new());
 #[cfg(feature = "i128_support")] gen_uint!(gen_u128_os, u128, OsRng::new().unwrap());
+#[cfg(feature = "i128_support")]
+gen_uint!(gen_u128_hc128_trait_obj, u128, &mut Hc128Rng::new() as &mut RngCore);
 
 // Do not test JitterRng like the others by running it RAND_BENCH_N times per,
 // measurement, because it is way too slow. Only run it once.

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -186,6 +186,19 @@ pub trait RngCore {
     /// 
     /// [`fill_bytes`]: trait.RngCore.html#method.fill_bytes
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error>;
+
+    /// Number of bytes generated per round of this RNG.
+    ///
+    /// Some algorithms would benefit from knowing some basic properties about
+    /// the RNG. In terms of performance an algorithm may want to know whether
+    /// an RNG is best at generating `u32`s, or could provide `u64`s or more at
+    /// little to no extra cost.
+    ///
+    /// For many RNGs a simple definition is: the smallest number of bytes this
+    /// RNG can generate without throwing away part of the generated value.
+    ///
+    /// `bytes_per_round` has a default implementation that returns `4` (bytes).
+    fn bytes_per_round(&self) -> usize { 4 }
 }
 
 /// A trait for RNGs which do not generate random numbers individually, but in
@@ -403,6 +416,10 @@ impl<'a, R: RngCore + ?Sized> RngCore for &'a mut R {
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         (**self).try_fill_bytes(dest)
     }
+
+    fn bytes_per_round(&self) -> usize {
+        (**self).bytes_per_round()
+    }
 }
 
 #[cfg(feature="alloc")]
@@ -423,5 +440,9 @@ impl<R: RngCore + ?Sized> RngCore for Box<R> {
 
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         (**self).try_fill_bytes(dest)
+    }
+
+    fn bytes_per_round(&self) -> usize {
+        (**self).bytes_per_round()
     }
 }

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -397,7 +397,9 @@ pub trait SeedableRng: Sized {
     }
 }
 
-
+// Implement `RngCore` for references to an `RngCore`.
+// Force inlining all functions, so that it is up to the `RngCore`
+// implementation and the optimizer to decide on inlining.
 impl<'a, R: RngCore + ?Sized> RngCore for &'a mut R {
     #[inline(always)]
     fn next_u32(&mut self) -> u32 {
@@ -409,10 +411,12 @@ impl<'a, R: RngCore + ?Sized> RngCore for &'a mut R {
         (**self).next_u64()
     }
 
+    #[inline(always)]
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         (**self).fill_bytes(dest)
     }
 
+    #[inline(always)]
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         (**self).try_fill_bytes(dest)
     }
@@ -422,6 +426,9 @@ impl<'a, R: RngCore + ?Sized> RngCore for &'a mut R {
     }
 }
 
+// Implement `RngCore` for boxed references to an `RngCore`.
+// Force inlining all functions, so that it is up to the `RngCore`
+// implementation and the optimizer to decide on inlining.
 #[cfg(feature="alloc")]
 impl<R: RngCore + ?Sized> RngCore for Box<R> {
     #[inline(always)]
@@ -434,10 +441,12 @@ impl<R: RngCore + ?Sized> RngCore for Box<R> {
         (**self).next_u64()
     }
 
+    #[inline(always)]
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         (**self).fill_bytes(dest)
     }
 
+    #[inline(always)]
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         (**self).try_fill_bytes(dest)
     }

--- a/src/distributions/integer.rs
+++ b/src/distributions/integer.rs
@@ -13,63 +13,6 @@
 use {Rng};
 use distributions::{Distribution, Standard};
 
-impl Distribution<isize> for Standard {
-    #[inline]
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> isize {
-        rng.gen::<usize>() as isize
-    }
-}
-
-impl Distribution<i8> for Standard {
-    #[inline]
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> i8 {
-        rng.next_u32() as i8
-    }
-}
-
-impl Distribution<i16> for Standard {
-    #[inline]
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> i16 {
-        rng.next_u32() as i16
-    }
-}
-
-impl Distribution<i32> for Standard {
-    #[inline]
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> i32 {
-        rng.next_u32() as i32
-    }
-}
-
-impl Distribution<i64> for Standard {
-    #[inline]
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> i64 {
-        rng.next_u64() as i64
-    }
-}
-
-#[cfg(feature = "i128_support")]
-impl Distribution<i128> for Standard {
-    #[inline]
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> i128 {
-        rng.gen::<u128>() as i128
-    }
-}
-
-impl Distribution<usize> for Standard {
-    #[inline]
-    #[cfg(any(target_pointer_width = "32", target_pointer_width = "16"))]
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> usize {
-        rng.next_u32() as usize
-    }
-
-    #[inline]
-    #[cfg(target_pointer_width = "64")]
-    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> usize {
-        rng.next_u64() as usize
-    }
-}
-
 impl Distribution<u8> for Standard {
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> u8 {
@@ -102,12 +45,54 @@ impl Distribution<u64> for Standard {
 impl Distribution<u128> for Standard {
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> u128 {
-        // Use LE; we explicitly generate one value before the next.
-        let x = rng.next_u64() as u128;
-        let y = rng.next_u64() as u128;
-        (y << 64) | x
+        if rng.bytes_per_round() < 128 {
+            // Use LE; we explicitly generate one value before the next.
+            let x = rng.next_u64() as u128;
+            let y = rng.next_u64() as u128;
+            (y << 64) | x
+        } else {
+            let mut val = 0u128;
+            unsafe {
+                let ptr = &mut val;
+                let b_ptr = &mut *(ptr as *mut u128 as *mut [u8; 16]);
+                rng.fill_bytes(b_ptr);
+            }
+            val.to_le()
+        }
     }
 }
+
+impl Distribution<usize> for Standard {
+    #[inline]
+    #[cfg(any(target_pointer_width = "32", target_pointer_width = "16"))]
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> usize {
+        rng.next_u32() as usize
+    }
+
+    #[inline]
+    #[cfg(target_pointer_width = "64")]
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> usize {
+        rng.next_u64() as usize
+    }
+}
+
+macro_rules! impl_int_from_uint {
+    ($ty:ty, $uty:ty) => {
+        impl Distribution<$ty> for Standard {
+            #[inline]
+            fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $ty {
+                rng.gen::<$uty>() as $ty
+            }
+        }
+    }
+}
+
+impl_int_from_uint! { i8, u8 }
+impl_int_from_uint! { i16, u16 }
+impl_int_from_uint! { i32, u32 }
+impl_int_from_uint! { i64, u64 }
+#[cfg(feature = "i128_support")] impl_int_from_uint! { i128, u128 }
+impl_int_from_uint! { isize, usize }
 
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -849,6 +849,10 @@ impl RngCore for StdRng {
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         self.0.try_fill_bytes(dest)
     }
+
+    fn bytes_per_round(&self) -> usize {
+        self.0.bytes_per_round()
+    }
 }
 
 impl SeedableRng for StdRng {
@@ -936,6 +940,10 @@ impl RngCore for SmallRng {
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         self.0.try_fill_bytes(dest)
     }
+
+    fn bytes_per_round(&self) -> usize {
+        self.0.bytes_per_round()
+    }
 }
 
 impl SeedableRng for SmallRng {
@@ -1016,6 +1024,9 @@ mod test {
         }
         fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
             self.inner.try_fill_bytes(dest)
+        }
+        fn bytes_per_round(&self) -> usize {
+            self.inner.bytes_per_round()
         }
     }
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -58,4 +58,6 @@ impl RngCore for StepRng {
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         Ok(self.fill_bytes(dest))
     }
+
+    fn bytes_per_round(&self) -> usize { 8 }
 }

--- a/src/os.rs
+++ b/src/os.rs
@@ -131,6 +131,14 @@ impl RngCore for OsRng {
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         self.0.try_fill_bytes(dest)
     }
+
+    fn bytes_per_round(&self) -> usize {
+        // The overhead of doing a syscall is large compared to the time
+        // it takes to generate the values. Requesting many values at a time is
+        // often faster than only one at a time.
+        // 256 is the limit some operating systems have per system call.
+        256
+    }
 }
 
 #[cfg(all(unix,

--- a/src/reseeding.rs
+++ b/src/reseeding.rs
@@ -101,6 +101,10 @@ where R: BlockRngCore<Item = u32> + SeedableRng,
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         self.0.try_fill_bytes(dest)
     }
+
+    fn bytes_per_round(&self) -> usize {
+        self.0.bytes_per_round()
+    }
 }
 
 impl<R, Rsdr> CryptoRng for ReseedingRng<R, Rsdr>


### PR DESCRIPTION
From the doc comment:
> Number of bytes generated per round of this RNG.
>
> Some algorithms would benefit from knowing some basic properties about the RNG. In terms of performance an algorithm may want to know whether an RNG is best at generating `u32`s, or could provide `u64`s or more at little to no extra cost.
>
> For many RNGs a simple definition is: the smallest number of bytes this RNG can generate without throwing away part of the generated value.
>
> `bytes_per_round` has a default implementation that returns `4` (bytes).

I have thought quite a few times over the last couple of months: It would be great to know if this is a 32 or 64-bit RNG. Then I could implement this algorithm more optimally. Now, when playing with SIMD, this became even more visible.

I added one example in this PR: generating an `u128`. For most RNGs the current method of combining to `u64`s is optimal. But for `OsRng` and SIMD RNGs it would be twice as fast two use `fill_bytes`. Now it can make the choice.

The same is true for `HighPrecision01`. The implementation for `f32` now always uses `next_u32`. With a 64-bit RNG it always throws away half the generated bits. And when it finds out it needs more, generates another 32. It could easily be made more optimal, if only we knew whether the RNG is best at generating 32 or 64 bit at a time.

And a bit more controversial: `gen_bool` now uses 32 bits to make its decision on. Fast and usually good enough. Using 64 bits could halve the performance for many RNGs. But if the RNG produces 64 bits at a time (and throws away half of it), it could just as well use them to increase precision at no extra cost.