### PR TITLE
Clean up benchmarks

### DIFF
--- a/benches/generators.rs
+++ b/benches/generators.rs
@@ -51,7 +51,7 @@ macro_rules! gen_uint {
                 for _ in 0..RAND_BENCH_N {
                     accum = accum.wrapping_add(rng.gen::<$ty>());
                 }
-                black_box(accum);
+                accum
             });
             b.bytes = size_of::<$ty>() as u64 * RAND_BENCH_N;
         }
@@ -82,7 +82,7 @@ gen_uint!(gen_u64_os, u64, OsRng::new().unwrap());
 fn gen_u64_jitter(b: &mut Bencher) {
     let mut rng = JitterRng::new().unwrap();
     b.iter(|| {
-        black_box(rng.gen::<u64>());
+        rng.gen::<u64>()
     });
     b.bytes = size_of::<u64>() as u64;
 }
@@ -94,7 +94,7 @@ macro_rules! init_gen {
             let mut rng = XorShiftRng::from_entropy();
             b.iter(|| {
                 let r2 = $gen::from_rng(&mut rng).unwrap();
-                black_box(r2);
+                r2
             });
         }
     }
@@ -109,7 +109,7 @@ init_gen!(init_chacha, ChaChaRng);
 #[bench]
 fn init_jitter(b: &mut Bencher) {
     b.iter(|| {
-        black_box(JitterRng::new().unwrap());
+        JitterRng::new().unwrap()
     });
 }
 
@@ -144,7 +144,7 @@ macro_rules! reseeding_uint {
                 for _ in 0..RAND_BENCH_N {
                     accum = accum.wrapping_add(rng.gen::<$ty>());
                 }
-                black_box(accum);
+                accum
             });
             b.bytes = size_of::<$ty>() as u64 * RAND_BENCH_N;
         }
@@ -165,7 +165,7 @@ macro_rules! threadrng_uint {
                 for _ in 0..RAND_BENCH_N {
                     accum = accum.wrapping_add(rng.gen::<$ty>());
                 }
-                black_box(accum);
+                accum
             });
             b.bytes = size_of::<$ty>() as u64 * RAND_BENCH_N;
         }


### PR DESCRIPTION
This includes the change as discussed for the `gen_bool` en `Bernoulli` benchmarks.

Also it turns out almost all our uses of `black_box` were unnecessary, it is enough to return a variable or some accumulator at the end of the benchmark run.

Results with `cargo benchcmp --threshold 2`:
```
 name                             master ns/iter       new ns/iter          diff ns/iter   diff %  speedup 
 distr_standard_alphanumeric      2,430 (1646 MB/s)    1,803 (2218 MB/s)            -627  -25.80%   x 1.35 
 distr_standard_bool              4,379 (228 MB/s)     1,055 (947 MB/s)           -3,324  -75.91%   x 4.15 
 distr_uniform_i64                5,497 (1455 MB/s)    5,384 (1485 MB/s)            -113   -2.06%   x 1.02 
 gen_u32_hc128                    2,498 (1601 MB/s)    2,265 (1766 MB/s)            -233   -9.33%   x 1.10 
 gen_u32_isaac                    3,448 (1160 MB/s)    3,593 (1113 MB/s)             145    4.21%   x 0.96 
 gen_u32_std                      2,223 (1799 MB/s)    2,508 (1594 MB/s)             285   12.82%   x 0.89 
 gen_u64_jitter                   23,335               23,998                        663    2.84%   x 0.97 
 init_chacha                      31                   27                             -4  -12.90%   x 1.15 
 init_hc128                       5,072                4,852                        -220   -4.34%   x 1.05 
 init_isaac                       1,454                1,417                         -37   -2.54%   x 1.03 
 init_jitter                      23,329               24,014                        685    2.94%   x 0.97 
 misc_bernoulli_const             2,234                3,873                       1,639   73.37%   x 0.58 
 misc_bernoulli_var               2,922                6,216                       3,294  112.73%   x 0.47 
 misc_gen_bool_const              2,201                4,221                       2,020   91.78%   x 0.52 
 misc_gen_bool_var                4,469                6,211                       1,742   38.98%   x 0.72 
 misc_sample_slice_ref_10_of_100  158                  167                             9    5.70%   x 0.95 
 thread_rng_u32                   3,197 (1251 MB/s)    3,461 (1155 MB/s)             264    8.26%   x 0.92 
```

- The `misc_gen_bool` and `misc_bernoulli` benchmarks are clearly different (in part because of using `StdRng`).
- Benchmarking distributions producing a `bool` or `char` using an accumulator gives more realistic results.
- `Hc128Rng` and `StdRng` produce results somewhere between 1250 MB/s and 1800 MB/s, without recompilation. Still don't know what causes the variance.
- I didn't dare to remove `black_box` from the `gen_bytes` benchmarks, it improves performance a bit more than I think is plausible, but I didn't want to figure out the assembly for those...