### PR TITLE
Enable std by default in rand_core; adjust CI targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,29 +11,32 @@ matrix:
     - rust: 1.22.0
       install:
       script:
-        - cargo test --all --tests --no-default-features
+        - cargo test --tests --no-default-features
+        - cargo test --package rand_core --no-default-features
         - cargo test --features serde1,log
     - rust: stable
       os: osx
       install:
       script:
-        - cargo test --all --tests --no-default-features
+        - cargo test --tests --no-default-features
+        - cargo test --package rand_core --no-default-features
         - cargo test --features serde1,log
     - rust: beta
       install:
       script:
-        - cargo test --all --tests --no-default-features
-        - cargo test --tests --no-default-features --features=serde1
+        - cargo test --tests --no-default-features
+        - cargo test --package rand_core --no-default-features
+        - cargo test --features serde1,log
     - rust: nightly
       install:
         - cargo --list | egrep "^\s*deadlinks$" -q || cargo install cargo-deadlinks
       before_script:
         - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
       script:
-        - cargo test --all --tests --no-default-features --features=alloc
-        - cargo test --all --features=alloc
-        - cargo test --features serde1,log,nightly
-        - cargo test --benches
+        - cargo test --tests --no-default-features --features=alloc
+        - cargo test --package rand_core --no-default-features --features=alloc,serde1
+        - cargo test --features serde1,log,nightly,alloc
+        - cargo test --all --benches
         - cargo doc --no-deps --all --all-features
         - cargo deadlinks --dir target/doc
       after_success:
@@ -56,7 +59,7 @@ matrix:
         - rustup target add thumbv6m-none-eabi
       script:
         # Bare metal target; no std; only works on nightly
-        - cargo build --all --no-default-features --target thumbv6m-none-eabi --release
+        - cargo build --no-default-features --target thumbv6m-none-eabi --release
 
     # Trust cross-built/emulated targets. We must repeat all non-default values.
     - rust: stable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,8 +32,8 @@ install:
 build: false
 
 test_script:
-  - cargo test --benches
-  - cargo test --all
+  - cargo test --all # cannot use --all and --features together
+  - cargo test --all --benches
   - cargo test --features serde1,log,nightly
-  - cargo test --all --tests --no-default-features --features=alloc
-  - cargo test --tests --no-default-features --features=serde1
+  - cargo test --tests --no-default-features --features=alloc,serde1
+  - cargo test --package rand_core --no-default-features --features=alloc,serde1

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -18,8 +18,7 @@ travis-ci = { repository = "rust-lang-nursery/rand" }
 appveyor = { repository = "alexcrichton/rand" }
 
 [features]
-# Bug: https://github.com/rust-lang/cargo/issues/4361
-# default = ["std"]
+default = ["std"]
 std = ["alloc"]    # use std library; should be default but for above bug
 alloc = []  # enables Vec and Box support without std
 serde1 = ["serde", "serde_derive"] # enables serde for BlockRng wrapper

--- a/utils/ci/script.sh
+++ b/utils/ci/script.sh
@@ -3,20 +3,22 @@
 set -ex
 
 main() {
-    if [ ! -z $DISABLE_TESTS ]; then
-        cross build --all --no-default-features --target $TARGET --release
-        if [ -z $DISABLE_STD ]; then
+    if [ ! -z $DISABLE_TESTS ]; then    # tests are disabled
+        cross build --no-default-features --target $TARGET --release
+        if [ -z $DISABLE_STD ]; then    # std is enabled
             cross build --features log,serde1 --target $TARGET
         fi
         return
     fi
 
-    if [ ! -z $NIGHTLY ]; then
-        cross test --all --tests --no-default-features --features alloc --target $TARGET
-        cross test --features serde1,log,nightly --target $TARGET
+    if [ ! -z $NIGHTLY ]; then  # have nightly Rust
+        cross test --tests --no-default-features --features alloc --target $TARGET
+        cross test --package rand_core --no-default-features --features alloc --target $TARGET
+        cross test --features serde1,log,nightly,alloc --target $TARGET
         cross test --all --benches --target $TARGET
-    else
-        cross test --all --tests --no-default-features --target $TARGET
+    else    # have stable Rust
+        cross test --tests --no-default-features --target $TARGET
+        cross test --package rand_core --no-default-features --target $TARGET
         cross test --features serde1,log --target $TARGET
     fi
 }


### PR DESCRIPTION
Avoid using --all and --features together (fix #406)

Can we release rand_core 0.1.1 with this change?