### PR TITLE
Use 'dest' as name for bytes param

### DIFF
--- a/src/rngs/thread.rs
+++ b/src/rngs/thread.rs
@@ -112,8 +112,8 @@ impl RngCore for ThreadRng {
         unsafe { (*self.rng.get()).next_u64() }
     }
 
-    fn fill_bytes(&mut self, bytes: &mut [u8]) {
-        unsafe { (*self.rng.get()).fill_bytes(bytes) }
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        unsafe { (*self.rng.get()).fill_bytes(dest) }
     }
 
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {


### PR DESCRIPTION
Other implementations of RngCore appear to consistently use "dest" as the name for this parameter. I have submitted this PR because RLS uses this name for autocomplete, which can result in mild annoyance when it doesn't match as anticipated.