### PR TITLE
Clarify advantages of Uniform over gen_range

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,7 +385,8 @@ pub trait Rng: RngCore {
     /// repeatedly with the same arguments, it will likely be faster to
     /// construct a [`Uniform`] distribution object and sample from that; this
     /// allows amortization of the computations that allow for perfect
-    /// uniformity within the [`Uniform::new`] constructor.
+    /// uniformity within the [`Uniform::new`] constructor and the
+    /// computations allow faster sampling with [`Uniform::sample`].
     ///
     /// # Panics
     ///
@@ -406,6 +407,7 @@ pub trait Rng: RngCore {
     /// [`Uniform`]: distributions/uniform/struct.Uniform.html
     /// [`Uniform::new`]: distributions/uniform/struct.Uniform.html#method.new
     /// [`Uniform::sample_single`]: distributions/uniform/struct.Uniform.html#method.sample_single
+    /// [`Uniform::sample`]: distributions/uniform/struct.Uniform.html#method.sample
     fn gen_range<T: PartialOrd + SampleUniform>(&mut self, low: T, high: T) -> T {
         T::Sampler::sample_single(low, high, self)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,7 +381,7 @@ pub trait Rng: RngCore {
     /// `low` and exclusive of `high`.
     ///
     /// This is a convenience wrapper around
-    /// [`Uniform::sample_single`]. If this function will be called
+    /// [`UniformSampler::sample_single`]. If this function will be called
     /// repeatedly with the same arguments, it will likely be faster to
     /// construct a [`Uniform`] distribution object and sample from that; this
     /// allows amortization of the computations that allow for perfect
@@ -406,7 +406,7 @@ pub trait Rng: RngCore {
     ///
     /// [`Uniform`]: distributions/uniform/struct.Uniform.html
     /// [`Uniform::new`]: distributions/uniform/struct.Uniform.html#method.new
-    /// [`Uniform::sample_single`]: distributions/uniform/struct.Uniform.html#method.sample_single
+    /// [`UniformSampler::sample_single`]: distributions/uniform/trait.UniformSampler.html#method.sample_single
     /// [`Uniform::sample`]: distributions/uniform/struct.Uniform.html#method.sample
     fn gen_range<T: PartialOrd + SampleUniform>(&mut self, low: T, high: T) -> T {
         T::Sampler::sample_single(low, high, self)


### PR DESCRIPTION
This should hopefully indicate to users that the rejection sampling math is different.

Though this doesn't feel like the best way to articulate that and that it causes fewer sample rejections. Perhaps we should be explicit about that.