### PR TITLE
Documentation

### DIFF
--- a/rand_core/src/impls.rs
+++ b/rand_core/src/impls.rs
@@ -119,7 +119,7 @@ macro_rules! fill_via_chunks {
 /// # Example
 /// (from `IsaacRng`)
 ///
-/// ```rust,ignore
+/// ```ignore
 /// fn fill_bytes(&mut self, dest: &mut [u8]) {
 ///     let mut read_len = 0;
 ///     while read_len < dest.len() {

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -109,7 +109,7 @@ pub mod le;
 /// 
 /// A simple example, obviously not generating very *random* output:
 /// 
-/// ```rust
+/// ```
 /// #![allow(dead_code)]
 /// use rand_core::{RngCore, Error, impls};
 /// 

--- a/src/distributions/binomial.rs
+++ b/src/distributions/binomial.rs
@@ -22,7 +22,7 @@ use std::f64::consts::PI;
 ///
 /// # Example
 ///
-/// ```rust
+/// ```
 /// use rand::distributions::{Binomial, Distribution};
 ///
 /// let bin = Binomial::new(20, 0.3);

--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -29,7 +29,7 @@ use distributions::{ziggurat, ziggurat_tables, Distribution};
 /// College, Oxford
 ///
 /// # Example
-/// ```rust
+/// ```
 /// use rand::prelude::*;
 /// use rand::distributions::Exp1;
 ///
@@ -66,7 +66,7 @@ impl Distribution<f64> for Exp1 {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```
 /// use rand::distributions::{Exp, Distribution};
 ///
 /// let exp = Exp::new(2.0);

--- a/src/distributions/float.rs
+++ b/src/distributions/float.rs
@@ -27,7 +27,7 @@ use distributions::{Distribution, Standard};
 /// ranges.
 ///
 /// # Example
-/// ```rust
+/// ```
 /// use rand::{thread_rng, Rng};
 /// use rand::distributions::OpenClosed01;
 ///
@@ -53,7 +53,7 @@ pub struct OpenClosed01;
 /// ranges.
 ///
 /// # Example
-/// ```rust
+/// ```
 /// use rand::{thread_rng, Rng};
 /// use rand::distributions::Open01;
 ///

--- a/src/distributions/gamma.rs
+++ b/src/distributions/gamma.rs
@@ -35,7 +35,7 @@ use distributions::{Distribution, Exp, Open01};
 ///
 /// # Example
 ///
-/// ```rust
+/// ```
 /// use rand::distributions::{Distribution, Gamma};
 ///
 /// let gamma = Gamma::new(2.0, 5.0);
@@ -178,7 +178,7 @@ impl Distribution<f64> for GammaLargeShape {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```
 /// use rand::distributions::{ChiSquared, Distribution};
 ///
 /// let chi = ChiSquared::new(11.0);
@@ -233,7 +233,7 @@ impl Distribution<f64> for ChiSquared {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```
 /// use rand::distributions::{FisherF, Distribution};
 ///
 /// let f = FisherF::new(2.0, 32.0);
@@ -274,7 +274,7 @@ impl Distribution<f64> for FisherF {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```
 /// use rand::distributions::{StudentT, Distribution};
 ///
 /// let t = StudentT::new(11.0);

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -83,6 +83,7 @@
 //!   - [`Normal`] distribution, and [`StandardNormal`] as a primitive
 //! - Related to Bernoulli trials (yes/no events, with a given probability):
 //!   - [`Binomial`] distribution
+//!   - [`Bernoulli`] distribution, similar to [`Rng::gen_bool`].
 //! - Related to positive real-valued quantities that grow exponentially
 //!   (e.g. prices, incomes, populations):
 //!   - [`LogNormal`] distribution
@@ -145,6 +146,7 @@
 //! [Floating point implementation]: struct.Standard.html#floating-point-implementation
 // distributions
 //! [`Alphanumeric`]: struct.Alphanumeric.html
+//! [`Bernoulli`]: struct.Bernoulli.html
 //! [`Binomial`]: struct.Binomial.html
 //! [`ChiSquared`]: struct.ChiSquared.html
 //! [`Exp`]: struct.Exp.html

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -27,7 +27,7 @@ use distributions::{ziggurat, ziggurat_tables, Distribution, Open01};
 /// College, Oxford
 ///
 /// # Example
-/// ```rust
+/// ```
 /// use rand::prelude::*;
 /// use rand::distributions::StandardNormal;
 ///
@@ -79,7 +79,7 @@ impl Distribution<f64> for StandardNormal {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```
 /// use rand::distributions::{Normal, Distribution};
 ///
 /// // mean 2, standard deviation 3
@@ -124,7 +124,7 @@ impl Distribution<f64> for Normal {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```
 /// use rand::distributions::{LogNormal, Distribution};
 ///
 /// // mean 2, standard deviation 3

--- a/src/distributions/other.rs
+++ b/src/distributions/other.rs
@@ -23,7 +23,7 @@ use distributions::{Distribution, Standard, Uniform};
 /// 
 /// # Example
 ///
-/// ```rust
+/// ```
 /// use std::iter;
 /// use rand::{Rng, thread_rng};
 /// use rand::distributions::Alphanumeric;

--- a/src/distributions/poisson.rs
+++ b/src/distributions/poisson.rs
@@ -22,7 +22,7 @@ use std::f64::consts::PI;
 ///
 /// # Example
 ///
-/// ```rust
+/// ```
 /// use rand::distributions::{Poisson, Distribution};
 ///
 /// let poi = Poisson::new(2.0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -847,6 +847,8 @@ pub trait FromEntropy: SeedableRng {
     /// applications targetting PC/mobile platforms should not need to worry
     /// about this failing.
     ///
+    /// # Panics
+    ///
     /// If all entropy sources fail this will panic. If you need to handle
     /// errors, use the following code, equivalent aside from error handling:
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! # Basic usage
 //!
-//! To get you started quickly, the easiest and highist-level way to get
+//! To get you started quickly, the easiest and highest-level way to get
 //! a random value is to use [`random()`].
 //!
 //! ```
@@ -39,10 +39,10 @@
 //! Generating random values is typically a two-step process:
 //!
 //! - get some *random data* (an integer or bit/byte sequence) from a random
-//!   number generator (RNG)
+//!   number generator (RNG);
 //! - use some function to transform that *data* into the type of value you want
 //!   (this function is an implementation of some *distribution* describing the
-//!   kind of value produced)
+//!   kind of value produced).
 //!
 //! Rand represents the first step with the [`RngCore`] trait and the second
 //! step via a combination of the [`Rng`] extension trait and the
@@ -53,7 +53,7 @@
 //! There are many kinds of RNGs, with different trade-offs. You can read more
 //! about them in the [`rngs` module] and even more in the [`prng` module],
 //! however, often you can just use [`thread_rng()`]. This function
-//! automatically initialises an RNG in thread-local memory, then returns a
+//! automatically initializes an RNG in thread-local memory, then returns a
 //! reference to it. It is fast, good quality, and secure (unpredictable).
 //!
 //! To turn the output of the RNG into something usable, you usually want to use
@@ -149,17 +149,15 @@
 //! However, external RNGs can fail, and being able to handle this is important.
 //!
 //! It has therefore been decided that *most* methods should not return a
-//! `Result` type, and must therefore panic if an error does occur. The
-//! exceptions are [`Rng::try_fill`], [`RngCore::try_fill_bytes`], and
-//! [`SeedableRng::from_rng`].
+//! `Result` type, with as exceptions [`Rng::try_fill`],
+//! [`RngCore::try_fill_bytes`], and [`SeedableRng::from_rng`].
 //!
-//! To reduce the risk of panic due to failure to access the operating system's
-//! generator, we recommend using [`EntropyRng`] which uses [`OsRng`] but will
-//! fall back to a local implementation of a jitter collector when necessary.
-//! To properly handle errors due to inability to access external entropy, we
-//! recommend testing [`EntropyRng`] with one of the above methods at
-//! application startup.
-//! 
+//! Note that it is the RNG that panics when it fails but is not used through a
+//! method that can report errors. Currently Rand contains only three RNGs that
+//! can return an error (and thus may panic), and documents this property:
+//! [`OsRng`], [`EntropyRng`] and [`ReadRng`]. Other RNGs, like [`ThreadRng`]
+//! and [`StdRng`], can be used with all methods without concern.
+//!
 //!
 //! # Distinction between Rand and `rand_core`
 //!
@@ -184,12 +182,15 @@
 //!
 //! [`distributions` module]: distributions/index.html
 //! [`distributions::WeightedChoice`]: distributions/struct.WeightedChoice.html
+//! [`EntropyRng`]: rngs/struct.EntropyRng.html
 //! [`Error`]: struct.Error.html
 //! [`gen_range`]: trait.Rng.html#method.gen_range
 //! [`gen`]: trait.Rng.html#method.gen
+//! [`OsRng`]: rngs/struct.OsRng.html
 //! [prelude]: prelude/index.html
 //! [`rand_core`]: https://crates.io/crates/rand_core
 //! [`random()`]: fn.random.html
+//! [`ReadRng`]: rngs/adapter/struct.ReadRng.html
 //! [`Rng::choose`]: trait.Rng.html#method.choose
 //! [`Rng::fill`]: trait.Rng.html#method.fill
 //! [`Rng::gen_bool`]: trait.Rng.html#method.gen_bool
@@ -212,8 +213,6 @@
 //! [`ThreadRng`]: rngs/struct.ThreadRng.html
 //! [`Standard`]: distributions/struct.Standard.html
 //! [`Uniform`]: distributions/struct.Uniform.html
-//! [`EntropyRng`]: rngs/struct.EntropyRng.html
-//! [`OsRng`]: rngs/struct.OsRng.html
 
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,7 +308,7 @@ pub trait Rand : Sized {
 /// 
 /// Example:
 /// 
-/// ```rust
+/// ```
 /// # use rand::thread_rng;
 /// use rand::Rng;
 /// 
@@ -327,7 +327,7 @@ pub trait Rng: RngCore {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```
     /// use rand::{thread_rng, Rng};
     ///
     /// let mut rng = thread_rng();
@@ -355,7 +355,7 @@ pub trait Rng: RngCore {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```
     /// use rand::{thread_rng, Rng};
     ///
     /// let mut rng = thread_rng();
@@ -376,7 +376,7 @@ pub trait Rng: RngCore {
     ///
     /// ### Example
     ///
-    /// ```rust
+    /// ```
     /// use rand::{thread_rng, Rng};
     /// use rand::distributions::Uniform;
     ///
@@ -394,7 +394,7 @@ pub trait Rng: RngCore {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```
     /// use rand::{thread_rng, Rng};
     /// use rand::distributions::{Alphanumeric, Uniform, Standard};
     ///
@@ -436,7 +436,7 @@ pub trait Rng: RngCore {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```
     /// use rand::{thread_rng, Rng};
     ///
     /// let mut arr = [0i8; 20];
@@ -465,7 +465,7 @@ pub trait Rng: RngCore {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```
     /// # use rand::Error;
     /// use rand::{thread_rng, Rng};
     ///
@@ -494,7 +494,7 @@ pub trait Rng: RngCore {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```
     /// use rand::{thread_rng, Rng};
     ///
     /// let mut rng = thread_rng();
@@ -554,7 +554,7 @@ pub trait Rng: RngCore {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```
     /// use rand::{thread_rng, Rng};
     ///
     /// let mut rng = thread_rng();
@@ -599,7 +599,7 @@ pub trait Rng: RngCore {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```
     /// # #![allow(deprecated)]
     /// use rand::{thread_rng, Rng};
     ///
@@ -622,7 +622,7 @@ pub trait Rng: RngCore {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```
     /// # #![allow(deprecated)]
     /// use rand::{thread_rng, Rng};
     ///
@@ -819,7 +819,7 @@ pub trait FromEntropy: SeedableRng {
     /// If all entropy sources fail this will panic. If you need to handle
     /// errors, use the following code, equivalent aside from error handling:
     ///
-    /// ```rust
+    /// ```
     /// # use rand::Error;
     /// use rand::prelude::*;
     /// use rand::rngs::EntropyRng;
@@ -873,7 +873,7 @@ pub fn weak_rng() -> XorShiftRng {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
 /// let x = rand::random::<u8>();
 /// println!("{}", x);
 ///
@@ -888,7 +888,7 @@ pub fn weak_rng() -> XorShiftRng {
 /// If you're calling `random()` in a loop, caching the generator as in the
 /// following example can increase performance.
 ///
-/// ```rust
+/// ```
 /// # #![allow(deprecated)]
 /// use rand::Rng;
 ///
@@ -921,7 +921,7 @@ pub fn random<T>() -> T where Standard: Distribution<T> {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```
 /// # #![allow(deprecated)]
 /// use rand::{thread_rng, sample};
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,12 @@
 //! [`OsRng`], [`EntropyRng`] and [`ReadRng`]. Other RNGs, like [`ThreadRng`]
 //! and [`StdRng`], can be used with all methods without concern.
 //!
+//! One further problem is that if Rand is unable to get any external randomness
+//! when initializing an RNG with [`EntropyRng`], it will panic in
+//! [`FromEntropy::from_entropy`], and notably in [`thread_rng`]. Except by
+//! compromising security, this problem is as unsolvable as running out of
+//! memory.
+//!
 //!
 //! # Distinction between Rand and `rand_core`
 //!
@@ -366,6 +372,7 @@ pub trait Rng: RngCore {
     /// println!("{}", x);
     /// println!("{:?}", rng.gen::<(f64, bool)>());
     /// ```
+    #[inline]
     fn gen<T>(&mut self) -> T where Standard: Distribution<T> {
         Standard.sample(self)
     }
@@ -943,6 +950,7 @@ pub fn weak_rng() -> XorShiftRng {
 /// [`thread_rng`]: fn.thread_rng.html
 /// [`Standard`]: distributions/struct.Standard.html
 #[cfg(feature="std")]
+#[inline]
 pub fn random<T>() -> T where Standard: Distribution<T> {
     thread_rng().gen()
 }
@@ -963,6 +971,7 @@ pub fn random<T>() -> T where Standard: Distribution<T> {
 /// println!("{:?}", sample);
 /// ```
 #[cfg(feature="std")]
+#[inline]
 #[deprecated(since="0.4.0", note="renamed to seq::sample_iter")]
 pub fn sample<T, I, R>(rng: &mut R, iterable: I, amount: usize) -> Vec<T>
     where I: IntoIterator<Item=T>,

--- a/src/prng/chacha.rs
+++ b/src/prng/chacha.rs
@@ -112,7 +112,7 @@ impl ChaChaRng {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
     /// # #![allow(deprecated)]
     /// use rand::{RngCore, ChaChaRng};
     ///

--- a/src/prng/hc128.rs
+++ b/src/prng/hc128.rs
@@ -40,7 +40,7 @@ const SEED_WORDS: usize = 8; // 128 bit key followed by 128 bit iv
 /// current state of known attacks / weaknesses of HC-128 is given in [4].
 ///
 /// The average cycle length is expected to be
-/// 2<sup>1024*32-1</sup> = 2<sup>32767</sup>.
+/// 2<sup>1024*32+10-1</sup> = 2<sup>32777</sup>.
 /// We support seeding with a 256-bit array, which matches the 128-bit key
 /// concatenated with a 128-bit IV from the stream cipher.
 ///
@@ -50,7 +50,7 @@ const SEED_WORDS: usize = 8; // 128 bit key followed by 128 bit iv
 /// ## References
 /// [1]: Hongjun Wu (2008). ["The Stream Cipher HC-128"](
 ///      http://www.ecrypt.eu.org/stream/p3ciphers/hc/hc128_p3.pdf).
-///      *The eSTREAM Finalists*, LNCS 4986, pp. 39--47, Springer-Verlag.
+///      *The eSTREAM Finalists*, LNCS 4986, pp. 39–47, Springer-Verlag.
 ///
 /// [2]: [eSTREAM: the ECRYPT Stream Cipher Project](
 ///      http://www.ecrypt.eu.org/stream/)

--- a/src/prng/isaac.rs
+++ b/src/prng/isaac.rs
@@ -72,7 +72,7 @@ const RAND_SIZE: usize = 1 << RAND_SIZE_LEN;
 /// runs once every 256 times you ask for a next random number. In all other
 /// circumstances the last element of the results array is returned.
 ///
-/// ISAAC therefore needs a lot of memory, relative to other non-vrypto RNGs.
+/// ISAAC therefore needs a lot of memory, relative to other non-crypto RNGs.
 /// 2 * 256 * 4 = 2 kb to hold the state and results.
 ///
 /// This implementation uses [`BlockRng`] to implement the [`RngCore`] methods.

--- a/src/prng/isaac.rs
+++ b/src/prng/isaac.rs
@@ -167,7 +167,7 @@ impl BlockRngCore for IsaacCore {
     type Results = IsaacArray<Self::Item>;
 
     /// Refills the output buffer, `results`. See also the pseudocode desciption
-    /// of the algorithm in the [`Isaac64Rng`] documentation.
+    /// of the algorithm in the [`IsaacRng`] documentation.
     ///
     /// Optimisations used (similar to the reference implementation):
     /// 

--- a/src/prng/mod.rs
+++ b/src/prng/mod.rs
@@ -39,6 +39,50 @@
 //! short periods for some seeds. If one PRNG is seeded from another using the
 //! same algorithm, it is possible that both will yield the same sequence of
 //! values (with some lag).
+//!
+//! ## Cryptographic security
+//!
+//! First, lets recap some terminology:
+//!
+//! - **PRNG:** *Pseudo-Random-Number-Generator* is another name for an
+//!   *algorithmic generator*
+//! - **CSPRNG:** a *Cryptographically Secure* PRNG
+//!
+//! Security analysis requires a threat model and expert review; we can provide
+//! neither, but we can provide a few hints. We assume that the goal is to
+//! produce secret apparently-random data. Therefore, we need:
+//!
+//! - A good source of entropy. A known algorithm given known input data is
+//!   trivial to predict, and likewise if there's a non-negligable chance that
+//!   the input to a PRNG is guessable then there's a chance its output is too.
+//!   We recommend seeding CSPRNGs with [`EntropyRng`] or [`OsRng`] which
+//!   provide fresh "random" values from an external source.
+//!   One can also seed from another CSPRNG, e.g. [`thread_rng`], which is faster,
+//!   but adds another component which must be trusted.
+//! - A strong algorithmic generator. It is possible to use a good entropy
+//!   source like [`OsRng`] directly, and in some cases this is the best option,
+//!   but for better performance (or if requiring reproducible values generated
+//!   from a fixed seed) it is common to use a local CSPRNG. The basic security
+//!   that CSPRNGs must provide is making it infeasible to predict future output
+//!   given a sample of past output. A further security that *some* CSPRNGs
+//!   provide is *forward secrecy*; this ensures that in the event that the
+//!   algorithm's state is revealed, it is infeasible to reconstruct past
+//!   output. See the [`CryptoRng`] trait and notes on individual algorithms.
+//! - To be careful not to leak secrets like keys and CSPRNG's internal state
+//!   and robust against "side channel attacks". This goes well beyond the scope
+//!   of random number generation, but this crate takes some precautions:
+//!   - to avoid printing CSPRNG state in log files, implementations have a
+//!     custom `Debug` implementation which omits all internal state
+//!   - [`thread_rng`] uses [`ReseedingRng`] to periodically refresh its state
+//!   - in the future we plan to add some protection against fork attacks
+//!     (where the process is forked and each clone generates the same "random"
+//!     numbers); this is not yet implemented (see issues #314, #370)
+//!
+//! [`CryptoRng`]: ../trait.CryptoRng.html
+//! [`EntropyRng`]: ../rngs/struct.EntropyRng.html
+//! [`OsRng`]: ../rngs/struct.OsRng.html
+//! [`ReseedingRng`]: ../rngs/adaptor/struct.ReseedingRng.html
+//! [`thread_rng`]: ../fn.thread_rng.html
 
 pub mod chacha;
 pub mod hc128;

--- a/src/prng/mod.rs
+++ b/src/prng/mod.rs
@@ -145,6 +145,21 @@
 //! unpredictable. This implies there must be no obvious correlations between
 //! output values.
 //!
+//! ### Quality stars:
+// 5. reserved for crypto-level (e.g. ChaCha8, ISAAC)
+// 4. good performance on TestU01 and PractRand, good theory
+//    (e.g. PCG, truncated Xorshift*)
+// 3. good performance on TestU01 and PractRand, but "falling through the
+//    cracks" or insufficient theory (e.g. SFC, Xoshiro)
+// 2. imperfect performance on tests or other limiting properties, but not
+//    terrible (e.g. Xoroshiro128+)
+// 1. clear deficiencies in test results, cycle length, theory, or other
+//    properties (e.g. Xorshift)
+//!
+//! PRNGs with 3 stars or more should be good enough for any purpose.
+//! 1 or 2 stars may be good enough for typical apps and games, but do not work
+//! well with all algorithms.
+//!
 //! ## Period
 //!
 //! The *period* or *cycle length* of a PRNG is the number of values that can be

--- a/src/prng/mod.rs
+++ b/src/prng/mod.rs
@@ -8,81 +8,238 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! Pseudo random number generators are algorithms to produce *apparently
-//! random* numbers deterministically, and usually fairly quickly.
+//! Pseudo-random number generators.
 //!
-//! So long as the algorithm is computationally secure, is initialised with
-//! sufficient entropy (i.e. unknown by an attacker), and its internal state is
-//! also protected (unknown to an attacker), the output will also be
-//! *computationally secure*. Computationally Secure Pseudo Random Number
-//! Generators (CSPRNGs) are thus suitable sources of random numbers for
-//! cryptography. There are a couple of gotchas here, however. First, the seed
-//! used for initialisation must be unknown. Usually this should be provided by
-//! the operating system and should usually be secure, however this may not
-//! always be the case (especially soon after startup). Second, user-space
-//! memory may be vulnerable, for example when written to swap space, and after
-//! forking a child process should reinitialise any user-space PRNGs. For this
-//! reason it may be preferable to source random numbers directly from the OS
-//! for cryptographic applications.
+//! Pseudo-random number generators are algorithms to produce apparently random
+//! numbers deterministically, and usually fairly quickly. See the documentation
+//! of the [`rngs` module] for some introduction to PRNGs.
 //!
-//! PRNGs are also widely used for non-cryptographic uses: randomised
-//! algorithms, simulations, games. In these applications it is usually not
-//! important for numbers to be cryptographically *unguessable*, but even
-//! distribution and independence from other samples (from the point of view
-//! of someone unaware of the algorithm used, at least) may still be important.
-//! Good PRNGs should satisfy these properties, but do not take them for
-//! granted; Wikipedia's article on
-//! [Pseudorandom number generators](https://en.wikipedia.org/wiki/Pseudorandom_number_generator)
-//! provides some background on this topic.
+//! As mentioned there, PRNGs fall in two broad categories:
 //!
-//! Care should be taken when seeding (initialising) PRNGs. Some PRNGs have
-//! short periods for some seeds. If one PRNG is seeded from another using the
-//! same algorithm, it is possible that both will yield the same sequence of
-//! values (with some lag).
+//! - [normal PRNGs], primarily designed for simulations.
+//! - [CSPRNGs], primarily designed for cryptography.
 //!
-//! ## Cryptographic security
+//! This module provides a few different PRNG implementations, and the
+//! documentation aims to provide enough background to make a reasonably
+//! informed choice.
 //!
-//! First, lets recap some terminology:
 //!
-//! - **PRNG:** *Pseudo-Random-Number-Generator* is another name for an
-//!   *algorithmic generator*
-//! - **CSPRNG:** a *Cryptographically Secure* PRNG
+//! # Normal pseudo-random number generators (PRNGs)
 //!
-//! Security analysis requires a threat model and expert review; we can provide
-//! neither, but we can provide a few hints. We assume that the goal is to
-//! produce secret apparently-random data. Therefore, we need:
+//! The goal of normal PRNGs is usually to find a good balance between
+//! simplicity, quality and performance. They are generally developed for doing
+//! simulations, but the good performance and simplicity make them suitable for
+//! many common programming problems.
 //!
-//! - A good source of entropy. A known algorithm given known input data is
-//!   trivial to predict, and likewise if there's a non-negligable chance that
-//!   the input to a PRNG is guessable then there's a chance its output is too.
-//!   We recommend seeding CSPRNGs with [`EntropyRng`] or [`OsRng`] which
-//!   provide fresh "random" values from an external source.
-//!   One can also seed from another CSPRNG, e.g. [`thread_rng`], which is faster,
-//!   but adds another component which must be trusted.
-//! - A strong algorithmic generator. It is possible to use a good entropy
-//!   source like [`OsRng`] directly, and in some cases this is the best option,
-//!   but for better performance (or if requiring reproducible values generated
-//!   from a fixed seed) it is common to use a local CSPRNG. The basic security
-//!   that CSPRNGs must provide is making it infeasible to predict future output
-//!   given a sample of past output. A further security that *some* CSPRNGs
-//!   provide is *forward secrecy*; this ensures that in the event that the
-//!   algorithm's state is revealed, it is infeasible to reconstruct past
-//!   output. See the [`CryptoRng`] trait and notes on individual algorithms.
-//! - To be careful not to leak secrets like keys and CSPRNG's internal state
-//!   and robust against "side channel attacks". This goes well beyond the scope
-//!   of random number generation, but this crate takes some precautions:
-//!   - to avoid printing CSPRNG state in log files, implementations have a
-//!     custom `Debug` implementation which omits all internal state
-//!   - [`thread_rng`] uses [`ReseedingRng`] to periodically refresh its state
-//!   - in the future we plan to add some protection against fork attacks
-//!     (where the process is forked and each clone generates the same "random"
-//!     numbers); this is not yet implemented (see issues #314, #370)
+//! Mathematical theory is involved to ensure certain properties of the PRNG,
+//! most notably to prove that it doesn't cycle before generating all values in
+//! its period once.
 //!
-//! [`CryptoRng`]: ../trait.CryptoRng.html
-//! [`EntropyRng`]: ../rngs/struct.EntropyRng.html
-//! [`OsRng`]: ../rngs/struct.OsRng.html
-//! [`ReseedingRng`]: ../rngs/adaptor/struct.ReseedingRng.html
-//! [`thread_rng`]: ../fn.thread_rng.html
+//! Usually there are three properties of a PRNG to consider:
+//!
+//! - performance
+//! - quality
+//! - extra features
+//!
+//! Currently Rand provides only one PRNG, and not a very good one at that:
+//! [`XorShiftRng`].
+//!
+//!
+//! ## Performance
+//!
+//! First it has to be said most PRNGs are really incredibly fast, and will
+//! rarely be a performance bottleneck. Performance of PRNGs is however a bit of
+//! a subtle thing. It depends much on the CPU architecture (32 vs. 64 bits),
+//! inlining, but also on the number available of registers, which makes
+//! performance dependent on the surrounding code.
+//!
+//! Some PRNGs are plain and simple faster than others, thanks to using cheaper
+//! instructions, shuffling around less state etc. But when absolute performance
+//! is a goal, benchmarking a few different PRNGs with your specific use case is
+//! always recommended.
+//!
+//!
+//! ## Quality
+//!
+//! Many PRNGs are not much more than a couple of bitwise and arithmetic
+//! operations. Their simplicity gives good performance, but also means there
+//! are small regularities hidden in the generated random number stream.
+//!
+//! How much do those hidden regularities matter? That is hard to say, and
+//! depends on how the RNG gets used. If there happen to be correlations between
+//! the random numbers and the algorithm they are used in, the results can be
+//! wrong or misleading.
+//!
+//! A random number generator can be considered good if it gives the correct
+//! results in as many applications as possible. There are test suites designed
+//! to test how well a PRNG performs on a wide range of possible uses, the
+//! latest and most complete of which are [TestU01] and [PractRand].
+//!
+//! It is easy to measure whether the PRNG is an actual performance bottleneck,
+//! but hard to measure that generated values are as random as you expect them
+//! to be. Then the safe choice is to use an RNG that performs well on the
+//! empirical RNG tests.
+//!
+//! In other situations is is clear that some small hidden regularities are of
+//! no concern. In that case, just choose a fast PRNG.
+//!
+//!
+//! ## Extra features
+//!
+//! Some PRNGs may provide extra features, which can be a reason to prefer that
+//! algorithm over others. Examples include:
+//!
+//! - Support for multiple streams, which helps with parallel tasks;
+//! - The ability to jump or seek around in the random number stream.
+//! - The algorithm uses some chaotic process, which will usually produce much
+//!   more random-looking numbers, at the cost of loosing the ability to reason
+//!   about things like it's period.
+//! - Given previous values, the next value may be predictable, but not
+//!   trivially.
+//! - Having a huge period.
+//!
+//! ## Period
+//!
+//! The period of a PRNG is the number of values after which it starts repeating
+//! the same random number stream. While an important property, it will usually
+//! be of little concern as modern PRNGs just satisfy it.
+//!
+//! On today's hardware, even a fast RNG  with a period of only 2<sup>64</sup>
+//! can be used for centuries before wrapping around. Yet we recommend a period
+//! of 2<sup>128</sup> or more, which most modern PRNGs satisfy. Or a shorter
+//! period, but support for multiple streams. Two reasons:
+//!
+//! If we see the entire period of an RNG as one long random number stream,
+//! every independently seeded RNG returns a slice of that stream. When multiple
+//! RNG are seeded randomly, there is an increasingly large chance to end up
+//! with a partially overlapping slice of the stream.
+//!
+//! If the period of the RNG is 2<sup>128</sup>, and we take 2<sup>48</sup> as
+//! the number of values usually consumed, it then takes about 2<sup>32</sup>
+//! random initializations to have a chance of 1 in a million to repeat part of
+//! an already used stream. Something that seems good enough for common use. As
+//! an estimation, `chance ~= 1-e^((-initializations^2)/(2*period/used))`.
+//!
+//! Also not the entire period of an RNG should be used. The RNG produces every
+//! possible value exactly the same number of times. This is not a property of
+//! true randomness, it is natural to expect some variation in how often values
+//! appear. This is known as the generalized birthday problem, see the
+//! [PCG paper] for a good explanation. It becomes noticable after generating
+//! more values than the root of the period (after 2<sup>64</sup> values for a
+//! period of 2<sup>128</sup>).
+//!
+//!
+//! # Cryptographically secure pseudo-random number generators (CSPRNGs)
+//!
+//! CSPRNGs have much higher requirements than normal PRNGs. The primary
+//! consideration is security. Performance and simplicity are also important,
+//! but in general CSPRNGs are more complex and slower than normal PRNGs.
+//! Quality is no longer a concern, as it is a requirement for a
+//! CSPRNG that the output is basically indistinguishable from true randomness,
+//! otherwise information could be leaked.
+//!
+//! There is a relation between CSPRNGs and cryptographic ciphers.
+//! One way to create a CSPRNG is to take a block cipher and to run in it
+//! counter mode, i.e. to encrypt a simple counter. Another option is to take a
+//! stream cipher, but to just leave out the part where it is combined (usually
+//! XOR-ed) with the plaintext.
+//!
+//! Rand currently provides two CSPRNGs:
+//!
+//! - [`ChaChaRng`]. A reasonable fast RNG using little memory, which works
+//!   by encrypting a counter. Based on the ChaCha20 stream cipher.
+//! - [`Hc128Rng`]. A very fast array-based RNG that requires a lot of memory,
+//!   4 KiB. Based on the HC-128 stream cipher.
+//!
+//! Since the beginning of randomness support in Rust an RNG based on the ISAAC
+//! algorithm ([`IsaacRng`]) has been available. This an example of an algorithm
+//! advertised as secure (which it very well may be), but which since its design
+//! in 1996 never really attracted the attention of cryptography experts.
+//!
+//!
+//! ## Security
+//!
+//! The basic security that CSPRNGs must provide is making it infeasible to
+//! predict future output given a sample of past output. A further security that
+//! some CSPRNGs provide is *forward secrecy*; this ensures that in the event
+//! that the algorithm's state is revealed, it is infeasible to reconstruct past
+//! output.
+//!
+//! As an outsider it is hard to get a good idea about the security of an
+//! algorithm. People in the field of cryptography spend a lot of effort
+//! analyzing existing designs, and what was once considered good may now turn
+//! out to be weaker. Generally it is best to use algorithms well-analyzed by
+//! experts. Not the very latest design, and also not older algorithms that
+//! gained little attention. In practice it is best to just use algorithms
+//! recommended by reputable organizations, such as the ciphers selected by the
+//! eSTREAM contest, or some of those recommended by NIST.
+//!
+//! It is important to use a good source of entropy to get the seed for a
+//! CSPRNG. When a known algorithm is given known input data, it is trivial to
+//! predict. Likewise if there's a non-negligible chance that the input to a
+//! PRNG is guessable, then there's a chance its output is too. We recommend
+//! seeding CSPRNGs using the [`FromEntropy`] trait, which uses fresh random
+//! values from an external source, usually the OS. You can also seed from
+//! another CSPRNG, like [`ThreadRng`], which is faster, but adds another
+//! component which must be trusted.
+//!
+//! ## Not a crypto library
+//!
+//! When using a CSPRNG for cryptographic purposes, more is required than
+//! chosing a good algorithm.
+//!
+//! It is important not to leak secrets such as the seed or the RNG's internal
+//! state, and to prevent other kinds of "side channel attacks". This means
+//! among other things that memory needs to be zeroed on move, and should not
+//! be written to swap space on disk. Another problem is fork attacks, where
+//! the process is forked and each clone generates the same random numbers.
+//!
+//! This all goes beyond the scope of random number generation, use a good
+//! crypto library instead.
+//!
+//! Rand does take a few precautions however. To avoid printing a CSPRNG's state
+//! in log files, implementations have a custom `Debug` implementation which
+//! omits internal state. In the future we plan to add some protection against
+//! fork attacks.
+//!
+//! ## Performance
+//!
+//! Most algorithms don't generate values one at a time, as simple PRNGs, but in
+//! blocks. There will be a longer pause when such a block needs to be
+//! generated, while a random number can be returned almost instantly when there
+//! are unused values in the buffer.
+//!
+//! Performance may be different depending on the architecture; but in contrast
+//! to PRNGs that generate one value at a time, the performance of CSPRNGs
+//! rarely if ever depends on the surrounding code.
+//!
+//! Because generating blocks of values lends itself well to loop unrolling, the
+//! code size of CSPRNGs can be significant.
+//!
+//!
+//! # Further reading
+//!
+//! There is quite a lot that can be said about PRNGs. The [PCG paper] is a
+//! very approachable explaining more concepts.
+//!
+//! A good paper about RNG quality is
+//! ["Good random number generators are (not so) easy to find"](
+//! http://random.mat.sbg.ac.at/results/peter/A19final.pdf) by P. Hellekalek.
+//!
+//!
+//! [`rngs` module]: ../rngs/index.html
+//! [normal PRNGs]: #normal-pseudo-random-number-generators-prngs
+//! [CSPRNGs]: #cryptographically-secure-pseudo-random-number-generators-csprngs
+//! [`XorShiftRng`]: struct.XorShiftRng.html
+//! [`ChaChaRng`]: chacha/struct.ChaChaRng.html
+//! [`Hc128Rng`]: hc128/struct.Hc128Rng.html
+//! [`IsaacRng`]: isaac/struct.IsaacRng.html
+//! [`ThreadRng`]: ../rngs/struct.ThreadRng.html
+//! [`FromEntropy`]: ../trait.FromEntropy.html
+//! [TestU01]: http://simul.iro.umontreal.ca/testu01/tu01.html
+//! [PractRand]: http://pracrand.sourceforge.net/
+//! [PCG paper]: http://www.pcg-random.org/pdf/hmc-cs-2014-0905.pdf
+
 
 pub mod chacha;
 pub mod hc128;

--- a/src/prng/mod.rs
+++ b/src/prng/mod.rs
@@ -16,52 +16,125 @@
 //!
 //! As mentioned there, PRNGs fall in two broad categories:
 //!
-//! - [normal PRNGs], primarily designed for simulations.
-//! - [CSPRNGs], primarily designed for cryptography.
+//! - [basic PRNGs], primarily designed for simulations
+//! - [CSPRNGs], primarily designed for cryptography
 //!
-//! This module provides a few different PRNG implementations, and the
-//! documentation aims to provide enough background to make a reasonably
-//! informed choice.
+//! In simple terms, the basic PRNGs are often predictable; CSPRNGs should not
+//! be predictable *when used correctly*.
+//! 
+//! Contents of this documentation:
+//!
+//! 1. [The generators](#the-generators)
+//! 1. [Performance and size](#performance)
+//! 1. [Quality and cycle length](#quality)
+//! 1. [Security](#security)
+//! 1. [Extra features](#extra-features)
+//! 1. [Further reading](#further-reading)
 //!
 //!
-//! # Normal pseudo-random number generators (PRNGs)
+//! # The generators
 //!
-//! The goal of normal PRNGs is usually to find a good balance between
-//! simplicity, quality and performance. They are generally developed for doing
-//! simulations, but the good performance and simplicity make them suitable for
-//! many common programming problems.
+//! ## Basic pseudo-random number generators (PRNGs)
 //!
-//! Mathematical theory is involved to ensure certain properties of the PRNG,
-//! most notably to prove that it doesn't cycle before generating all values in
-//! its period once.
-//!
-//! Usually there are three properties of a PRNG to consider:
-//!
-//! - performance
-//! - quality
-//! - extra features
+//! The goal of non-cryptographic PRNGs is usually to find a good balance between
+//! simplicity, quality, memory usage and performance. These algorithms are
+//! very important to Monte Carlo simulations, and also suitable for several
+//! other problems such as randomised algorithms and games (except where there
+//! is a risk of players predicting the next output value from previous values,
+//! in which case a CSPRNG should be used).
 //!
 //! Currently Rand provides only one PRNG, and not a very good one at that:
-//! [`XorShiftRng`].
+//!
+//! | name | performance | worst-case | memory usage | initialisation | quality | predictability |
+//! |----- |------------ |----------- | -------------|--------------- |-------- |--------------- |
+//! | [`XorShiftRng`] | fast | fast | 16 bytes | fast | poor | trivial after 4 words |
+//!
+//! ## Cryptographically secure pseudo-random number generators (CSPRNGs)
+//!
+//! CSPRNGs have much higher requirements than normal PRNGs. The primary
+//! consideration is security. Performance and simplicity are also important,
+//! but in general CSPRNGs are more complex and slower than normal PRNGs.
+//! Quality is no longer a concern, as it is a requirement for a
+//! CSPRNG that the output is basically indistinguishable from true randomness
+//! since any bias or correlation makes the output more predictable.
+//!
+//! There is a close relationship between CSPRNGs and cryptographic ciphers.
+//! Any block cipher can be turned into a CSPRNG simply by encrypting a counter.
+//! Stream ciphers are simply a CSPRNG and a combining operation, usually XOR.
+//! This means that we can easily use any stream cipher as a CSPRNG.
+//!
+//! Rand currently provides two trustworthy CSPRNGs and two CSPRNG-like PRNGs:
+//!
+//! | name | performance | memory usage | initialisation | predictability | forward-secure |
+//! |----- |------------ | -------------|--------------- |--------------- |--------------- |
+//! | [`ChaChaRng`] | moderate | 136 bytes | fast        | secure         | no             |
+//! | [`Hc128Rng`] | fast | 4176 bytes  | slow           | secure         | no             |
+//! | [`IsaacRng`] | good | 2072 bytes  | slow           | unknown        | unknown        |
+//! | [`Isaac64Rng`] | fast | 4136 bytes | slow          | unknown        | unknown        |
+//!
+//! It should be noted that the ISAAC generators are only included for
+//! historical reasons, originally being selected as a "compromise" between
+//! security and performance. They have good quality output and no attacks are
+//! known, but have received little review from cryptography experts.
 //!
 //!
-//! ## Performance
+//! # Performance
 //!
-//! First it has to be said most PRNGs are really incredibly fast, and will
+//! First it has to be said most PRNGs are very fast, and will
 //! rarely be a performance bottleneck. Performance of PRNGs is however a bit of
-//! a subtle thing. It depends much on the CPU architecture (32 vs. 64 bits),
-//! inlining, but also on the number available of registers, which makes
-//! performance dependent on the surrounding code.
+//! a subtle thing. It depends a lot on the CPU architecture (32 vs. 64 bits),
+//! inlining, and also on the number available of registers. The performance of
+//! simple PRNGs is often affected by surrounding code due to inlining and
+//! other usage of registers.
 //!
-//! Some PRNGs are plain and simple faster than others, thanks to using cheaper
-//! instructions, shuffling around less state etc. But when absolute performance
-//! is a goal, benchmarking a few different PRNGs with your specific use case is
-//! always recommended.
+//! When choosing a PRNG for performance it is very important to benchmark your
+//! own application due to interactions between PRNGs and surrounding code and
+//! dependence on the CPU architecture as well as the impact of the size of
+//! data requested. Because of all this, we do not include performance numbers
+//! here but merely a qualitative description.
 //!
+//! CSPRNGs are a little different in that they typically generate a block of
+//! output in a cache, and pull outputs from the cache. This allows them to have
+//! good amortised performance, and reduces or completely removes the influence
+//! of surrounding code on the CSPRNG performance.
 //!
-//! ## Quality
+//! ## Worst-case performance
 //!
-//! Many PRNGs are not much more than a couple of bitwise and arithmetic
+//! Simple PRNGs tend to use constant-time functions and thus have very good
+//! worst case performance. In contrast, CSPRNGs usually produce a block of
+//! values into a cache, giving them poor worst case performance.
+//!
+//! ## State size
+//!
+//! Simple PRNGs often use very little memory, from as little as one word but
+//! commonly 2-4 words, where a *word* is usually either `u32` or `u64`. This
+//! is not universal across non-cryptographic PRNGs however; for example the
+//! previously popular Mersenne Twister MT19937 algorithm requires 2.5 kB of
+//! state.
+//!
+//! CSPRNGs typically require more memory; since the seed size is recommended
+//! to be at least 192 bits and more memory is required for a counter, 256 bits
+//! would be approximately the minimum secure size. In practice, CSPRNGs tend
+//! to use a lot of memory; [`ChaChaRng`] is relatively small with 512 bits
+//! state + 512 bits cache + cache counter (136 bytes on x86_64) while [`Hc128Rng`]
+//! requires over 4 kB.
+//! 
+//! ## Initialisation time
+//!
+//! The time required to initialise new generators varies significantly. Many
+//! simple PRNGs and even some cryptographic ones (including [`ChaChaRng`])
+//! only need to copy the seed value and some constants into their state, and
+//! thus can be constructed very quickly. In contrast, CSPRNGs with large state
+//! require key-expansion, often achieved by using their state-advance function
+//! many times over.
+//!
+//! # Quality
+//!
+//! PRNGs are based in mathematical Number Theory. The quality of PRNG
+//! algorithms can be evaluated both analytically and empirically in order to
+//! examine for bias, correlations and cycle length.
+//!
+//! Many simple PRNGs are not much more than a couple of bitwise and arithmetic
 //! operations. Their simplicity gives good performance, but also means there
 //! are small regularities hidden in the generated random number stream.
 //!
@@ -70,137 +143,126 @@
 //! the random numbers and the algorithm they are used in, the results can be
 //! wrong or misleading.
 //!
+//! CSPRNGs tend to be much more complex (or at least use many more operations)
+//! and have an explicit requirement to be unpredictable; this implies there
+//! must be no obvious correlations between output values.
+//!
 //! A random number generator can be considered good if it gives the correct
 //! results in as many applications as possible. There are test suites designed
 //! to test how well a PRNG performs on a wide range of possible uses, the
 //! latest and most complete of which are [TestU01] and [PractRand].
 //!
-//! It is easy to measure whether the PRNG is an actual performance bottleneck,
-//! but hard to measure that generated values are as random as you expect them
-//! to be. Then the safe choice is to use an RNG that performs well on the
-//! empirical RNG tests.
-//!
-//! In other situations is is clear that some small hidden regularities are of
-//! no concern. In that case, just choose a fast PRNG.
-//!
-//!
-//! ## Extra features
-//!
-//! Some PRNGs may provide extra features, which can be a reason to prefer that
-//! algorithm over others. Examples include:
-//!
-//! - Support for multiple streams, which helps with parallel tasks;
-//! - The ability to jump or seek around in the random number stream.
-//! - The algorithm uses some chaotic process, which will usually produce much
-//!   more random-looking numbers, at the cost of loosing the ability to reason
-//!   about things like it's period.
-//! - Given previous values, the next value may be predictable, but not
-//!   trivially.
-//! - Having a huge period.
-//!
 //! ## Period
 //!
-//! The period of a PRNG is the number of values after which it starts repeating
-//! the same random number stream. While an important property, it will usually
-//! be of little concern as modern PRNGs just satisfy it.
+//! The *period* or *cycle length* of a PRNG is the number of samples (or amount
+//! of data) which can be generated before the algorithm's state returns to a
+//! previous value (from where it will *cycle* over all previous output again).
+//! Since PRNGs typically have a fixed state size, the maximum cycle length is
+//! 2<sup>n</sup> where *n* is the number of bits in the state, but often it is
+//! less; with some algorithms the cycle length is fixed, while for others it
+//! depends on the seed.
 //!
-//! On today's hardware, even a fast RNG  with a period of only 2<sup>64</sup>
-//! can be used for centuries before wrapping around. Yet we recommend a period
-//! of 2<sup>128</sup> or more, which most modern PRNGs satisfy. Or a shorter
-//! period, but support for multiple streams. Two reasons:
+//! Generally it is desired that the cycle length is sufficiently long not to
+//! cycle during usage; a period of *only* 2<sup>64</sup> can be used for
+//! centuries before cycling. Despite this, we recommend a period of
+//! 2<sup>128</sup> or more, which most modern PRNGs satisfy; alternatively
+//! a PRNG with shorter period but support for multiple streams may be chosen.
+//! There are two reasons for this, as follows.
 //!
-//! If we see the entire period of an RNG as one long random number stream,
-//! every independently seeded RNG returns a slice of that stream. When multiple
-//! RNG are seeded randomly, there is an increasingly large chance to end up
-//! with a partially overlapping slice of the stream.
+//! With small PRNGs, often two different seeds will be part of the same cycle,
+//! thus will use two slices from the same (large) sequence. There is no
+//! guarantee that these slices do not overlap, although when the whole sequence
+//! (cycle) is much larger than the slices the chance of overlap is small.
+//! When many independently seeded PRNGs are used this is especially important.
 //!
-//! If the period of the RNG is 2<sup>128</sup>, and we take 2<sup>48</sup> as
-//! the number of values usually consumed, it then takes about 2<sup>32</sup>
-//! random initializations to have a chance of 1 in a million to repeat part of
-//! an already used stream. Something that seems good enough for common use. As
-//! an estimation, `chance ~= 1-e^((-initializations^2)/(2*period/used))`.
+//! If the period of the RNG is 2<sup>128</sup>, and an application consumes
+//! 2<sup>48</sup> values, it then takes about 2<sup>32</sup> random
+//! initializations to have a chance of 1 in a million to repeat part of an
+//! already used stream. This seems good enough for common usage of
+//! non-cryptographic generators, hence the recommendation of at least
+//! 2<sup>128</sup>. As an estimate, the chance of any overlap in a period of
+//! size `p` with `n` independent seeds and `u` values used per seed is
+//! approximately `1 - e^(-u * n^2 / (2 * p))`.
 //!
-//! Also not the entire period of an RNG should be used. The RNG produces every
-//! possible value exactly the same number of times. This is not a property of
-//! true randomness, it is natural to expect some variation in how often values
-//! appear. This is known as the generalized birthday problem, see the
-//! [PCG paper] for a good explanation. It becomes noticable after generating
-//! more values than the root of the period (after 2<sup>64</sup> values for a
+//! Further, it is not recommended to use the full period of an RNG. Many
+//! PRNGs have a property called *k-dimensional equidistribution*, meaning that
+//! for values of some size (potentially larger than the output size), all
+//! possible values are produced the same number of times over the generator's
+//! period. This is not a property of true randomness. This is known as the
+//! generalized birthday problem, see the [PCG paper] for a good explanation.
+//! This results in a noticable bias on output after generating more values
+//! than the square root of the period (after 2<sup>64</sup> values for a
 //! period of 2<sup>128</sup>).
 //!
 //!
-//! # Cryptographically secure pseudo-random number generators (CSPRNGs)
+//! # Security
 //!
-//! CSPRNGs have much higher requirements than normal PRNGs. The primary
-//! consideration is security. Performance and simplicity are also important,
-//! but in general CSPRNGs are more complex and slower than normal PRNGs.
-//! Quality is no longer a concern, as it is a requirement for a
-//! CSPRNG that the output is basically indistinguishable from true randomness,
-//! otherwise information could be leaked.
+//! ## Predictability
 //!
-//! There is a relation between CSPRNGs and cryptographic ciphers.
-//! One way to create a CSPRNG is to take a block cipher and to run in it
-//! counter mode, i.e. to encrypt a simple counter. Another option is to take a
-//! stream cipher, but to just leave out the part where it is combined (usually
-//! XOR-ed) with the plaintext.
+//! From the context of any PRNG, one can ask the question *given some previous
+//! output from the PRNG, is it possible to predict the next output value?*
 //!
-//! Rand currently provides two CSPRNGs:
+//! Simple PRNGs tend to fall into one of two categories here; *yes* and
+//! *possibly*. In some cases prediction is trivial; e.g. plain Xorshift outputs
+//! part of its state without mutation, and prediction is as simple as seeding
+//! a new Xorshift generator from four `u32` outputs. The widely-used Mersenne
+//! Twister algorithms are also easy to predict, though more samples are
+//! required (624 `u32` samples, in the case of MT19937). At the other end of
+//! the range, the PCG generators are small and fast yet designed to be
+//! [hard to predict](http://www.pcg-random.org/predictability.html),
+//! however they should not be trusted to be secure.
 //!
-//! - [`ChaChaRng`]. A reasonable fast RNG using little memory, which works
-//!   by encrypting a counter. Based on the ChaCha20 stream cipher.
-//! - [`Hc128Rng`]. A very fast array-based RNG that requires a lot of memory,
-//!   4 KiB. Based on the HC-128 stream cipher.
+//! The basic security that CSPRNGs must provide is precisely the above, i.e.
+//! infeasible to predict. This requirement is formalised as the
+//! [next-bit test]; this is roughly stated as: given the first *k* bits of a
+//! random sequence, the sequence satisfies the next-bit test if there is no
+//! algorithm able to predict the next bit using reasonable computing power.
+//! We therefore rate predictability as one of *secure*, *unknown* (meaning
+//! apparently strong and no known attacks, but not trusted) or *insecure*.
 //!
-//! Since the beginning of randomness support in Rust an RNG based on the ISAAC
-//! algorithm ([`IsaacRng`]) has been available. This an example of an algorithm
-//! advertised as secure (which it very well may be), but which since its design
-//! in 1996 never really attracted the attention of cryptography experts.
-//!
-//!
-//! ## Security
-//!
-//! The basic security that CSPRNGs must provide is making it infeasible to
-//! predict future output given a sample of past output. A further security that
-//! some CSPRNGs provide is *forward secrecy*; this ensures that in the event
-//! that the algorithm's state is revealed, it is infeasible to reconstruct past
-//! output.
+//! A further security that *some* CSPRNGs provide is forward-security: in the
+//! event that the CSPRNGs state is revealed after generating some output, it
+//! must be infeasible to reconstruct previous states or output. Note that many
+//! CSPRNGs *do not* have forward-security in their usual formulations. It is
+//! possible to make any CSPRNG forward-secure by reseeding it from its own
+//! output after generating each output value, however this is quite slow
+//! (especially since CSPRNGs usually cache a block of output values).
 //!
 //! As an outsider it is hard to get a good idea about the security of an
 //! algorithm. People in the field of cryptography spend a lot of effort
 //! analyzing existing designs, and what was once considered good may now turn
 //! out to be weaker. Generally it is best to use algorithms well-analyzed by
-//! experts. Not the very latest design, and also not older algorithms that
-//! gained little attention. In practice it is best to just use algorithms
-//! recommended by reputable organizations, such as the ciphers selected by the
-//! eSTREAM contest, or some of those recommended by NIST.
+//! experts, such as those recommended by NIST or ECRYPT.
 //!
-//! It is important to use a good source of entropy to get the seed for a
-//! CSPRNG. When a known algorithm is given known input data, it is trivial to
-//! predict. Likewise if there's a non-negligible chance that the input to a
-//! PRNG is guessable, then there's a chance its output is too. We recommend
-//! seeding CSPRNGs using the [`FromEntropy`] trait, which uses fresh random
-//! values from an external source, usually the OS. You can also seed from
-//! another CSPRNG, like [`ThreadRng`], which is faster, but adds another
-//! component which must be trusted.
+//! ## State and seeding
+//!
+//! It is worth noting that a CSPRNG's security relies absolutely on being
+//! seeded with a secure random key. Should the key be known or guessable, all
+//! output of the CSPRNG is easy to guess. This implies that the seed should
+//! come from a trusted source; usually either the OS or another CSPRNG. Our
+//! seeding helper trait, [`FromEntropy`], and the source it uses
+//! ([`EntropyRng`]), should be secure. Additionally, [`ThreadRng`] is a CSPRNG,
+//! thus it is acceptable to seed from this (although for security applications
+//! fresh/external entropy should be preferred).
+//!
+//! Further, it should be obvious that the internal state of a CSPRNG must be
+//! kept secret. With that in mind, our implementations do not provide direct
+//! access to most of their internal state, and `Debug` implementations do not
+//! print any internal state. Of course this does not fully protect CSPRNG
+//! state; code within the same process may of course read this memory (and we
+//! allow cloning and serialisation of CSPRNGs for convenience). Further, a
+//! running process may be forked by the operating system, which may leave both
+//! processes with a copy of the same generator.
 //!
 //! ## Not a crypto library
 //!
-//! When using a CSPRNG for cryptographic purposes, more is required than
-//! chosing a good algorithm.
-//!
-//! It is important not to leak secrets such as the seed or the RNG's internal
-//! state, and to prevent other kinds of "side channel attacks". This means
-//! among other things that memory needs to be zeroed on move, and should not
-//! be written to swap space on disk. Another problem is fork attacks, where
-//! the process is forked and each clone generates the same random numbers.
-//!
-//! This all goes beyond the scope of random number generation, use a good
-//! crypto library instead.
-//!
-//! Rand does take a few precautions however. To avoid printing a CSPRNG's state
-//! in log files, implementations have a custom `Debug` implementation which
-//! omits internal state. In the future we plan to add some protection against
-//! fork attacks.
+//! It should be emphasised that this is not a cryptography library; although
+//! Rand does take some measures to provide secure random numbers, it does not
+//! necessarily take all recommended measures. Further, cryptographic processes
+//! such as encryption and authentication are complex and must be implemented
+//! very carefully to avoid flaws and resist known attacks. It is therefore
+//! recommended to use a higher-level libraries where possible, for example
+//! [openssl], [ring] and the [RustCrypto libraries].
 //!
 //! ## Performance
 //!
@@ -217,6 +279,15 @@
 //! code size of CSPRNGs can be significant.
 //!
 //!
+//! # Extra features
+//!
+//! Some PRNGs may provide extra features:
+//!
+//! - Support for multiple streams, which can help with parallel tasks
+//! - The ability to jump or seek around in the random number stream;
+//!   with large periood this can be used as an alternative to streams
+//!
+//!
 //! # Further reading
 //!
 //! There is quite a lot that can be said about PRNGs. The [PCG paper] is a
@@ -228,17 +299,21 @@
 //!
 //!
 //! [`rngs` module]: ../rngs/index.html
-//! [normal PRNGs]: #normal-pseudo-random-number-generators-prngs
+//! [basic PRNGs]: #basic-pseudo-random-number-generators-prngs
 //! [CSPRNGs]: #cryptographically-secure-pseudo-random-number-generators-csprngs
 //! [`XorShiftRng`]: struct.XorShiftRng.html
 //! [`ChaChaRng`]: chacha/struct.ChaChaRng.html
 //! [`Hc128Rng`]: hc128/struct.Hc128Rng.html
 //! [`IsaacRng`]: isaac/struct.IsaacRng.html
+//! [`Isaac64Rng`]: isaac64/struct.Isaac64Rng.html
 //! [`ThreadRng`]: ../rngs/struct.ThreadRng.html
 //! [`FromEntropy`]: ../trait.FromEntropy.html
 //! [TestU01]: http://simul.iro.umontreal.ca/testu01/tu01.html
 //! [PractRand]: http://pracrand.sourceforge.net/
 //! [PCG paper]: http://www.pcg-random.org/pdf/hmc-cs-2014-0905.pdf
+//! [openssl]: https://crates.io/crates/openssl
+//! [ring]: https://crates.io/crates/ring
+//! [RustCrypto libraries]: https://github.com/RustCrypto
 
 
 pub mod chacha;

--- a/src/prng/mod.rs
+++ b/src/prng/mod.rs
@@ -16,10 +16,10 @@
 //!
 //! As mentioned there, PRNGs fall in two broad categories:
 //!
-//! - [basic PRNGs], primarily designed for simulations
+//! - [normal PRNGs], primarily designed for simulations
 //! - [CSPRNGs], primarily designed for cryptography
 //!
-//! In simple terms, the basic PRNGs are often predictable; CSPRNGs should not
+//! In simple terms, the normal PRNGs are often predictable; CSPRNGs should not
 //! be predictable *when used correctly*.
 //! 
 //! Contents of this documentation:
@@ -34,20 +34,20 @@
 //!
 //! # The generators
 //!
-//! ## Basic pseudo-random number generators (PRNGs)
+//! ## Normal pseudo-random number generators (PRNGs)
 //!
-//! The goal of non-cryptographic PRNGs is usually to find a good balance between
-//! simplicity, quality, memory usage and performance. These algorithms are
-//! very important to Monte Carlo simulations, and also suitable for several
-//! other problems such as randomised algorithms and games (except where there
-//! is a risk of players predicting the next output value from previous values,
-//! in which case a CSPRNG should be used).
+//! The goal of normal, non-cryptographic PRNGs is usually to find a good
+//! balance between simplicity, quality, memory usage and performance. These
+//! algorithms are very important to Monte Carlo simulations, and also suitable
+//! for several other problems such as randomized algorithms and games (except
+//! where there is a risk of players predicting the next output value from
+//! previous values, in which case a CSPRNG should be used).
 //!
 //! Currently Rand provides only one PRNG, and not a very good one at that:
 //!
-//! | name | performance | worst-case | memory usage | initialisation | quality | predictability |
-//! |----- |------------ |----------- | -------------|--------------- |-------- |--------------- |
-//! | [`XorShiftRng`] | fast | fast | 16 bytes | fast | poor | trivial after 4 words |
+//! | name | full name | performance | memory | quality | period | features |
+//! |------|-----------|-------------|--------|---------|--------|----------|
+//! | [`XorShiftRng`] | Xorshift 32/128 | ⭐⭐⭐ | 16 bytes | ⭐ | `u32` * 2<sup>128</sup> - 1 | — |
 //!
 //! ## Cryptographically secure pseudo-random number generators (CSPRNGs)
 //!
@@ -59,82 +59,72 @@
 //! since any bias or correlation makes the output more predictable.
 //!
 //! There is a close relationship between CSPRNGs and cryptographic ciphers.
-//! Any block cipher can be turned into a CSPRNG simply by encrypting a counter.
-//! Stream ciphers are simply a CSPRNG and a combining operation, usually XOR.
-//! This means that we can easily use any stream cipher as a CSPRNG.
+//! Any block cipher can be turned into a CSPRNG by encrypting a counter. Stream
+//! ciphers are basically a CSPRNG and a combining operation, usually XOR. This
+//! means that we can easily use any stream cipher as a CSPRNG.
 //!
 //! Rand currently provides two trustworthy CSPRNGs and two CSPRNG-like PRNGs:
 //!
-//! | name | performance | memory usage | initialisation | predictability | forward-secure |
-//! |----- |------------ | -------------|--------------- |--------------- |--------------- |
-//! | [`ChaChaRng`] | moderate | 136 bytes | fast        | secure         | no             |
-//! | [`Hc128Rng`] | fast | 4176 bytes  | slow           | secure         | no             |
-//! | [`IsaacRng`] | good | 2072 bytes  | slow           | unknown        | unknown        |
-//! | [`Isaac64Rng`] | fast | 4136 bytes | slow          | unknown        | unknown        |
+//! | name | full name |  performance | initialization | memory | predictability | backtracking resistance |
+//! |------|-----------|--------------|--------------|----------|----------------|-------------------------|
+//! | [`ChaChaRng`] | ChaCha20 | ⭐⭐⭐ | ⭐⭐⭐⭐⭐ | 136 bytes | secure | no |
+//! | [`Hc128Rng`] | HC-128 | ⭐⭐⭐⭐⭐ | ⭐ | 4176 bytes | secure | no |
+//! | [`IsaacRng`] | ISAAC | ⭐⭐⭐⭐ | ⭐ | 2072 bytes | unknown | unknown |
+//! | [`Isaac64Rng`] | ISAAC-64 | ⭐⭐⭐⭐⭐ | ⭐ | 4136 bytes| unknown | unknown |
 //!
 //! It should be noted that the ISAAC generators are only included for
-//! historical reasons, originally being selected as a "compromise" between
-//! security and performance. They have good quality output and no attacks are
-//! known, but have received little review from cryptography experts.
+//! historical reasons, they have been with the Rust language since the very
+//! beginning. They have good quality output and no attacks are known, but have
+//! received little attention from cryptography experts.
 //!
 //!
 //! # Performance
 //!
-//! First it has to be said most PRNGs are very fast, and will
-//! rarely be a performance bottleneck. Performance of PRNGs is however a bit of
-//! a subtle thing. It depends a lot on the CPU architecture (32 vs. 64 bits),
-//! inlining, and also on the number available of registers. The performance of
-//! simple PRNGs is often affected by surrounding code due to inlining and
-//! other usage of registers.
+//! First it has to be said most PRNGs are very fast, and will rarely be a
+//! performance bottleneck.
 //!
-//! When choosing a PRNG for performance it is very important to benchmark your
-//! own application due to interactions between PRNGs and surrounding code and
+//! Performance of normal PRNGs is a bit of a subtle thing. It depends a lot on
+//! the CPU architecture (32 vs. 64 bits), inlining, and also on the number of
+//! available registers. This often causes the performance to be affected by
+//! surrounding code due to inlining and other usage of registers.
+//!
+//! When choosing a PRNG for performance it is important to benchmark your own
+//! application due to interactions between PRNGs and surrounding code and
 //! dependence on the CPU architecture as well as the impact of the size of
 //! data requested. Because of all this, we do not include performance numbers
-//! here but merely a qualitative description.
+//! here but merely a qualitative rating (which is not comparable between PRNGs
+//! and CSPRNGs).
 //!
 //! CSPRNGs are a little different in that they typically generate a block of
 //! output in a cache, and pull outputs from the cache. This allows them to have
 //! good amortised performance, and reduces or completely removes the influence
-//! of surrounding code on the CSPRNG performance.
-//!
-//! ## Worst-case performance
-//!
-//! Simple PRNGs tend to use constant-time functions and thus have very good
-//! worst case performance. In contrast, CSPRNGs usually produce a block of
-//! values into a cache, giving them poor worst case performance.
+//! of surrounding code on the CSPRNG performance. It does however cause *poor
+//! worst case performance*.
 //!
 //! ## State size
 //!
-//! Simple PRNGs often use very little memory, from as little as one word but
-//! commonly 2-4 words, where a *word* is usually either `u32` or `u64`. This
-//! is not universal across non-cryptographic PRNGs however; for example the
-//! previously popular Mersenne Twister MT19937 algorithm requires 2.5 kB of
-//! state.
+//! Normal PRNGs often use very little memory, commonly only a few words, where
+//! a *word* is usually either `u32` or `u64`. This is not universal however,
+//! for example the historically popular Mersenne Twister MT19937 algorithm
+//! requires 2.5 kB of state.
 //!
 //! CSPRNGs typically require more memory; since the seed size is recommended
-//! to be at least 192 bits and more memory is required for a counter, 256 bits
-//! would be approximately the minimum secure size. In practice, CSPRNGs tend
-//! to use a lot of memory; [`ChaChaRng`] is relatively small with 512 bits
-//! state + 512 bits cache + cache counter (136 bytes on x86_64) while [`Hc128Rng`]
-//! requires over 4 kB.
+//! to be at least 192 bits and some more may be required for the algorithm,
+//! 256 bits would be approximately the minimum secure size. In practice,
+//! CSPRNGs tend to use quite a bit more, [`ChaChaRng`] is relatively small with
+//! 136 bytes.
 //! 
-//! ## Initialisation time
+//! ## Initialization time
 //!
-//! The time required to initialise new generators varies significantly. Many
+//! The time required to initialize new generators varies significantly. Many
 //! simple PRNGs and even some cryptographic ones (including [`ChaChaRng`])
 //! only need to copy the seed value and some constants into their state, and
 //! thus can be constructed very quickly. In contrast, CSPRNGs with large state
-//! require key-expansion, often achieved by using their state-advance function
-//! many times over.
+//! require an expensive key-expansion.
 //!
 //! # Quality
 //!
-//! PRNGs are based in mathematical Number Theory. The quality of PRNG
-//! algorithms can be evaluated both analytically and empirically in order to
-//! examine for bias, correlations and cycle length.
-//!
-//! Many simple PRNGs are not much more than a couple of bitwise and arithmetic
+//! Many normal PRNGs are not much more than a couple of bitwise and arithmetic
 //! operations. Their simplicity gives good performance, but also means there
 //! are small regularities hidden in the generated random number stream.
 //!
@@ -143,37 +133,35 @@
 //! the random numbers and the algorithm they are used in, the results can be
 //! wrong or misleading.
 //!
-//! CSPRNGs tend to be much more complex (or at least use many more operations)
-//! and have an explicit requirement to be unpredictable; this implies there
-//! must be no obvious correlations between output values.
-//!
 //! A random number generator can be considered good if it gives the correct
-//! results in as many applications as possible. There are test suites designed
-//! to test how well a PRNG performs on a wide range of possible uses, the
-//! latest and most complete of which are [TestU01] and [PractRand].
+//! results in as many applications as possible. The quality of PRNG
+//! algorithms can be evaluated to some extend analytically, to determine the
+//! cycle length and to rule out some correlations. Then there are empirical
+//! test suites designed to test how well a PRNG performs on a wide range of
+//! possible uses, the latest and most complete of which are [TestU01] and
+//! [PractRand].
+//!
+//! CSPRNGs tend to be more complex, and have an explicit requirement to be
+//! unpredictable. This implies there must be no obvious correlations between
+//! output values.
 //!
 //! ## Period
 //!
-//! The *period* or *cycle length* of a PRNG is the number of samples (or amount
-//! of data) which can be generated before the algorithm's state returns to a
-//! previous value (from where it will *cycle* over all previous output again).
-//! Since PRNGs typically have a fixed state size, the maximum cycle length is
-//! 2<sup>n</sup> where *n* is the number of bits in the state, but often it is
-//! less; with some algorithms the cycle length is fixed, while for others it
-//! depends on the seed.
+//! The *period* or *cycle length* of a PRNG is the number of values that can be
+//! generated after which it starts repeating the same random number stream.
+//! Many PRNGs have a fixed-size period, but for some only an expected average
+//! cycle length can be given, where the exact length depends on the seed.
 //!
-//! Generally it is desired that the cycle length is sufficiently long not to
-//! cycle during usage; a period of *only* 2<sup>64</sup> can be used for
-//! centuries before cycling. Despite this, we recommend a period of
-//! 2<sup>128</sup> or more, which most modern PRNGs satisfy; alternatively
-//! a PRNG with shorter period but support for multiple streams may be chosen.
-//! There are two reasons for this, as follows.
+//! On today's hardware, even a fast RNG with a cycle length of *only*
+//! 2<sup>64</sup> can be used for centuries before cycling. Yet we recommend a
+//! period of 2<sup>128</sup> or more, which most modern PRNGs satisfy.
+//! Alternatively a PRNG with shorter period but support for multiple streams
+//! may be chosen. There are two reasons for this, as follows.
 //!
-//! With small PRNGs, often two different seeds will be part of the same cycle,
-//! thus will use two slices from the same (large) sequence. There is no
-//! guarantee that these slices do not overlap, although when the whole sequence
-//! (cycle) is much larger than the slices the chance of overlap is small.
-//! When many independently seeded PRNGs are used this is especially important.
+//! If we see the entire period of an RNG as one long random number stream,
+//! every independently seeded RNG returns a slice of that stream. When multiple
+//! RNG are seeded randomly, there is an increasingly large chance to end up
+//! with a partially overlapping slice of the stream.
 //!
 //! If the period of the RNG is 2<sup>128</sup>, and an application consumes
 //! 2<sup>48</sup> values, it then takes about 2<sup>32</sup> random
@@ -202,31 +190,26 @@
 //! From the context of any PRNG, one can ask the question *given some previous
 //! output from the PRNG, is it possible to predict the next output value?*
 //!
-//! Simple PRNGs tend to fall into one of two categories here; *yes* and
-//! *possibly*. In some cases prediction is trivial; e.g. plain Xorshift outputs
-//! part of its state without mutation, and prediction is as simple as seeding
-//! a new Xorshift generator from four `u32` outputs. The widely-used Mersenne
-//! Twister algorithms are also easy to predict, though more samples are
-//! required (624 `u32` samples, in the case of MT19937). At the other end of
-//! the range, the PCG generators are small and fast yet designed to be
-//! [hard to predict](http://www.pcg-random.org/predictability.html),
-//! however they should not be trusted to be secure.
+//! Normal PRNGs tend to fall into one of two categories here; *yes* and
+//! *with effort*. In some cases prediction is trivial; e.g. plain Xorshift
+//! outputs part of its state without mutation, and prediction is as simple as
+//! seeding a new Xorshift generator from four `u32` outputs. The widely-used
+//! Mersenne Twister algorithms are also easy to predict, though more samples
+//! are required (624 `u32` samples, in the case of MT19937). Other generators,
+//! like [PCG](http://www.pcg-random.org/predictability.html) and truncated
+//! Xorshift* are harder to predict, but not outside the realm of common
+//! mathematics and a desktop PC.
 //!
-//! The basic security that CSPRNGs must provide is precisely the above, i.e.
-//! infeasible to predict. This requirement is formalised as the
-//! [next-bit test]; this is roughly stated as: given the first *k* bits of a
-//! random sequence, the sequence satisfies the next-bit test if there is no
-//! algorithm able to predict the next bit using reasonable computing power.
-//! We therefore rate predictability as one of *secure*, *unknown* (meaning
-//! apparently strong and no known attacks, but not trusted) or *insecure*.
+//! The basic security that CSPRNGs must provide is the infeasibility to predict
+//! output. This requirement is formalized as the [next-bit test]; this is
+//! roughly stated as: given the first *k* bits of a random sequence, the
+//! sequence satisfies the next-bit test if there is no algorithm able to
+//! predict the next bit using reasonable computing power.
 //!
-//! A further security that *some* CSPRNGs provide is forward-security: in the
-//! event that the CSPRNGs state is revealed after generating some output, it
-//! must be infeasible to reconstruct previous states or output. Note that many
-//! CSPRNGs *do not* have forward-security in their usual formulations. It is
-//! possible to make any CSPRNG forward-secure by reseeding it from its own
-//! output after generating each output value, however this is quite slow
-//! (especially since CSPRNGs usually cache a block of output values).
+//! A further security that *some* CSPRNGs provide is backtracking resistance:
+//! in the event that the CSPRNGs state is revealed at some point, it must be
+//! infeasible to reconstruct previous states or output. Note that many CSPRNGs
+//! *do not* have backtracking resistance in their usual formulations.
 //!
 //! As an outsider it is hard to get a good idea about the security of an
 //! algorithm. People in the field of cryptography spend a lot of effort
@@ -248,11 +231,11 @@
 //! Further, it should be obvious that the internal state of a CSPRNG must be
 //! kept secret. With that in mind, our implementations do not provide direct
 //! access to most of their internal state, and `Debug` implementations do not
-//! print any internal state. Of course this does not fully protect CSPRNG
-//! state; code within the same process may of course read this memory (and we
-//! allow cloning and serialisation of CSPRNGs for convenience). Further, a
-//! running process may be forked by the operating system, which may leave both
-//! processes with a copy of the same generator.
+//! print any internal state. This does not fully protect CSPRNG state; code
+//! within the same process may read this memory (and we allow cloning and
+//! serialisation of CSPRNGs for convenience). Further, a running process may be
+//! forked by the operating system, which may leave both processes with a copy
+//! of the same generator.
 //!
 //! ## Not a crypto library
 //!
@@ -261,31 +244,17 @@
 //! necessarily take all recommended measures. Further, cryptographic processes
 //! such as encryption and authentication are complex and must be implemented
 //! very carefully to avoid flaws and resist known attacks. It is therefore
-//! recommended to use a higher-level libraries where possible, for example
+//! recommended to use specialized libraries where possible, for example
 //! [openssl], [ring] and the [RustCrypto libraries].
-//!
-//! ## Performance
-//!
-//! Most algorithms don't generate values one at a time, as simple PRNGs, but in
-//! blocks. There will be a longer pause when such a block needs to be
-//! generated, while a random number can be returned almost instantly when there
-//! are unused values in the buffer.
-//!
-//! Performance may be different depending on the architecture; but in contrast
-//! to PRNGs that generate one value at a time, the performance of CSPRNGs
-//! rarely if ever depends on the surrounding code.
-//!
-//! Because generating blocks of values lends itself well to loop unrolling, the
-//! code size of CSPRNGs can be significant.
 //!
 //!
 //! # Extra features
 //!
-//! Some PRNGs may provide extra features:
+//! Some PRNGs may provide extra features, like:
 //!
-//! - Support for multiple streams, which can help with parallel tasks
+//! - Support for multiple streams, which can help with parallel tasks.
 //! - The ability to jump or seek around in the random number stream;
-//!   with large periood this can be used as an alternative to streams
+//!   with large periood this can be used as an alternative to streams.
 //!
 //!
 //! # Further reading
@@ -299,7 +268,7 @@
 //!
 //!
 //! [`rngs` module]: ../rngs/index.html
-//! [basic PRNGs]: #basic-pseudo-random-number-generators-prngs
+//! [normal PRNGs]: #normal-pseudo-random-number-generators-prngs
 //! [CSPRNGs]: #cryptographically-secure-pseudo-random-number-generators-csprngs
 //! [`XorShiftRng`]: struct.XorShiftRng.html
 //! [`ChaChaRng`]: chacha/struct.ChaChaRng.html
@@ -308,12 +277,14 @@
 //! [`Isaac64Rng`]: isaac64/struct.Isaac64Rng.html
 //! [`ThreadRng`]: ../rngs/struct.ThreadRng.html
 //! [`FromEntropy`]: ../trait.FromEntropy.html
+//! [`EntropyRng`]: ../rngs/struct.EntropyRng.html
 //! [TestU01]: http://simul.iro.umontreal.ca/testu01/tu01.html
 //! [PractRand]: http://pracrand.sourceforge.net/
 //! [PCG paper]: http://www.pcg-random.org/pdf/hmc-cs-2014-0905.pdf
 //! [openssl]: https://crates.io/crates/openssl
 //! [ring]: https://crates.io/crates/ring
 //! [RustCrypto libraries]: https://github.com/RustCrypto
+//! [next-bit test]: https://en.wikipedia.org/wiki/Next-bit_test
 
 
 pub mod chacha;

--- a/src/rngs/adapter/read.rs
+++ b/src/rngs/adapter/read.rs
@@ -32,7 +32,7 @@ use rand_core::{RngCore, Error, ErrorKind, impls};
 ///
 /// # Example
 ///
-/// ```rust
+/// ```
 /// use rand::{read, Rng};
 ///
 /// let data = vec![1, 2, 3, 4, 5, 6, 7, 8];

--- a/src/rngs/adapter/read.rs
+++ b/src/rngs/adapter/read.rs
@@ -27,8 +27,8 @@ use rand_core::{RngCore, Error, ErrorKind, impls};
 ///
 /// `ReadRng` uses `std::io::read_exact`, which retries on interrupts. All other
 /// errors from the underlying reader, including when it does not have enough
-/// data, will only be reported through `try_fill_bytes`. The other `RngCore`
-/// methods will panic in case of an error error.
+/// data, will only be reported through [`try_fill_bytes`]. The other
+/// [`RngCore`] methods will panic in case of an error.
 ///
 /// # Example
 ///
@@ -41,6 +41,8 @@ use rand_core::{RngCore, Error, ErrorKind, impls};
 /// ```
 ///
 /// [`OsRng`]: ../struct.OsRng.html
+/// [`RngCore`]: ../../trait.RngCore.html
+/// [`try_fill_bytes`]: ../../trait.RngCore.html#method.tymethod.try_fill_bytes
 #[derive(Debug)]
 pub struct ReadRng<R> {
     reader: R

--- a/src/rngs/entropy.rs
+++ b/src/rngs/entropy.rs
@@ -15,12 +15,12 @@ use rngs::{OsRng, JitterRng};
 
 /// An interface returning random data from external source(s), provided
 /// specifically for securely seeding algorithmic generators (PRNGs).
-/// 
+///
 /// Where possible, `EntropyRng` retrieves random data from the operating
 /// system's interface for random numbers ([`OsRng`]); if that fails it will
 /// fall back to the [`JitterRng`] entropy collector. In the latter case it will
 /// still try to use [`OsRng`] on the next usage.
-/// 
+///
 /// If no secure source of entropy is available `EntropyRng` will panic on use;
 /// i.e. it should never output predictable data.
 /// 
@@ -32,9 +32,12 @@ use rngs::{OsRng, JitterRng};
 ///
 /// # Panics
 ///
-/// In the extraordinary situation that both [`OsRng`] and [`JitterRng`] fail,
-/// only [`try_fill_bytes`] is able to report the error, and only the one from
-/// `OsRng`. The other [`RngCore`] methods will panic in case of an error.
+/// On most systems, like Windows, Linux, macOS and *BSD on common hardware, it
+/// is highly unlikely for both [`OsRng`] and [`JitterRng`] to fail. But on
+/// combinations like webassembly without Emscripten or stdweb both sources are
+/// unavailable. If both sources fail, only [`try_fill_bytes`] is able to
+/// report the error, and only the one from `OsRng`. The other [`RngCore`]
+/// methods will panic in case of an error.
 ///
 /// [`OsRng`]: struct.OsRng.html
 /// [`JitterRng`]: jitter/struct.JitterRng.html

--- a/src/rngs/entropy.rs
+++ b/src/rngs/entropy.rs
@@ -30,9 +30,17 @@ use rngs::{OsRng, JitterRng};
 /// external entropy then primarily use the local PRNG ([`thread_rng`] is
 /// provided as a convenient, local, automatically-seeded CSPRNG).
 ///
+/// # Panics
+///
+/// In the extraordinary situation that both [`OsRng`] and [`JitterRng`] fail,
+/// only [`try_fill_bytes`] is able to report the error, and only the one from
+/// `OsRng`. The other [`RngCore`] methods will panic in case of an error.
+///
 /// [`OsRng`]: struct.OsRng.html
 /// [`JitterRng`]: jitter/struct.JitterRng.html
 /// [`thread_rng`]: ../fn.thread_rng.html
+/// [`RngCore`]: ../trait.RngCore.html
+/// [`try_fill_bytes`]: ../trait.RngCore.html#method.tymethod.try_fill_bytes
 #[derive(Debug)]
 pub struct EntropyRng {
     rng: EntropySource,

--- a/src/rngs/jitter.rs
+++ b/src/rngs/jitter.rs
@@ -311,7 +311,7 @@ impl JitterRng {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```
     /// # use rand::{Rng, Error};
     /// use rand::jitter::JitterRng;
     ///

--- a/src/rngs/mock.rs
+++ b/src/rngs/mock.rs
@@ -18,7 +18,7 @@ use rand_core::{RngCore, Error, impls};
 /// over a `u64` number, using wrapping arithmetic. If the increment is 0
 /// the generator yields a constant.
 /// 
-/// ```rust
+/// ```
 /// use rand::Rng;
 /// use rand::rngs::mock::StepRng;
 /// 

--- a/src/rngs/os.rs
+++ b/src/rngs/os.rs
@@ -65,7 +65,16 @@ use rand_core::{CryptoRng, RngCore, Error, impls};
 /// error. Because we keep one file descriptor to `/dev/urandom` open when
 /// succesful, this is only a small one-time cost.
 ///
+/// # Panics
+///
+/// `OsRng` is extremely unlikely to fail if `OsRng::new()` was succesfull. But
+/// in case it does fail, only [`try_fill_bytes`] is able to report the cause.
+/// Depending on the error the other [`RngCore`] methods will retry several
+/// times, and panic in case the error remains.
+///
 /// [`EntropyRng`]: struct.EntropyRng.html
+/// [`RngCore`]: ../trait.RngCore.html
+/// [`try_fill_bytes`]: ../trait.RngCore.html#method.tymethod.try_fill_bytes
 
 
 #[allow(unused)]    // not used by all targets

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -32,7 +32,7 @@ use super::Rng;
 ///
 /// # Example
 ///
-/// ```rust
+/// ```
 /// use rand::{thread_rng, seq};
 ///
 /// let mut rng = thread_rng();
@@ -77,7 +77,7 @@ pub fn sample_iter<T, I, R>(rng: &mut R, iterable: I, amount: usize) -> Result<V
 ///
 /// # Example
 ///
-/// ```rust
+/// ```
 /// use rand::{thread_rng, seq};
 ///
 /// let mut rng = thread_rng();
@@ -105,7 +105,7 @@ pub fn sample_slice<R, T>(rng: &mut R, slice: &[T], amount: usize) -> Vec<T>
 ///
 /// # Example
 ///
-/// ```rust
+/// ```
 /// use rand::{thread_rng, seq};
 ///
 /// let mut rng = thread_rng();


### PR DESCRIPTION
Split out from https://github.com/rust-lang-nursery/rand/pull/422.

As I commented in https://github.com/rust-lang-nursery/rand/pull/422#issuecomment-386038219 I tried something a bit more crazy: more all `*Rng` stuff into a separate module.

I am sure there quite a few things still messy, but this is just in a way reopening the other PR. Will work on it some more tomorrow.

I have tried to set up the documentation online. The [top-level documentation](https://pitdicker.github.io/rand/rand/) is now of a reasonable length, and I added more documentation in the [`rngs`](https://pitdicker.github.io/rand/rand/rngs/index.html) and [`distribution`](https://pitdicker.github.io/rand/rand/distributions/index.html) modules.