### PR TITLE
Fix build error with `i128_support` on Rust 1.26

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -12,6 +12,10 @@ Random number generators and other randomness functionality.
 """
 keywords = ["random", "rng"]
 categories = ["algorithms"]
+build = "build.rs"
+
+[build-dependencies]
+version_check = "0.1"
 
 [features]
 default = ["std"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+extern crate version_check;
+
+fn main() {
+    if version_check::is_min_version("1.26.0").expect("couldn't query version info from rustc").0 {
+        println!("cargo:rustc-cfg=stable_i128");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,7 +245,7 @@
 
 #![cfg_attr(not(feature="std"), no_std)]
 #![cfg_attr(all(feature="alloc", not(feature="std")), feature(alloc))]
-#![cfg_attr(feature = "i128_support", feature(i128_type, i128))]
+#![cfg_attr(all(feature = "i128_support", not(stable_i128)), feature(i128_type, i128))]
 
 #[cfg(feature="std")] extern crate std as core;
 #[cfg(all(feature = "alloc", not(feature="std")))] extern crate alloc;


### PR DESCRIPTION
This PR leaves i128 support opt-in -- I don't know if it should be automatically enabled for Rust 1.26+.

Also let me know if you prefer to manually parse output from `rustc --version` to keep `rand` with fewer dependencies.

Fixes #458.