### PR TITLE
Rand core changes

### DIFF
--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -5,7 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.1.0] - TODO - date
+## [0.2.0] - Unreleased
+- Enable the `std` feature by default. (#409)
+- Change `BlockRng64::inner` and add `BlockRng64::inner_mut` to mirror `BlockRng`. (#419)
+- Add `BlockRng{64}::index` and `BlockRng{64}::generate_and_set`. (#374, #419)
+
+## [0.1.0] - 2018-04-17
 (Split out of the Rand crate, changes here are relative to rand 0.4.2)
 - `RngCore` and `SeedableRng` are now part of `rand_core`. (#288)
 - Add modules to help implementing RNGs `impl` and `le`. (#209, #228)

--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enable the `std` feature by default. (#409)
 - Change `BlockRng64::inner` and add `BlockRng64::inner_mut` to mirror `BlockRng`. (#419)
 - Add `BlockRng{64}::index` and `BlockRng{64}::generate_and_set`. (#374, #419)
+- Change `BlockRngCore::Results` bound to also require `AsMut<[Self::Item]>`. (#419)
 
 ## [0.1.0] - 2018-04-17
 (Split out of the Rand crate, changes here are relative to rand 0.4.2)

--- a/rand_core/Cargo.toml
+++ b/rand_core/Cargo.toml
@@ -25,4 +25,4 @@ serde1 = ["serde", "serde_derive"] # enables serde for BlockRng wrapper
 
 [dependencies]
 serde = { version = "1", optional = true }
-serde_derive = { version = "1", optional = true }
+serde_derive = { version = "^1.0.38", optional = true }

--- a/rand_core/src/impls.rs
+++ b/rand_core/src/impls.rs
@@ -430,10 +430,27 @@ impl<R: BlockRngCore> BlockRng64<R> {
         &mut self.core
     }
 
-    // Reset the number of available results.
-    // This will force a new set of results to be generated on next use.
+    /// Get the index into the result buffer.
+    ///
+    /// If this is equal to or larger than the size of the result buffer then
+    /// the buffer is "empty" and `generate()` must be called to produce new
+    /// results.
+    pub fn index(&self) -> usize {
+        self.index
+    }
+
+    /// Reset the number of available results.
+    /// This will force a new set of results to be generated on next use.
     pub fn reset(&mut self) {
         self.index = self.results.as_ref().len();
+    }
+
+    /// Generate a new set of results immediately, setting the index to the
+    /// given value.
+    pub fn generate_and_set(&mut self, index: usize) {
+        assert!(index < self.results.as_ref().len());
+        self.core.generate(&mut self.results);
+        self.index = index;
     }
 }
 

--- a/rand_core/src/impls.rs
+++ b/rand_core/src/impls.rs
@@ -420,8 +420,13 @@ impl<R: BlockRngCore> BlockRng64<R> {
         }
     }
 
+    /// Return a reference the wrapped `BlockRngCore`.
+    pub fn inner(&self) -> &R {
+        &self.core
+    }
+
     /// Return a mutable reference the wrapped `BlockRngCore`.
-    pub fn inner(&mut self) -> &mut R {
+    pub fn inner_mut(&mut self) -> &mut R {
         &mut self.core
     }
 

--- a/rand_core/src/impls.rs
+++ b/rand_core/src/impls.rs
@@ -249,7 +249,7 @@ impl<R: BlockRngCore> BlockRng<R> {
 }
 
 impl<R: BlockRngCore<Item=u32>> RngCore for BlockRng<R>
-where <R as BlockRngCore>::Results: AsRef<[u32]>
+where <R as BlockRngCore>::Results: AsRef<[u32]> + AsMut<[u32]>
 {
     #[inline(always)]
     fn next_u32(&mut self) -> u32 {
@@ -448,7 +448,7 @@ impl<R: BlockRngCore> BlockRng64<R> {
 }
 
 impl<R: BlockRngCore<Item=u64>> RngCore for BlockRng64<R>
-where <R as BlockRngCore>::Results: AsRef<[u64]>
+where <R as BlockRngCore>::Results: AsRef<[u64]> + AsMut<[u64]>
 {
     #[inline(always)]
     fn next_u32(&mut self) -> u32 {

--- a/rand_core/src/impls.rs
+++ b/rand_core/src/impls.rs
@@ -27,7 +27,6 @@ use core::cmp::min;
 use core::mem::size_of;
 use {RngCore, BlockRngCore, CryptoRng, SeedableRng, Error};
 
-#[cfg(feature="serde1")] use serde::{Serialize, Deserialize};
 
 /// Implement `next_u64` via `next_u32`, little-endian order.
 pub fn next_u64_via_u32<R: RngCore + ?Sized>(rng: &mut R) -> u64 {
@@ -187,9 +186,6 @@ pub fn next_u64_via_fill<R: RngCore + ?Sized>(rng: &mut R) -> u64 {
 #[derive(Clone)]
 #[cfg_attr(feature="serde1", derive(Serialize, Deserialize))]
 pub struct BlockRng<R: BlockRngCore + ?Sized> {
-    #[cfg_attr(feature="serde1", serde(bound(
-        serialize = "R::Results: Serialize",
-        deserialize = "R::Results: Deserialize<'de>")))]
     results: R::Results,
     index: usize,
     core: R,
@@ -386,9 +382,6 @@ impl<R: BlockRngCore + SeedableRng> SeedableRng for BlockRng<R> {
 #[derive(Clone)]
 #[cfg_attr(feature="serde1", derive(Serialize, Deserialize))]
 pub struct BlockRng64<R: BlockRngCore + ?Sized> {
-    #[cfg_attr(feature="serde1", serde(bound(
-        serialize = "R::Results: Serialize",
-        deserialize = "R::Results: Deserialize<'de>")))]
     results: R::Results,
     index: usize,
     half_used: bool, // true if only half of the previous result is used

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -37,7 +37,9 @@
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
        html_root_url = "https://docs.rs/rand_core/0.1.0")]
 
+#![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
+#![doc(test(attr(allow(unused_variables), deny(warnings))))]
 
 #![cfg_attr(not(feature="std"), no_std)]
 #![cfg_attr(all(feature="alloc", not(feature="std")), feature(alloc))]
@@ -107,6 +109,7 @@ pub mod le;
 /// A simple example, obviously not generating very *random* output:
 /// 
 /// ```rust
+/// #![allow(dead_code)]
 /// use rand_core::{RngCore, Error, impls};
 /// 
 /// struct CountingRng(u64);

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -238,7 +238,7 @@ pub trait BlockRngCore {
     
     /// Results type. This is the 'block' an RNG implementing `BlockRngCore`
     /// generates, which will usually be an array like `[u32; 16]`.
-    type Results: AsRef<[Self::Item]> + Default;
+    type Results: AsRef<[Self::Item]> + AsMut<[Self::Item]> + Default;
 
     /// Generate a new block of results.
     fn generate(&mut self, results: &mut Self::Results);

--- a/src/prng/isaac_array.rs
+++ b/src/prng/isaac_array.rs
@@ -38,6 +38,13 @@ impl<T> ::core::convert::AsRef<[T]> for IsaacArray<T> {
     }
 }
 
+impl<T> ::core::convert::AsMut<[T]> for IsaacArray<T> {
+    #[inline(always)]
+    fn as_mut(&mut self) -> &mut [T] {
+        &mut self.inner[..]
+    }
+}
+
 impl<T> ::core::ops::Deref for IsaacArray<T> {
     type Target = [T; RAND_SIZE];
     #[inline(always)]

--- a/src/reseeding.rs
+++ b/src/reseeding.rs
@@ -84,7 +84,7 @@ where R: BlockRngCore + SeedableRng,
 // implements RngCore, but we can't specify that because ReseedingCore is private
 impl<R, Rsdr: RngCore> RngCore for ReseedingRng<R, Rsdr>
 where R: BlockRngCore<Item = u32> + SeedableRng,
-    <R as BlockRngCore>::Results: AsRef<[u32]>
+    <R as BlockRngCore>::Results: AsRef<[u32]> + AsMut<[u32]>
 {
     #[inline(always)]
     fn next_u32(&mut self) -> u32 {


### PR DESCRIPTION
I forgot to change `BlockRng64::inner` to return a reference and to add `inner_mut` in https://github.com/rust-lang-nursery/rand/pull/325#discussion_r179197675.

This PR also copies the `index` and `generate_and_set` methods from https://github.com/rust-lang-nursery/rand/pull/374 to `BlockRng64`, and updates the changelog.

Edit: the build will fail because I added `#![deny(missing_docs)]`. The offending line is fixed in https://github.com/rust-lang-nursery/rand/pull/374; as it gets fixed anyway it seemed nice to prevent a merge conflict.