### PR TITLE
Lower Rustc version requirement to 1.9 for rand_core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ matrix:
         - cargo test --tests --no-default-features
         - cargo test --package rand_core --no-default-features
         - cargo test --features serde1,log
+    - rust: 1.9.0
+      install:
+      script:
+        # Ensure minimum rustc version for rand_core.
+        - cargo test --package rand_core --lib
     - rust: stable
       os: osx
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
         - cargo test --tests --no-default-features
         - cargo test --package rand_core --no-default-features
         - cargo test --features serde1,log
-    - rust: 1.9.0
+    - rust: 1.13.0
       install:
       script:
         # Ensure minimum rustc version for rand_core.

--- a/rand_core/README.md
+++ b/rand_core/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/rust-lang-nursery/rand?svg=true)](https://ci.appveyor.com/project/alexcrichton/rand)
 [![Latest version](https://img.shields.io/crates/v/rand_core.svg)](https://crates.io/crates/rand_core)
 [![Documentation](https://docs.rs/rand_core/badge.svg)](https://docs.rs/rand_core)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.9+-yellow.svg)](https://github.com/rust-lang-nursery/rand#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.13+-yellow.svg)](https://github.com/rust-lang-nursery/rand#rust-version-requirements)
 
 Core traits and error types of the [rand] library, plus tools for implementing
 RNGs.
@@ -56,7 +56,7 @@ implementations that use the `BlockRng` or `BlockRng64` wrappers.
 ### Rust version requirements
 
 `rand_core` works with a wide range of Rustc versions, with the oldest supported
-version being **Rustc 1.9.0**. The optional `serde1` feature requires a higher
+version being **Rustc 1.13.0**. The optional `serde1` feature requires a higher
 Rustc version, as it depends on the minimum version supported by Serde.
 
 Travis CI always has a build with a pinned version of Rustc matching the oldest

--- a/rand_core/README.md
+++ b/rand_core/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/rust-lang-nursery/rand?svg=true)](https://ci.appveyor.com/project/alexcrichton/rand)
 [![Latest version](https://img.shields.io/crates/v/rand_core.svg)](https://crates.io/crates/rand_core)
 [![Documentation](https://docs.rs/rand_core/badge.svg)](https://docs.rs/rand_core)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-yellow.svg)](https://github.com/rust-lang-nursery/rand#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.9+-yellow.svg)](https://github.com/rust-lang-nursery/rand#rust-version-requirements)
 
 Core traits and error types of the [rand] library, plus tools for implementing
 RNGs.
@@ -52,6 +52,16 @@ default features will also enable `std` support in `rand_core`.
 
 The `serde1` feature can be used to derive `Serialize` and `Deserialize` for RNG
 implementations that use the `BlockRng` or `BlockRng64` wrappers.
+
+### Rust version requirements
+
+`rand_core` works with a wide range of Rustc versions, with the oldest supported
+version being **Rustc 1.9.0**. The optional `serde1` feature requires a higher
+Rustc version, as it depends on the minimum version supported by Serde.
+
+Travis CI always has a build with a pinned version of Rustc matching the oldest
+supported Rust release. The current policy is that this can be updated in any
+`rand_core` release if required, but the change must be noted in the changelog.
 
 
 # License

--- a/rand_core/src/impls.rs
+++ b/rand_core/src/impls.rs
@@ -355,7 +355,7 @@ impl<R: BlockRngCore + SeedableRng> SeedableRng for BlockRng<R> {
     }
 
     fn from_rng<S: RngCore>(rng: S) -> Result<Self, Error> {
-        Ok(Self::new(try!(R::from_rng(rng))))
+        Ok(Self::new(R::from_rng(rng)?))
     }
 }
 
@@ -534,7 +534,7 @@ impl<R: BlockRngCore + SeedableRng> SeedableRng for BlockRng64<R> {
     }
 
     fn from_rng<S: RngCore>(rng: S) -> Result<Self, Error> {
-        Ok(Self::new(try!(R::from_rng(rng))))
+        Ok(Self::new(R::from_rng(rng)?))
     }
 }
 

--- a/rand_core/src/impls.rs
+++ b/rand_core/src/impls.rs
@@ -212,7 +212,7 @@ impl<R: BlockRngCore> BlockRng<R> {
     pub fn new(core: R) -> BlockRng<R>{
         let results_empty = R::Results::default();
         BlockRng {
-            core,
+            core: core,
             index: results_empty.as_ref().len(),
             results: results_empty,
         }
@@ -355,7 +355,7 @@ impl<R: BlockRngCore + SeedableRng> SeedableRng for BlockRng<R> {
     }
 
     fn from_rng<S: RngCore>(rng: S) -> Result<Self, Error> {
-        Ok(Self::new(R::from_rng(rng)?))
+        Ok(Self::new(try!(R::from_rng(rng))))
     }
 }
 
@@ -400,7 +400,7 @@ impl<R: BlockRngCore> BlockRng64<R> {
     pub fn new(core: R) -> BlockRng64<R>{
         let results_empty = R::Results::default();
         BlockRng64 {
-            core,
+            core: core,
             index: results_empty.as_ref().len(),
             half_used: false,
             results: results_empty,
@@ -534,7 +534,7 @@ impl<R: BlockRngCore + SeedableRng> SeedableRng for BlockRng64<R> {
     }
 
     fn from_rng<S: RngCore>(rng: S) -> Result<Self, Error> {
-        Ok(Self::new(R::from_rng(rng)?))
+        Ok(Self::new(try!(R::from_rng(rng))))
     }
 }
 

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -381,7 +381,7 @@ pub trait SeedableRng: Sized {
     /// [`OsRng`]: ../rand/os/struct.OsRng.html
     fn from_rng<R: RngCore>(mut rng: R) -> Result<Self, Error> {
         let mut seed = Self::Seed::default();
-        try!(rng.try_fill_bytes(seed.as_mut()));
+        rng.try_fill_bytes(seed.as_mut())?;
         Ok(Self::from_seed(seed))
     }
 }

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -381,7 +381,7 @@ pub trait SeedableRng: Sized {
     /// [`OsRng`]: ../rand/os/struct.OsRng.html
     fn from_rng<R: RngCore>(mut rng: R) -> Result<Self, Error> {
         let mut seed = Self::Seed::default();
-        rng.try_fill_bytes(seed.as_mut())?;
+        try!(rng.try_fill_bytes(seed.as_mut()));
         Ok(Self::from_seed(seed))
     }
 }


### PR DESCRIPTION
After seeing how much contortions some crates go through to keep building on older rust versions, I changed my mind and want to document the oldest version supported by rand_core.

Rayon depends on rust 1.12, which we can support to with just a few cosmetic changes. With those changes `rand_core` also builds on rust 1.9.0.