### PR TITLE
Optimize `fill_bytes_via_*` and prepare rand_core 0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ You may also find the [Update Guide](UPDATING.md) useful.
 - Add `Error` and `ErrorKind`. (#225)
 - Add `CryptoRng` marker trait. (#273)
 - Add `BlockRngCore` trait. (#281)
-- Add `BlockRng` wrapper to help implementations. (#281)
+- Add `BlockRng` and `BlockRng64` wrappers to help implementations. (#281, #325)
 - Revise the `SeedableRng` trait. (#233)
 - Remove default implementations for `RngCore::next_u64` and `RngCore::fill_bytes`. (#288)
 - Add `RngCore::try_fill_bytes`. (#225)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde1 = ["serde", "serde_derive", "rand_core/serde1"] # enables serialization f
 members = ["rand_core"]
 
 [dependencies]
-rand_core = { path="rand_core", default-features = false }
+rand_core = { path = "rand_core", version = "0.1.0-pre.0", default-features = false }
 log = { version = "0.4", optional = true }
 serde = { version = "1", optional = true }
 serde_derive = { version = "1", optional = true }

--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `Error` and `ErrorKind`. (#225)
 - Add `CryptoRng` marker trait. (#273)
 - Add `BlockRngCore` trait. (#281)
-- Add `BlockRng` wrapper to help implemtations. (#281)
+- Add `BlockRng` and `BlockRng64` wrappers to help implementations. (#281, #325)
 - Revise the `SeedableRng` trait. (#233)
 - Remove default implementations for `RngCore::next_u64` and `RngCore::fill_bytes`. (#288)
 - Add `RngCore::try_fill_bytes`. (#225)

--- a/rand_core/README.md
+++ b/rand_core/README.md
@@ -50,6 +50,9 @@ Due to [rust-lang/cargo#1596](https://github.com/rust-lang/cargo/issues/1596),
 unioned across the whole dependency tree, any crate using `rand` with its
 default features will also enable `std` support in `rand_core`.
 
+The `serde1` feature can be used to derive `Serialize` and `Deserialize` for RNG
+implementations that use the `BlockRng` or `BlockRng64` wrappers.
+
 
 # License
 

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -35,7 +35,7 @@
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-       html_root_url = "https://docs.rs/rand_core/0.1")]
+       html_root_url = "https://docs.rs/rand_core/0.1.0-pre.0")]
 
 #![deny(missing_debug_implementations)]
 

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -121,7 +121,7 @@ pub mod le;
 ///     }
 ///     
 ///     fn fill_bytes(&mut self, dest: &mut [u8]) {
-///         impls::fill_bytes_via_u64(self, dest)
+///         impls::fill_bytes_via_next(self, dest)
 ///     }
 ///     
 ///     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
@@ -160,8 +160,7 @@ pub trait RngCore {
     ///
     /// RNGs must implement at least one method from this trait directly. In
     /// the case this method is not implemented directly, it can be implemented
-    /// [via `next_u32`](../rand_core/impls/fn.fill_bytes_via_u32.html) or
-    /// [via `next_u64`](../rand_core/impls/fn.fill_bytes_via_u64.html) or
+    /// [via `next_u*`](../rand_core/impls/fn.fill_bytes_via_next.html) or
     /// via `try_fill_bytes`; if this generator can fail the implementation
     /// must choose how best to handle errors here (e.g. panic with a
     /// descriptive message or log a warning and retry a few times).

--- a/src/jitter.rs
+++ b/src/jitter.rs
@@ -804,7 +804,7 @@ impl RngCore for JitterRng {
         //
         // This is done especially for wrappers that implement `next_u32`
         // themselves via `fill_bytes`.
-        impls::fill_bytes_via_u32(self, dest)
+        impls::fill_bytes_via_next(self, dest)
     }
 
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -52,7 +52,7 @@ impl RngCore for StepRng {
     }
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {
-        impls::fill_bytes_via_u64(self, dest);
+        impls::fill_bytes_via_next(self, dest);
     }
 
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {

--- a/src/prng/xorshift.rs
+++ b/src/prng/xorshift.rs
@@ -71,12 +71,14 @@ impl RngCore for XorShiftRng {
         self.w.0
     }
 
+    #[inline]
     fn next_u64(&mut self) -> u64 {
         impls::next_u64_via_u32(self)
     }
 
+    #[inline]
     fn fill_bytes(&mut self, dest: &mut [u8]) {
-        impls::fill_bytes_via_u32(self, dest)
+        impls::fill_bytes_via_next(self, dest)
     }
 
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {


### PR DESCRIPTION
Benchmark before:
```
test gen_bytes_xorshift    ... bench:   1,131,259 ns/iter (+/- 2,399) = 905 MB/s
```

After:
```
test gen_bytes_xorshift    ... bench:     284,238 ns/iter (+/- 906) = 3602 MB/s
```

I updated the version number, changelog and readme of `rand_core` for a 0.1.0 release. I hope https://github.com/rust-lang-nursery/rand/pull/383 and https://github.com/rust-lang-nursery/rand/pull/396 can me merged first. The date in the changelog is set to 2018-04-15, this Sunday. @dhardy Do you think that is realistic?