### PR TITLE
Mention that examples and doctests require `std`

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ recommended:
 cargo test --all
 
 # Test no_std support
+# Note that the examples and doctests don't compile without the `std` feature.
 cargo test --tests --no-default-features
 # Test no_std+alloc support
 cargo test --tests --no-default-features --features alloc

--- a/examples/monte-carlo.rs
+++ b/examples/monte-carlo.rs
@@ -25,8 +25,6 @@
 //! the square at random, calculate the fraction that fall within the circle,
 //! and multiply this fraction by 4.
 
-#![cfg(feature="std")]
-
 
 extern crate rand;
 

--- a/examples/monty-hall.rs
+++ b/examples/monty-hall.rs
@@ -27,8 +27,6 @@
 //!
 //! [Monty Hall Problem]: https://en.wikipedia.org/wiki/Monty_Hall_problem
 
-#![cfg(feature="std")]
-
 
 extern crate rand;
 


### PR DESCRIPTION
Also remove pointless attributes. (`#![cfg(feature="std")]` does not work
for binaries, because `main` will be missing.)