### PR TITLE
BlockRng: make core public and remove inner() and inner_mut()

### DIFF
--- a/rand_core/CHANGELOG.md
+++ b/rand_core/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0] - Unreleased
 - Enable the `std` feature by default. (#409)
-- Change `BlockRng64::inner` and add `BlockRng64::inner_mut` to mirror `BlockRng`. (#419)
+- Remove `BlockRng{64}::inner` and `BlockRng::inner_mut`; instead making `core` public
 - Add `BlockRng{64}::index` and `BlockRng{64}::generate_and_set`. (#374, #419)
 - Change `BlockRngCore::Results` bound to also require `AsMut<[Self::Item]>`. (#419)
 

--- a/src/reseeding.rs
+++ b/src/reseeding.rs
@@ -76,7 +76,7 @@ where R: BlockRngCore + SeedableRng,
 
     /// Reseed the internal PRNG.
     pub fn reseed(&mut self) -> Result<(), Error> {
-        self.0.inner_mut().reseed()
+        self.0.core.reseed()
     }
 }
 
@@ -112,7 +112,7 @@ where R: BlockRngCore + SeedableRng + Clone,
     fn clone(&self) -> ReseedingRng<R, Rsdr> {
         // Recreating `BlockRng` seems easier than cloning it and resetting
         // the index.
-        ReseedingRng(BlockRng::new(self.0.inner().clone()))
+        ReseedingRng(BlockRng::new(self.0.core.clone()))
     }
 }
 


### PR DESCRIPTION
@pitdicker what do you think?

I believe I found a bug regarding `half_used`...

...which brings me to a related point: didn't you mention trying to transmute the output of generate from `[u64]` to `[u32]` then using the same `BlockRng` code in (or instead of) `BlockRng64`?

I don't like the way `half_used` works right now; it could make it difficult to reproduce RNG output in other implementations.