### PR TITLE
Implement Bernoulli distribution

### DIFF
--- a/benches/misc.rs
+++ b/benches/misc.rs
@@ -11,14 +11,15 @@ use rand::prelude::*;
 use rand::seq::*;
 
 #[bench]
-fn misc_gen_bool(b: &mut Bencher) {
+fn misc_gen_bool_const(b: &mut Bencher) {
     let mut rng = SmallRng::from_rng(&mut thread_rng()).unwrap();
     b.iter(|| {
+        // Can be evaluated at compile time.
         let mut accum = true;
         for _ in 0..::RAND_BENCH_N {
             accum ^= rng.gen_bool(0.18);
         }
-        black_box(accum);
+        accum
     })
 }
 
@@ -27,25 +28,24 @@ fn misc_gen_bool_var(b: &mut Bencher) {
     let mut rng = SmallRng::from_rng(&mut thread_rng()).unwrap();
     b.iter(|| {
         let mut p = 0.18;
-        let mut accum = true;
+        black_box(&mut p);  // Avoid constant folding.
         for _ in 0..::RAND_BENCH_N {
-            accum ^= rng.gen_bool(p);
-            p += 0.0001;
+            black_box(rng.gen_bool(p));
         }
-        black_box(accum);
     })
 }
 
 #[bench]
-fn misc_bernoulli(b: &mut Bencher) {
+fn misc_bernoulli_const(b: &mut Bencher) {
     let mut rng = SmallRng::from_rng(&mut thread_rng()).unwrap();
     let d = rand::distributions::Bernoulli::new(0.18);
     b.iter(|| {
+        // Can be evaluated at compile time.
         let mut accum = true;
         for _ in 0..::RAND_BENCH_N {
             accum ^= rng.sample(d);
         }
-        black_box(accum);
+        accum
     })
 }
 
@@ -54,13 +54,11 @@ fn misc_bernoulli_var(b: &mut Bencher) {
     let mut rng = SmallRng::from_rng(&mut thread_rng()).unwrap();
     b.iter(|| {
         let mut p = 0.18;
-        let mut accum = true;
+        black_box(&mut p);  // Avoid constant folding.
+        let d = rand::distributions::Bernoulli::new(p);
         for _ in 0..::RAND_BENCH_N {
-            let d = rand::distributions::Bernoulli::new(p);
-            accum ^= rng.sample(d);
-            p += 0.0001;
+            black_box(rng.sample(d));
         }
-        black_box(accum);
     })
 }
 

--- a/benches/misc.rs
+++ b/benches/misc.rs
@@ -37,6 +37,34 @@ fn misc_gen_bool_var(b: &mut Bencher) {
 }
 
 #[bench]
+fn misc_bernoulli(b: &mut Bencher) {
+    let mut rng = SmallRng::from_rng(&mut thread_rng()).unwrap();
+    let d = rand::distributions::Bernoulli::new(0.18);
+    b.iter(|| {
+        let mut accum = true;
+        for _ in 0..::RAND_BENCH_N {
+            accum ^= rng.sample(d);
+        }
+        black_box(accum);
+    })
+}
+
+#[bench]
+fn misc_bernoulli_var(b: &mut Bencher) {
+    let mut rng = SmallRng::from_rng(&mut thread_rng()).unwrap();
+    b.iter(|| {
+        let mut p = 0.18;
+        let mut accum = true;
+        for _ in 0..::RAND_BENCH_N {
+            let d = rand::distributions::Bernoulli::new(p);
+            accum ^= rng.sample(d);
+            p += 0.0001;
+        }
+        black_box(accum);
+    })
+}
+
+#[bench]
 fn misc_shuffle_100(b: &mut Bencher) {
     let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
     let x : &mut [usize] = &mut [1; 100];

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -48,32 +48,20 @@ impl Bernoulli {
     ///
     /// For `p = 1.0`, the resulting distribution will always generate true.
     /// For `p = 0.0`, the resulting distribution will always generate false.
-    /// Due to the limitations of floating point numbers, not all internally
-    /// supported probabilities (multiples of 2<sup>-64</sup>) can be specified
-    /// using this constructor. If you need more precision, use
-    /// `Bernoulli::from_int` instead.
+    ///
+    /// This method is accurate for any input `p` in the range `[0, 1]` which is
+    /// a multiple of 2<sup>-64</sup>. If you need more precision, use `Uniform`
+    /// and a comparison instead. (Note that not all multiples of
+    /// 2<sup>-64</sup> in `[0, 1]` can be represented as a `f64`.)
     #[inline]
     pub fn new(p: f64) -> Bernoulli {
-        assert!(p >= 0.0, "Bernoulli::new called with p < 0");
-        assert!(p <= 1.0, "Bernoulli::new called with p > 1");
+        assert!(p >= 0.0 & p <= 1.0, "Bernoulli::new not called with 0 <= p <= 0");
         let p_int = if p < 1.0 {
             (p * (::core::u64::MAX as f64)) as u64
         } else {
             // Avoid overflow: u64::MAX as f64 cannot be represented as u64.
             ::core::u64::MAX
         };
-        Bernoulli { p_int }
-    }
-
-    /// Construct a new `Bernoulli` with the probability of success given as an
-    /// integer `p_int = p * 2^64`.
-    ///
-    /// `p_int = 0` corresponds to `p = 0.0`.
-    /// `p_int = u64::MAX` corresponds to `p = 1.0`.
-    ///
-    /// This is more precise than using `Bernoulli::new`.
-    #[inline]
-    pub fn from_int(p_int: u64) -> Bernoulli {
         Bernoulli { p_int }
     }
 }

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -13,7 +13,7 @@ use distributions::Distribution;
 /// use rand::distributions::{Bernoulli, Distribution};
 ///
 /// let d = Bernoulli::new(0.3);
-/// let v: u64 = d.sample(&mut rand::thread_rng());
+/// let v = d.sample(&mut rand::thread_rng());
 /// println!("{} is from a Bernoulli distribution", v);
 /// ```
 #[derive(Clone, Copy, Debug)]
@@ -42,36 +42,6 @@ impl Distribution<bool> for Bernoulli {
         rng.gen_bool(self.p)
     }
 }
-
-macro_rules! impl_bernoulli_int {
-    ($($t: ty), *) => {
-        $(
-            impl Distribution<$t> for Bernoulli {
-                #[inline]
-                fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $t {
-                    rng.gen_bool(self.p) as $t
-                }
-            }
-        )*
-    }
-}
-
-impl_bernoulli_int!(u8, u16, u32, u64, i8, i16, i32, i64);
-
-macro_rules! impl_bernoulli_float {
-    ($($t: ty), *) => {
-        $(
-            impl Distribution<$t> for Bernoulli {
-                #[inline]
-                fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $t {
-                    rng.gen_bool(self.p) as u8 as $t
-                }
-            }
-        )*
-    }
-}
-
-impl_bernoulli_float!(f32, f64);
 
 #[cfg(test)]
 mod test {
@@ -108,22 +78,5 @@ mod test {
         let avg = (sum as f64) / (N as f64);
 
         assert!((avg - P).abs() < 1e-3);
-    }
-
-    #[test]
-    fn test_nonbool() {
-
-        macro_rules! assert_nonbool {
-            ($($t: ty), *) => {
-                let d = Bernoulli::new(0.3);
-                let r = SmallRng::from_entropy();
-                $(
-                    assert_eq!(r.clone().sample::<$t, _>(&d) as f64 != 0.,
-                               r.clone().sample::<bool, _>(&d));
-                )*
-            }
-        }
-
-        assert_nonbool!(u8, u16, u32, u64, i8, i16, i32, i64, f32, f64);
     }
 }

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -1,0 +1,129 @@
+//! The Bernoulli distribution.
+
+use Rng;
+use distributions::Distribution;
+
+/// The Bernoulli distribution.
+///
+/// This is a special case of the Binomial distribution where `n = 1`.
+///
+/// # Example
+///
+/// ```rust
+/// use rand::distributions::{Bernoulli, Distribution};
+///
+/// let d = Bernoulli::new(0.3);
+/// let v: u64 = d.sample(&mut rand::thread_rng());
+/// println!("{} is from a Bernoulli distribution", v);
+/// ```
+#[derive(Clone, Copy, Debug)]
+pub struct Bernoulli {
+    /// Probability of success.
+    p: f64,
+}
+
+impl Bernoulli {
+    /// Construct a new `Bernoulli` with the given probability of success `p`.
+    ///
+    /// # Panics
+    ///
+    /// If `p < 0` or `p > 1`.
+    #[inline]
+    pub fn new(p: f64) -> Bernoulli {
+        assert!(p >= 0.0, "Bernoulli::new called with p < 0");
+        assert!(p <= 1.0, "Bernoulli::new called with p > 1");
+        Bernoulli { p }
+    }
+}
+
+impl Distribution<bool> for Bernoulli {
+    #[inline]
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> bool {
+        rng.gen_bool(self.p)
+    }
+}
+
+macro_rules! impl_bernoulli_int {
+    ($($t: ty), *) => {
+        $(
+            impl Distribution<$t> for Bernoulli {
+                #[inline]
+                fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $t {
+                    rng.gen_bool(self.p) as $t
+                }
+            }
+        )*
+    }
+}
+
+impl_bernoulli_int!(u8, u16, u32, u64, i8, i16, i32, i64);
+
+macro_rules! impl_bernoulli_float {
+    ($($t: ty), *) => {
+        $(
+            impl Distribution<$t> for Bernoulli {
+                #[inline]
+                fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $t {
+                    rng.gen_bool(self.p) as u8 as $t
+                }
+            }
+        )*
+    }
+}
+
+impl_bernoulli_float!(f32, f64);
+
+#[cfg(test)]
+mod test {
+    use {Rng, SmallRng, FromEntropy};
+    use distributions::Distribution;
+    use super::Bernoulli;
+
+    #[test]
+    fn test_trivial() {
+        let mut r = SmallRng::from_entropy();
+        let always_false = Bernoulli::new(0.0);
+        let always_true = Bernoulli::new(1.0);
+        for _ in 0..5 {
+            assert_eq!(r.sample::<bool, _>(&always_false), false);
+            assert_eq!(r.sample::<bool, _>(&always_true), true);
+            assert_eq!(Distribution::<bool>::sample(&always_false, &mut r), false);
+            assert_eq!(Distribution::<bool>::sample(&always_true, &mut r), true);
+        }
+    }
+
+    #[test]
+    fn test_average() {
+        const P: f64 = 0.3;
+        let d = Bernoulli::new(P);
+        const N: u32 = 10_000_000;
+
+        let mut sum: u32 = 0;
+        let mut rng = SmallRng::from_entropy();
+        for _ in 0..N {
+            if d.sample(&mut rng) {
+                sum += 1;
+            }
+        }
+        let avg = (sum as f64) / (N as f64);
+
+        assert!((avg - P).abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_nonbool() {
+
+        macro_rules! assert_nonbool {
+            ($($t: ty), *) => {
+                let d = Bernoulli::new(0.3);
+                let r = SmallRng::from_entropy();
+                $(
+                    assert_eq!(r.clone().sample::<$t, _>(&d) as f64 != 0.,
+                               r.clone().sample::<bool, _>(&d));
+                )*
+            }
+        }
+
+        assert_nonbool!(u8, u16, u32, u64, i8, i16, i32, i64, f32, f64);
+    }
+}

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -50,8 +50,7 @@ impl Bernoulli {
     /// For `p = 0.0`, the resulting distribution will always generate false.
     ///
     /// This method is accurate for any input `p` in the range `[0, 1]` which is
-    /// a multiple of 2<sup>-64</sup>. If you need more precision, use `Uniform`
-    /// and a comparison instead. (Note that not all multiples of
+    /// a multiple of 2<sup>-64</sup>. (Note that not all multiples of
     /// 2<sup>-64</sup> in `[0, 1]` can be represented as a `f64`.)
     #[inline]
     pub fn new(p: f64) -> Bernoulli {

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -79,14 +79,13 @@ impl Distribution<bool> for Bernoulli {
 
 #[cfg(test)]
 mod test {
-    use rngs::SmallRng;
-    use {Rng, FromEntropy};
+    use Rng;
     use distributions::Distribution;
     use super::Bernoulli;
 
     #[test]
     fn test_trivial() {
-        let mut r = SmallRng::from_entropy();
+        let mut r = ::test::rng(1);
         let always_false = Bernoulli::new(0.0);
         let always_true = Bernoulli::new(1.0);
         for _ in 0..5 {
@@ -104,7 +103,7 @@ mod test {
         const N: u32 = 10_000_000;
 
         let mut sum: u32 = 0;
-        let mut rng = SmallRng::from_entropy();
+        let mut rng = ::test::rng(2);
         for _ in 0..N {
             if d.sample(&mut rng) {
                 sum += 1;

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -1,3 +1,12 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// https://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
 //! The Bernoulli distribution.
 
 use Rng;

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -18,8 +18,8 @@ use distributions::Distribution;
 /// ```
 #[derive(Clone, Copy, Debug)]
 pub struct Bernoulli {
-    /// Probability of success.
-    p: f64,
+    /// Probability of success, relative to the maximal integer.
+    p_int: u32,
 }
 
 impl Bernoulli {
@@ -32,14 +32,16 @@ impl Bernoulli {
     pub fn new(p: f64) -> Bernoulli {
         assert!(p >= 0.0, "Bernoulli::new called with p < 0");
         assert!(p <= 1.0, "Bernoulli::new called with p > 1");
-        Bernoulli { p }
+        let p_int = (p * f64::from(::core::u32::MAX)) as u32;
+        Bernoulli { p_int }
     }
 }
 
 impl Distribution<bool> for Bernoulli {
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> bool {
-        rng.gen_bool(self.p)
+        // If `p` is constant, this will be evaluated at compile-time.
+        rng.gen::<u32>() <= self.p_int
     }
 }
 

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -19,7 +19,7 @@ use distributions::Distribution;
 #[derive(Clone, Copy, Debug)]
 pub struct Bernoulli {
     /// Probability of success, relative to the maximal integer.
-    p: f64,
+    p_int: u64,
 }
 
 impl Bernoulli {
@@ -32,14 +32,20 @@ impl Bernoulli {
     pub fn new(p: f64) -> Bernoulli {
         assert!(p >= 0.0, "Bernoulli::new called with p < 0");
         assert!(p <= 1.0, "Bernoulli::new called with p > 1");
-        Bernoulli { p }
+        let p_int = if p != 1.0 {
+            (p * (::core::u64::MAX as f64)) as u64
+        } else {
+            ::core::u64::MAX
+        };
+        Bernoulli { p_int }
     }
 }
 
 impl Distribution<bool> for Bernoulli {
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> bool {
-        rng.gen::<f64>() <= self.p
+        let r: u64 = rng.gen();
+        r <= self.p_int
     }
 }
 

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -28,6 +28,12 @@ impl Bernoulli {
     /// # Panics
     ///
     /// If `p < 0` or `p > 1`.
+    ///
+    /// # Precision
+    ///
+    /// For `p = 1.0`, the resulting distribution will always generate true.
+    /// For `p = 0.0`, there is a chance of 2<sup>64</sup> to incorrectly
+    /// generate true.
     #[inline]
     pub fn new(p: f64) -> Bernoulli {
         assert!(p >= 0.0, "Bernoulli::new called with p < 0");

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -25,6 +25,12 @@ use distributions::Distribution;
 /// let v = d.sample(&mut rand::thread_rng());
 /// println!("{} is from a Bernoulli distribution", v);
 /// ```
+///
+/// # Precision
+///
+/// This `Bernoulli` distribution uses 64 bits from the RNG (a `u64`), making
+/// its bias less than 1 in 2<sup>64</sup>. In practice the floating point
+/// accuracy of `p` will usually be the limiting factor.
 #[derive(Clone, Copy, Debug)]
 pub struct Bernoulli {
     /// Probability of success, relative to the maximal integer.

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -28,9 +28,9 @@ use distributions::Distribution;
 ///
 /// # Precision
 ///
-/// This `Bernoulli` distribution uses 64 bits from the RNG (a `u64`), making
-/// its bias less than 1 in 2<sup>64</sup>. In practice the floating point
-/// accuracy of `p` will usually be the limiting factor.
+/// This `Bernoulli` distribution uses 64 bits from the RNG (a `u64`),
+/// so only probabilities that are multiples of 2<sup>-64</sup> can be
+/// represented.
 #[derive(Clone, Copy, Debug)]
 pub struct Bernoulli {
     /// Probability of success, relative to the maximal integer.
@@ -48,6 +48,10 @@ impl Bernoulli {
     ///
     /// For `p = 1.0`, the resulting distribution will always generate true.
     /// For `p = 0.0`, the resulting distribution will always generate false.
+    /// Due to the limitations of floating point numbers, not all internally
+    /// supported probabilities (multiples of 2<sup>-64</sup>) can be specified
+    /// using this constructor. If you need more precision, use
+    /// `Bernoulli::from_int` instead.
     #[inline]
     pub fn new(p: f64) -> Bernoulli {
         assert!(p >= 0.0, "Bernoulli::new called with p < 0");
@@ -58,6 +62,18 @@ impl Bernoulli {
             // Avoid overflow: u64::MAX as f64 cannot be represented as u64.
             ::core::u64::MAX
         };
+        Bernoulli { p_int }
+    }
+
+    /// Construct a new `Bernoulli` with the probability of success given as an
+    /// integer `p_int = p * 2^64`.
+    ///
+    /// `p_int = 0` corresponds to `p = 0.0`.
+    /// `p_int = u64::MAX` corresponds to `p = 1.0`.
+    ///
+    /// This is more precise than using `Bernoulli::new`.
+    #[inline]
+    pub fn from_int(p_int: u64) -> Bernoulli {
         Bernoulli { p_int }
     }
 }

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -55,10 +55,14 @@ impl Bernoulli {
     #[inline]
     pub fn new(p: f64) -> Bernoulli {
         assert!((p >= 0.0) & (p <= 1.0), "Bernoulli::new not called with 0 <= p <= 0");
+        // Technically, this should be 2^64 or `u64::MAX + 1` because we compare
+        // using `<` when sampling. However, `u64::MAX` rounds to an `f64`
+        // larger than `u64::MAX` anyway.
+        const MAX_P_INT: f64 = ::core::u64::MAX as f64;
         let p_int = if p < 1.0 {
-            (p * (::core::u64::MAX as f64)) as u64
+            (p * MAX_P_INT) as u64
         } else {
-            // Avoid overflow: u64::MAX as f64 cannot be represented as u64.
+            // Avoid overflow: `MAX_P_INT` cannot be represented as u64.
             ::core::u64::MAX
         };
         Bernoulli { p_int }

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -79,7 +79,8 @@ impl Distribution<bool> for Bernoulli {
 
 #[cfg(test)]
 mod test {
-    use {Rng, SmallRng, FromEntropy};
+    use rngs::SmallRng;
+    use {Rng, FromEntropy};
     use distributions::Distribution;
     use super::Bernoulli;
 

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -19,7 +19,7 @@ use distributions::Distribution;
 #[derive(Clone, Copy, Debug)]
 pub struct Bernoulli {
     /// Probability of success, relative to the maximal integer.
-    p_int: u32,
+    p: f64,
 }
 
 impl Bernoulli {
@@ -32,16 +32,14 @@ impl Bernoulli {
     pub fn new(p: f64) -> Bernoulli {
         assert!(p >= 0.0, "Bernoulli::new called with p < 0");
         assert!(p <= 1.0, "Bernoulli::new called with p > 1");
-        let p_int = (p * f64::from(::core::u32::MAX)) as u32;
-        Bernoulli { p_int }
+        Bernoulli { p }
     }
 }
 
 impl Distribution<bool> for Bernoulli {
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> bool {
-        // If `p` is constant, this will be evaluated at compile-time.
-        rng.gen::<u32>() <= self.p_int
+        rng.gen::<f64>() <= self.p
     }
 }
 

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -54,7 +54,7 @@ impl Bernoulli {
     /// 2<sup>-64</sup> in `[0, 1]` can be represented as a `f64`.)
     #[inline]
     pub fn new(p: f64) -> Bernoulli {
-        assert!(p >= 0.0 & p <= 1.0, "Bernoulli::new not called with 0 <= p <= 0");
+        assert!((p >= 0.0) & (p <= 1.0), "Bernoulli::new not called with 0 <= p <= 0");
         let p_int = if p < 1.0 {
             (p * (::core::u64::MAX as f64)) as u64
         } else {

--- a/src/distributions/binomial.rs
+++ b/src/distributions/binomial.rs
@@ -31,13 +31,17 @@ use std::f64::consts::PI;
 /// ```
 #[derive(Clone, Copy, Debug)]
 pub struct Binomial {
-    n: u64, // number of trials
-    p: f64, // probability of success
+    /// Number of trials.
+    n: u64,
+    /// Probability of success.
+    p: f64,
 }
 
 impl Binomial {
-    /// Construct a new `Binomial` with the given shape parameters
-    /// `n`, `p`. Panics if `p <= 0` or `p >= 1`.
+    /// Construct a new `Binomial` with the given shape parameters `n` (number
+    /// of trials) and `p` (probability of success).
+    ///
+    /// Panics if `p <= 0` or `p >= 1`.
     pub fn new(n: u64, p: f64) -> Binomial {
         assert!(p > 0.0, "Binomial::new called with p <= 0");
         assert!(p < 1.0, "Binomial::new called with p >= 1");

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -178,6 +178,7 @@ pub use self::uniform::Uniform as Range;
 #[doc(inline)] pub use self::poisson::Poisson;
 #[cfg(feature = "std")]
 #[doc(inline)] pub use self::binomial::Binomial;
+#[doc(inline)] pub use self::bernoulli::Bernoulli;
 
 pub mod uniform;
 #[cfg(feature="std")]
@@ -190,6 +191,7 @@ pub mod uniform;
 #[doc(hidden)] pub mod poisson;
 #[cfg(feature = "std")]
 #[doc(hidden)] pub mod binomial;
+#[doc(hidden)] pub mod bernoulli;
 
 mod float;
 mod integer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -483,6 +483,10 @@ pub trait Rng: RngCore {
     /// println!("{}", rng.gen_bool(1.0 / 3.0));
     /// ```
     ///
+    /// # Panics
+    ///
+    /// If `p` < 0 or `p` > 1.
+    ///
     /// # Accuracy note
     ///
     /// `gen_bool` uses 32 bits of the RNG, so if you use it to generate close

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,10 +497,8 @@ pub trait Rng: RngCore {
     /// from an RNG just to consistently generate `false` does not match with
     /// the intent of this method.
     fn gen_bool(&mut self, p: f64) -> bool {
-        assert!(p >= 0.0 && p <= 1.0);
-        // If `p` is constant, this will be evaluated at compile-time.
-        let p_int = (p * f64::from(core::u32::MAX)) as u32;
-        self.gen::<u32>() <= p_int
+        let d = distributions::Bernoulli::new(p);
+        self.sample(d)
     }
 
     /// Return a random element from `values`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,7 +318,6 @@ pub trait Rng: RngCore {
     /// println!("{}", x);
     /// println!("{:?}", rng.gen::<(f64, bool)>());
     /// ```
-    #[inline(always)]
     fn gen<T>(&mut self) -> T where Standard: Distribution<T> {
         Standard.sample(self)
     }
@@ -352,7 +351,6 @@ pub trait Rng: RngCore {
     /// [`Uniform`]: distributions/uniform/struct.Uniform.html
     /// [`Uniform::new`]: distributions/uniform/struct.Uniform.html#method.new
     /// [`Uniform::sample_single`]: distributions/uniform/struct.Uniform.html#method.sample_single
-    #[inline]
     fn gen_range<T: PartialOrd + SampleUniform>(&mut self, low: T, high: T) -> T {
         Uniform::sample_single(low, high, self)
     }
@@ -371,7 +369,6 @@ pub trait Rng: RngCore {
     /// // distribution can be inferred.
     /// let y = rng.sample::<u16, _>(Uniform::new(10, 15));
     /// ```
-    #[inline]
     fn sample<T, D: Distribution<T>>(&mut self, distr: D) -> T {
         distr.sample(self)
     }
@@ -403,7 +400,6 @@ pub trait Rng: RngCore {
     ///     println!("Not a 6; rolling again!");
     /// }
     /// ```
-    #[inline]
     fn sample_iter<'a, T, D: Distribution<T>>(&'a mut self, distr: &'a D)
         -> distributions::DistIter<'a, D, Self, T> where Self: Sized
     {
@@ -897,7 +893,6 @@ pub fn weak_rng() -> XorShiftRng {
 /// [`thread_rng`]: fn.thread_rng.html
 /// [`Standard`]: distributions/struct.Standard.html
 #[cfg(feature="std")]
-#[inline]
 pub fn random<T>() -> T where Standard: Distribution<T> {
     thread_rng().gen()
 }
@@ -918,7 +913,6 @@ pub fn random<T>() -> T where Standard: Distribution<T> {
 /// println!("{:?}", sample);
 /// ```
 #[cfg(feature="std")]
-#[inline(always)]
 #[deprecated(since="0.4.0", note="renamed to seq::sample_iter")]
 pub fn sample<T, I, R>(rng: &mut R, iterable: I, amount: usize) -> Vec<T>
     where I: IntoIterator<Item=T>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,6 +352,7 @@ pub trait Rng: RngCore {
     /// [`Uniform`]: distributions/uniform/struct.Uniform.html
     /// [`Uniform::new`]: distributions/uniform/struct.Uniform.html#method.new
     /// [`Uniform::sample_single`]: distributions/uniform/struct.Uniform.html#method.sample_single
+    #[inline]
     fn gen_range<T: PartialOrd + SampleUniform>(&mut self, low: T, high: T) -> T {
         Uniform::sample_single(low, high, self)
     }
@@ -370,6 +371,7 @@ pub trait Rng: RngCore {
     /// // distribution can be inferred.
     /// let y = rng.sample::<u16, _>(Uniform::new(10, 15));
     /// ```
+    #[inline]
     fn sample<T, D: Distribution<T>>(&mut self, distr: D) -> T {
         distr.sample(self)
     }
@@ -401,6 +403,7 @@ pub trait Rng: RngCore {
     ///     println!("Not a 6; rolling again!");
     /// }
     /// ```
+    #[inline]
     fn sample_iter<'a, T, D: Distribution<T>>(&'a mut self, distr: &'a D)
         -> distributions::DistIter<'a, D, Self, T> where Self: Sized
     {
@@ -490,6 +493,7 @@ pub trait Rng: RngCore {
     /// If `p` < 0 or `p` > 1.
     ///
     /// [`distributions::Bernoulli`]: distributions/bernoulli/struct.Bernoulli.html
+    #[inline]
     fn gen_bool(&mut self, p: f64) -> bool {
         let d = distributions::Bernoulli::new(p);
         self.sample(d)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -474,6 +474,8 @@ pub trait Rng: RngCore {
 
     /// Return a bool with a probability `p` of being true.
     ///
+    /// This is a wrapper around [`distributions::Bernoulli`].
+    ///
     /// # Example
     ///
     /// ```rust
@@ -487,15 +489,7 @@ pub trait Rng: RngCore {
     ///
     /// If `p` < 0 or `p` > 1.
     ///
-    /// # Accuracy note
-    ///
-    /// `gen_bool` uses 32 bits of the RNG, so if you use it to generate close
-    /// to or more than `2^32` results, a tiny bias may become noticable.
-    /// A notable consequence of the method used here is that the worst case is
-    /// `rng.gen_bool(0.0)`: it has a chance of 1 in `2^32` of being true, while
-    /// it should always be false. But using `gen_bool` to consume *many* values
-    /// from an RNG just to consistently generate `false` does not match with
-    /// the intent of this method.
+    /// [`distributions::Bernoulli`]: distributions/bernoulli/struct.Bernoulli.html
     fn gen_bool(&mut self, p: f64) -> bool {
         let d = distributions::Bernoulli::new(p);
         self.sample(d)

--- a/tests/bool.rs
+++ b/tests/bool.rs
@@ -1,0 +1,26 @@
+#![cfg(feature = "std")]
+
+extern crate rand;
+extern crate libc;
+
+use rand::{FromEntropy, SmallRng};
+use rand::distributions::{Distribution, Bernoulli};
+
+#[link_name = "m"]
+extern "C" {
+    fn nextafter(x: f64, y: f64) -> f64;
+}
+
+/// This test should make sure that we don't accidentally have undefined
+/// behavior for large propabilties due to
+/// https://github.com/rust-lang/rust/issues/10184.
+#[test]
+fn large_probability() {
+    let p = unsafe { nextafter(1., 0.) };
+    assert!(p < 1.);
+    let d = Bernoulli::new(p);
+    let mut rng = SmallRng::from_entropy();
+    for _ in 0..10 {
+        assert!(d.sample(&mut rng));
+    }
+}

--- a/tests/bool.rs
+++ b/tests/bool.rs
@@ -3,7 +3,8 @@
 extern crate rand;
 extern crate libc;
 
-use rand::{FromEntropy, SmallRng};
+use rand::rngs::SmallRng;
+use rand::FromEntropy;
 use rand::distributions::{Distribution, Bernoulli};
 
 #[link_name = "m"]

--- a/tests/bool.rs
+++ b/tests/bool.rs
@@ -2,8 +2,8 @@
 
 extern crate rand;
 
+use rand::SeedableRng;
 use rand::rngs::SmallRng;
-use rand::FromEntropy;
 use rand::distributions::{Distribution, Bernoulli};
 
 /// This test should make sure that we don't accidentally have undefined
@@ -15,7 +15,8 @@ fn large_probability() {
     let p = 1. - ::core::f64::EPSILON / 2.;
     assert!(p < 1.);
     let d = Bernoulli::new(p);
-    let mut rng = SmallRng::from_entropy();
+    let mut rng = SmallRng::from_seed(
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
     for _ in 0..10 {
         assert!(d.sample(&mut rng), "extremely unlikely to fail by accident");
     }

--- a/tests/bool.rs
+++ b/tests/bool.rs
@@ -1,27 +1,22 @@
-#![cfg(feature = "std")]
+#![no_std]
 
 extern crate rand;
-extern crate libc;
 
 use rand::rngs::SmallRng;
 use rand::FromEntropy;
 use rand::distributions::{Distribution, Bernoulli};
 
-#[link_name = "m"]
-extern "C" {
-    fn nextafter(x: f64, y: f64) -> f64;
-}
-
 /// This test should make sure that we don't accidentally have undefined
 /// behavior for large propabilties due to
 /// https://github.com/rust-lang/rust/issues/10184.
+/// Expressions like `1.0*(u64::MAX as f64) as u64` have to be avoided.
 #[test]
 fn large_probability() {
-    let p = unsafe { nextafter(1., 0.) };
+    let p = 1. - ::core::f64::EPSILON / 2.;
     assert!(p < 1.);
     let d = Bernoulli::new(p);
     let mut rng = SmallRng::from_entropy();
     for _ in 0..10 {
-        assert!(d.sample(&mut rng));
+        assert!(d.sample(&mut rng), "extremely unlikely to fail by accident");
     }
 }


### PR DESCRIPTION
* This just uses `gen_bool`, not a different implementation.
* It is implemented for all primitive types. Not sure whether that makes sense. Maybe it is better to only generate `bool` and let the user do the conversion? Having `Distribution<T>` implemented for more than one `T` can make type annotations annoying. If we ever add `impl Distribution<f32> for Normal`, it will probably break a lot of code...