### PR TITLE
Implement std::io::Read for RngCore

### DIFF
--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -439,3 +439,11 @@ impl<R: RngCore + ?Sized> RngCore for Box<R> {
         (**self).try_fill_bytes(dest)
     }
 }
+
+#[cfg(feature="std")]
+impl std::io::Read for RngCore {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, std::io::Error> {
+        self.try_fill_bytes(buf)?;
+        Ok(buf.len())
+    }
+}


### PR DESCRIPTION
We once played with the idea of having an implementation of `std::io::Read` for `Rng` https://github.com/rust-lang-nursery/rand/issues/254, and that it could live in the `read` module https://github.com/rust-lang-nursery/rand/pull/366#discussion_r178506106.

I don't think it needs a wrapper type, as we can simply implement it for `RngCore`. Then the natural place would be in `rand_core`, so no need to preserve the `read` module.

This is not a very exiting PR in my opinion, I just wanted to test if it was necessary to keep the `read` module around. Just as well make a PR then.