### PR TITLE
Release: prepare rand_core 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ You may also find the [Update Guide](UPDATING.md) useful.
 - Deprecate `Rng::gen_ascii_chars`. (#279)
 
 ### `rand_core` crate
-(changes included here because they greatly influence the Rand crate)
+- `rand` now depends on new `rand_core` crate (#288)
 - `RngCore` and `SeedableRng` are now part of `rand_core`. (#288)
 - Add modules to help implementing RNGs `impl` and `le`. (#209, #228)
 - Add `Error` and `ErrorKind`. (#225)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde1 = ["serde", "serde_derive", "rand_core/serde1"] # enables serialization f
 members = ["rand_core"]
 
 [dependencies]
-rand_core = { path = "rand_core", version = "0.1.0-pre.0", default-features = false }
+rand_core = { path = "rand_core", version = "0.1.0", default-features = false }
 log = { version = "0.4", optional = true }
 serde = { version = "1", optional = true }
 serde_derive = { version = "1", optional = true }

--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.1.0] - Unreleased
+## [0.1.0] - TODO - date
 (Split out of the Rand crate, changes here are relative to rand 0.4.2)
 - `RngCore` and `SeedableRng` are now part of `rand_core`. (#288)
 - Add modules to help implementing RNGs `impl` and `le`. (#209, #228)

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_core"
-version = "0.1.0-pre.0" # NB: When modifying, also modify html_root_url in lib.rs
+version = "0.1.0" # NB: When modifying, also modify html_root_url in lib.rs
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -35,7 +35,7 @@
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-       html_root_url = "https://docs.rs/rand_core/0.1.0-pre.0")]
+       html_root_url = "https://docs.rs/rand_core/0.1.0")]
 
 #![deny(missing_debug_implementations)]
 


### PR DESCRIPTION
Are we ready for the release?

#396 affects `rand_core` but personally I'd prefer to wait a bit on this one (it can be added with 0.2.0 or even 0.1.1 if the default implementation of `bytes_per_round` is kept).