### PR TITLE
Fix #417: don't pass --all to rustdoc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,4 +57,3 @@ bincode = "1.0"
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = [ "--all" ] # also document rand_core


### PR DESCRIPTION
I suppose we need a new release to actually get the doc built on docs.rs?