### PR TITLE
Add a SampleUniform implementation for Duration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ sudo: false
 # - x86_64, ARMv7, a Big-Endian arch (MIPS)
 matrix:
   include:
-    - rust: 1.22.0
+    - rust: 1.24.0
       install:
       script:
         - cargo test --tests --no-default-features


### PR DESCRIPTION
This bumps the minimum supported version to 1.24, which is when Duration
moved to libcore. We can avoid that at the cost of only supporting this
impl with the std feature is enabled.