### PR TITLE
Implement `Standard` and `Uniform` for `Wrapping<T>`

### DIFF
--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -389,6 +389,8 @@ impl<'a, D, R, T> Iterator for DistIter<'a, D, R, T>
 /// * `bool`: Generates `false` or `true`, each with probability 0.5.
 /// * Floating point types (`f32` and `f64`): Uniformly distributed in the
 ///   half-open range `[0, 1)`. See notes below.
+/// * Wrapping integers (`Wrapping<T>`), besides the type identical to their
+///   normal integer variants.
 ///
 /// The following aggregate types also implement the distribution `Standard` as
 /// long as their component types implement it:

--- a/src/distributions/other.rs
+++ b/src/distributions/other.rs
@@ -11,6 +11,7 @@
 //! The implementations of the `Standard` distribution for other built-in types.
 
 use core::char;
+use core::num::Wrapping;
 
 use {Rng};
 use distributions::{Distribution, Standard, Uniform};
@@ -158,6 +159,13 @@ impl<T> Distribution<Option<T>> for Standard where Standard: Distribution<T> {
         } else {
             None
         }
+    }
+}
+
+impl<T> Distribution<Wrapping<T>> for Standard where Standard: Distribution<T> {
+    #[inline]
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Wrapping<T> {
+        Wrapping(rng.gen())
     }
 }
 

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -59,13 +59,13 @@
 //! use rand::distributions::uniform::{Uniform, SampleUniform};
 //! use rand::distributions::uniform::{UniformSampler, UniformFloat};
 //!
-//! #[derive(Clone, Copy, PartialEq, PartialOrd)]
 //! struct MyF32(f32);
 //!
 //! #[derive(Clone, Copy, Debug)]
 //! struct UniformMyF32 {
 //!     inner: UniformFloat<f32>,
 //! }
+//!
 //! impl UniformSampler for UniformMyF32 {
 //!     type X = MyF32;
 //!     fn new(low: Self::X, high: Self::X) -> Self {
@@ -251,6 +251,17 @@ pub trait UniformSampler: Sized {
     }
 }
 
+impl<X: SampleUniform> From<::core::ops::Range<X>> for Uniform<X> {
+    fn from(r: ::core::ops::Range<X>) -> Uniform<X> {
+        Uniform::new(r.start, r.end)
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+// What follows are all back-ends.
+
+
 /// The back-end implementing [`UniformSampler`] for integer types.
 ///
 /// Unless you are implementing [`UniformSampler`] for your own type, this type
@@ -405,12 +416,6 @@ macro_rules! uniform_int_impl {
     }
 }
 
-impl<X: SampleUniform> From<::core::ops::Range<X>> for Uniform<X> {
-    fn from(r: ::core::ops::Range<X>) -> Uniform<X> {
-        Uniform::new(r.start, r.end)
-    }
-}
-
 uniform_int_impl! { i8, i8, u8, i32, u32 }
 uniform_int_impl! { i16, i16, u16, i32, u32 }
 uniform_int_impl! { i32, i32, u32, i32, u32 }
@@ -446,7 +451,6 @@ macro_rules! wmul_impl {
         }
     }
 }
-
 wmul_impl! { u8, u16, 8 }
 wmul_impl! { u16, u32, 16 }
 wmul_impl! { u32, u64, 32 }
@@ -485,12 +489,10 @@ macro_rules! wmul_impl_large {
         }
     }
 }
-
 #[cfg(not(feature = "i128_support"))]
 wmul_impl_large! { u64, 32 }
 #[cfg(feature = "i128_support")]
 wmul_impl_large! { u128, 64 }
-
 
 macro_rules! wmul_impl_usize {
     ($ty:ty) => {
@@ -505,7 +507,6 @@ macro_rules! wmul_impl_usize {
         }
     }
 }
-
 #[cfg(target_pointer_width = "32")]
 wmul_impl_usize! { u32 }
 #[cfg(target_pointer_width = "64")]
@@ -607,7 +608,9 @@ macro_rules! uniform_float_impl {
 uniform_float_impl! { f32, 32 - 23, next_u32 }
 uniform_float_impl! { f64, 64 - 52, next_u64 }
 
-/// Implementation of [`UniformSampler`] for `Duration`.
+
+
+/// The back-end implementing [`UniformSampler`] for `Duration`.
 ///
 /// Unless you are implementing [`UniformSampler`] for your own types, this type
 /// should not be used directly, use [`Uniform`] instead.


### PR DESCRIPTION
This turned out to be a bit messier than I hoped...

The range checks are now moved to the `UniformSampler` implementations, as discussed in https://github.com/rust-lang-nursery/rand/pull/433#issuecomment-387390434. 

For wrapping types I wanted to have the range wrap around if `low > high`. This turned out to need a slightly different way to calculate the range and zone. Because it is simpler, I also adjusted the normal integer implementation.

I tried to share the code between `UniformInt` and `UniformWrapping`, but didn't find a nice way. One option is to abstract things away into another trait (https://github.com/pitdicker/rand/commit/6c215367fa23083c211144bcb9d3061a58032858), which is ugly. Implementing it directly by changing the macro was also not easy, because of the converting back-and-forth to `Wrapping` types. So the code is now just mostly duplicated.

Fixes https://github.com/rust-lang-nursery/rand/issues/168.