### PR TITLE
seq: use Floyd's combination algorithm to sample indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 
 You may also find the [Update Guide](UPDATING.md) useful.
 
+## [0.6.0] - Unreleased
+
+### Sequences module
+- Optimised and changed return type of the `sample_indices` function. (#479)
+
 ## [0.5.4] - 2018-07-11
 ### Platform support
 - Make `OsRng` work via WASM/stdweb for WebWorkers

--- a/benches/seq.rs
+++ b/benches/seq.rs
@@ -39,7 +39,7 @@ macro_rules! seq_slice_choose_multiple {
                 // Collect full result to prevent unwanted shortcuts getting
                 // first element (in case sample_indices returns an iterator).
                 for (slot, sample) in result.iter_mut().zip(
-                    x.choose_multiple(&mut rng, $amount)) {
+                    x.choose_multiple(&mut rng, $amount, false)) {
                     *slot = *sample;
                 }
                 result[$amount-1]
@@ -87,7 +87,7 @@ macro_rules! sample_indices {
         fn $name(b: &mut Bencher) {
             let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
             b.iter(|| {
-                $fn(&mut rng, $length, $amount)
+                $fn(&mut rng, $length, $amount, true)
             })
         }
     }

--- a/benches/seq.rs
+++ b/benches/seq.rs
@@ -39,7 +39,7 @@ macro_rules! seq_slice_choose_multiple {
                 // Collect full result to prevent unwanted shortcuts getting
                 // first element (in case sample_indices returns an iterator).
                 for (slot, sample) in result.iter_mut().zip(
-                    x.choose_multiple(&mut rng, $amount, false)) {
+                    x.choose_multiple(&mut rng, $amount)) {
                     *slot = *sample;
                 }
                 result[$amount-1]
@@ -87,7 +87,7 @@ macro_rules! sample_indices {
         fn $name(b: &mut Bencher) {
             let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
             b.iter(|| {
-                index::$fn(&mut rng, $length, $amount, false)
+                index::$fn(&mut rng, $length, $amount)
             })
         }
     }
@@ -98,5 +98,6 @@ sample_indices!(misc_sample_indices_10_of_1k, sample, 10, 1000);
 sample_indices!(misc_sample_indices_100_of_1k, sample, 100, 1000);
 sample_indices!(misc_sample_indices_100_of_1M, sample, 100, 1000_000);
 sample_indices!(misc_sample_indices_100_of_1G, sample, 100, 1000_000_000);
+sample_indices!(misc_sample_indices_200_of_1G, sample, 200, 1000_000_000);
 sample_indices!(misc_sample_indices_400_of_1G, sample, 400, 1000_000_000);
 sample_indices!(misc_sample_indices_600_of_1G, sample, 600, 1000_000_000);

--- a/benches/seq.rs
+++ b/benches/seq.rs
@@ -87,16 +87,16 @@ macro_rules! sample_indices {
         fn $name(b: &mut Bencher) {
             let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
             b.iter(|| {
-                $fn(&mut rng, $length, $amount, true)
+                index::$fn(&mut rng, $length, $amount, false)
             })
         }
     }
 }
 
-sample_indices!(misc_sample_indices_1_of_1k, sample_indices, 1, 1000);
-sample_indices!(misc_sample_indices_10_of_1k, sample_indices, 10, 1000);
-sample_indices!(misc_sample_indices_100_of_1k, sample_indices, 100, 1000);
-sample_indices!(misc_sample_indices_100_of_1M, sample_indices, 100, 1000_000);
-sample_indices!(misc_sample_indices_100_of_1G, sample_indices, 100, 1000_000_000);
-sample_indices!(misc_sample_indices_400_of_1G, sample_indices, 400, 1000_000_000);
-sample_indices!(misc_sample_indices_600_of_1G, sample_indices, 600, 1000_000_000);
+sample_indices!(misc_sample_indices_1_of_1k, sample, 1, 1000);
+sample_indices!(misc_sample_indices_10_of_1k, sample, 10, 1000);
+sample_indices!(misc_sample_indices_100_of_1k, sample, 100, 1000);
+sample_indices!(misc_sample_indices_100_of_1M, sample, 100, 1000_000);
+sample_indices!(misc_sample_indices_100_of_1G, sample, 100, 1000_000_000);
+sample_indices!(misc_sample_indices_400_of_1G, sample, 400, 1000_000_000);
+sample_indices!(misc_sample_indices_600_of_1G, sample, 600, 1000_000_000);

--- a/benches/seq.rs
+++ b/benches/seq.rs
@@ -1,4 +1,5 @@
 #![feature(test)]
+#![allow(non_snake_case)]
 
 extern crate test;
 extern crate rand;
@@ -27,27 +28,30 @@ fn seq_slice_choose_1_of_1000(b: &mut Bencher) {
     })
 }
 
-#[bench]
-fn seq_slice_choose_multiple_1_of_1000(b: &mut Bencher) {
-    let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
-    let x : &[usize] = &[1; 1000];
-    b.iter(|| {
-        x.choose_multiple(&mut rng, 1).cloned().next()
-    })
+macro_rules! seq_slice_choose_multiple {
+    ($name:ident, $amount:expr, $length:expr) => {
+        #[bench]
+        fn $name(b: &mut Bencher) {
+            let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
+            let x : &[i32] = &[$amount; $length];
+            let mut result = [0i32; $amount];
+            b.iter(|| {
+                // Collect full result to prevent unwanted shortcuts getting
+                // first element (in case sample_indices returns an iterator).
+                for (slot, sample) in result.iter_mut().zip(
+                    x.choose_multiple(&mut rng, $amount)) {
+                    *slot = *sample;
+                }
+                result[$amount-1]
+            })
+        }
+    }
 }
 
-#[bench]
-fn seq_slice_choose_multiple_10_of_100(b: &mut Bencher) {
-    let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
-    let x : &[usize] = &[1; 100];
-    let mut buf = [0; 10];
-    b.iter(|| {
-        for (v, slot) in x.choose_multiple(&mut rng, buf.len()).zip(buf.iter_mut()) {
-            *slot = *v;
-        }
-        buf
-    })
-}
+seq_slice_choose_multiple!(seq_slice_choose_multiple_1_of_1000, 1, 1000);
+seq_slice_choose_multiple!(seq_slice_choose_multiple_950_of_1000, 950, 1000);
+seq_slice_choose_multiple!(seq_slice_choose_multiple_10_of_100, 10, 100);
+seq_slice_choose_multiple!(seq_slice_choose_multiple_90_of_100, 90, 100);
 
 #[bench]
 fn seq_iter_choose_from_100(b: &mut Bencher) {
@@ -78,17 +82,21 @@ fn seq_iter_choose_multiple_fill_10_of_100(b: &mut Bencher) {
 }
 
 macro_rules! sample_indices {
-    ($name:ident, $amount:expr, $length:expr) => {
+    ($name:ident, $fn:ident, $amount:expr, $length:expr) => {
         #[bench]
         fn $name(b: &mut Bencher) {
             let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
             b.iter(|| {
-                sample_indices(&mut rng, $length, $amount)
+                $fn(&mut rng, $length, $amount)
             })
         }
     }
 }
 
-sample_indices!(seq_sample_indices_10_of_1k, 10, 1000);
-sample_indices!(seq_sample_indices_50_of_1k, 50, 1000);
-sample_indices!(seq_sample_indices_100_of_1k, 100, 1000);
+sample_indices!(misc_sample_indices_1_of_1k, sample_indices, 1, 1000);
+sample_indices!(misc_sample_indices_10_of_1k, sample_indices, 10, 1000);
+sample_indices!(misc_sample_indices_100_of_1k, sample_indices, 100, 1000);
+sample_indices!(misc_sample_indices_100_of_1M, sample_indices, 100, 1000_000);
+sample_indices!(misc_sample_indices_100_of_1G, sample_indices, 100, 1000_000_000);
+sample_indices!(misc_sample_indices_400_of_1G, sample_indices, 400, 1000_000_000);
+sample_indices!(misc_sample_indices_600_of_1G, sample_indices, 600, 1000_000_000);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,7 +234,7 @@
 #![cfg_attr(feature = "wasm-bindgen", feature(wasm_import_module))]
 
 #[cfg(feature = "std")] extern crate core;
-#[cfg(all(feature = "alloc", not(feature="std")))] extern crate alloc;
+#[cfg(all(feature = "alloc", not(feature="std")))] #[macro_use] extern crate alloc;
 
 #[cfg(feature="simd_support")] extern crate packed_simd;
 

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -496,10 +496,12 @@ pub fn sample_slice_ref<'a, R, T>(rng: &mut R, slice: &'a [T], amount: usize) ->
 
 /// Return type of `sample_indices`.
 #[cfg(feature = "alloc")]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub enum Indices {
     /// Representation: a vector over `u32` values
-    U32(Vec<u32>)
+    U32(Vec<u32>),
+    /// Representation: a vector over `usize` values
+    USize(Vec<usize>),
 }
 
 #[cfg(feature = "alloc")]
@@ -508,6 +510,7 @@ impl Indices {
     pub fn len(&self) -> usize {
         match self {
             &Indices::U32(ref v) => v.len(),
+            &Indices::USize(ref v) => v.len(),
         }
     }
 
@@ -515,6 +518,7 @@ impl Indices {
     pub fn into_vec_usize(self) -> Vec<usize> {
         match self {
             Indices::U32(v) => v.into_iter().map(|i| i as usize).collect(),
+            Indices::USize(v) => v,
         }
     }
 
@@ -522,6 +526,7 @@ impl Indices {
     pub fn iter_usize<'a>(&'a self) -> IndicesIter<'a> {
         match self {
             &Indices::U32(ref v) => IndicesIter::U32(v.iter()),
+            &Indices::USize(ref v) => IndicesIter::USize(v.iter()),
         }
     }
     
@@ -529,6 +534,20 @@ impl Indices {
     pub fn into_iter_usize(self) -> IndicesIntoIter {
         match self {
             Indices::U32(v) => IndicesIntoIter::U32(v.into_iter()),
+            Indices::USize(v) => IndicesIntoIter::USize(v.into_iter()),
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl PartialEq for Indices {
+    fn eq(&self, other: &Indices) -> bool {
+        use self::Indices::*;
+        match (self, other) {
+            (&U32(ref v1), &U32(ref v2)) => v1 == v2,
+            (&USize(ref v1), &USize(ref v2)) => v1 == v2,
+            (a @ _, b @ _) => (a.len() == b.len()) &&
+                    (a.iter_usize().zip(b.iter_usize()).all(|(x, y)| x == y)),
         }
     }
 }
@@ -540,11 +559,19 @@ impl From<Vec<u32>> for Indices {
     }
 }
 
+#[cfg(feature = "alloc")]
+impl From<Vec<usize>> for Indices {
+    fn from(v: Vec<usize>) -> Self {
+        Indices::USize(v)
+    }
+}
+
 /// Return type of `Indices::iter_usize`.
 #[cfg(feature = "alloc")]
 #[derive(Debug)]
 pub enum IndicesIter<'a> {
     #[doc(hidden)] U32(slice::Iter<'a, u32>),
+    #[doc(hidden)] USize(slice::Iter<'a, usize>),
 }
 
 #[cfg(feature = "alloc")]
@@ -554,12 +581,14 @@ impl<'a> Iterator for IndicesIter<'a> {
         use self::IndicesIter::*;
         match self {
             &mut U32(ref mut iter) => iter.next().map(|i| *i as usize),
+            &mut USize(ref mut iter) => iter.next().cloned(),
         }
     }
     
     fn size_hint(&self) -> (usize, Option<usize>) {
         match self {
             &IndicesIter::U32(ref v) => v.size_hint(),
+            &IndicesIter::USize(ref v) => v.size_hint(),
         }
     }
 }
@@ -569,6 +598,7 @@ impl<'a> ExactSizeIterator for IndicesIter<'a> {
     fn len(&self) -> usize {
         match self {
             &IndicesIter::U32(ref v) => v.len(),
+            &IndicesIter::USize(ref v) => v.len(),
         }
     }
 }
@@ -578,6 +608,7 @@ impl<'a> ExactSizeIterator for IndicesIter<'a> {
 #[derive(Clone, Debug)]
 pub enum IndicesIntoIter {
     #[doc(hidden)] U32(vec::IntoIter<u32>),
+    #[doc(hidden)] USize(vec::IntoIter<usize>),
 }
 
 #[cfg(feature = "alloc")]
@@ -588,6 +619,7 @@ impl Iterator for IndicesIntoIter {
         use self::IndicesIntoIter::*;
         match self {
             &mut U32(ref mut v) => v.next().map(|i| i as usize),
+            &mut USize(ref mut v) => v.next(),
         }
     }
     
@@ -595,6 +627,7 @@ impl Iterator for IndicesIntoIter {
         use self::IndicesIntoIter::*;
         match self {
             &U32(ref v) => v.size_hint(),
+            &USize(ref v) => v.size_hint(),
         }
     }
 }
@@ -605,6 +638,7 @@ impl ExactSizeIterator for IndicesIntoIter {
         use self::IndicesIntoIter::*;
         match self {
             &U32(ref v) => v.len(),
+            &USize(ref v) => v.len(),
         }
     }
 }
@@ -630,13 +664,14 @@ impl ExactSizeIterator for IndicesIntoIter {
 /// is closer to `O(amount^2)`, and when `length` is close to `amount` then
 /// `O(length)`.
 ///
-/// Note that we only support `u32` indices since this covers the vast majority
-/// of uses, and performance is significantly better than with `u64`.
+/// Note that performance is significantly better over `u32` indices than over
+/// `u64` indices. Because of this we hide the underlying type behind an
+/// abstraction, `Indices`.
 /// 
 /// If an allocation-free `no_std` function is required, it is suggested
 /// to adapt the internal `sample_indices_floyd` implementation.
 ///
-/// Panics if `amount > length` or if `length` is not reprentable as a `u32`.
+/// Panics if `amount > length`.
 #[cfg(feature = "alloc")]
 pub fn sample_indices<R>(rng: &mut R, length: usize, amount: usize,
     shuffled: bool) -> Indices
@@ -646,7 +681,9 @@ pub fn sample_indices<R>(rng: &mut R, length: usize, amount: usize,
         panic!("`amount` of samples must be less than or equal to `length`");
     }
     if length > (::core::u32::MAX as usize) {
-        panic!("`length` is not representable as `u32`");
+        // We never want to use inplace here, but could use floyd's alg
+        // Lazy version: always use the cache alg.
+        return sample_indices_cache(rng, length, amount);
     }
     let amount = amount as u32;
     let length = length as u32;
@@ -672,7 +709,9 @@ pub fn sample_indices<R>(rng: &mut R, length: usize, amount: usize,
         if (length as f32) < C[j] * (amount as f32) {
             sample_indices_inplace(rng, length, amount)
         } else {
-            sample_indices_cache(rng, length, amount)
+            // note: could have a specific u32 impl, but I'm lazy and
+            // generics don't have usable conversions
+            sample_indices_cache(rng, length as usize, amount as usize)
         }
     }
 }
@@ -745,15 +784,15 @@ fn sample_indices_inplace<R>(rng: &mut R, length: u32, amount: u32) -> Indices
 /// values from `1_000_000`. The algorithm is `O(amount)` time and memory,
 /// but due to overheads will often be slower than other approaches.
 #[cfg(feature = "alloc")]
-fn sample_indices_cache<R>(rng: &mut R, length: u32, amount: u32) -> Indices
+fn sample_indices_cache<R>(rng: &mut R, length: usize, amount: usize) -> Indices
     where R: Rng + ?Sized,
 {
     debug_assert!(amount <= length);
-    #[cfg(feature="std")] let mut cache = HashMap::with_capacity(amount as usize);
+    #[cfg(feature="std")] let mut cache = HashMap::with_capacity(amount);
     #[cfg(not(feature="std"))] let mut cache = BTreeMap::new();
-    let mut indices = Vec::with_capacity(amount as usize);
+    let mut indices = Vec::with_capacity(amount);
     for i in 0..amount {
-        let j: u32 = rng.gen_range(i, length);
+        let j: usize = rng.gen_range(i, length);
 
         // get the current values at i and j ...
         let x_i = match cache.get(&i) {
@@ -769,7 +808,7 @@ fn sample_indices_cache<R>(rng: &mut R, length: u32, amount: u32) -> Indices
         cache.insert(j, x_i);
         indices.push(x_j);  // push at position i
     }
-    debug_assert_eq!(indices.len(), amount as usize);
+    debug_assert_eq!(indices.len(), amount);
     Indices::from(indices)
 }
 
@@ -1035,7 +1074,7 @@ mod test {
         r.fill(&mut seed);
         let (length, amount): (usize, usize) = (1<<20, 600);
         let v1 = sample_indices(&mut xor_rng(seed), length, amount, true);
-        let v2 = sample_indices_cache(&mut xor_rng(seed), length as u32, amount as u32);
+        let v2 = sample_indices_cache(&mut xor_rng(seed), length, amount);
         assert!(v1.iter_usize().all(|e| e < length));
         assert_eq!(v1, v2);
     }

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -538,17 +538,17 @@ pub fn sample_indices<R>(rng: &mut R, length: usize, amount: usize,
     // https://github.com/rust-lang-nursery/rand/pull/479
     // We do some calculations with u64 to avoid overflow.
 
-    if amount < 517 {
-        const C: [[u64; 2]; 2] = [[1, 36], [200, 440]];
+    if amount < 442 {
+        const C: [[u64; 2]; 2] = [[5, 45], [50, 350]];
         let j = if length < 500_000 { 0 } else { 1 };
-        let m4 = 4 * amount as u64;
+        let m4 = 6 * amount as u64;
         if C[0][j] * (length as u64) < (C[1][j] + m4) * amount as u64 {
             sample_indices_inplace(rng, length, amount)
         } else {
             sample_indices_floyd(rng, length, amount, shuffled)
         }
     } else {
-        const C: [[u64; 2]; 2] = [[1, 36], [62*40, 68*40]];
+        const C: [[u64; 2]; 2] = [[1, 9], [590, 600]];
         let j = if length < 500_000 { 0 } else { 1 };
         if C[0][j] * (length as u64) < C[1][j] * amount as u64 {
             sample_indices_inplace(rng, length, amount)

--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -205,7 +205,7 @@ pub fn sample<R>(rng: &mut R, length: usize, amount: usize,
     // https://github.com/rust-lang-nursery/rand/pull/479
     // We do some calculations with f32. Accuracy is not very important.
 
-    if amount < 442 {
+    if amount < 217 {
         const C: [[f32; 2]; 2] = [[1.2, 6.0/45.0], [10.0, 70.0/9.0]];
         let j = if length < 500_000 { 0 } else { 1 };
         let amount_fp = amount as f32;
@@ -217,7 +217,7 @@ pub fn sample<R>(rng: &mut R, length: usize, amount: usize,
             sample_floyd(rng, length, amount, shuffled)
         }
     } else {
-        const C: [f32; 2] = [590.0, 600.0/9.0];
+        const C: [f32; 2] = [270.0, 330.0/9.0];
         let j = if length < 500_000 { 0 } else { 1 };
         if (length as f32) < C[j] * (amount as f32) {
             sample_inplace(rng, length, amount)

--- a/src/seq/index.rs
+++ b/src/seq/index.rs
@@ -1,0 +1,386 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// https://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Index sampling
+
+#[cfg(feature="alloc")] use core::slice;
+
+#[cfg(feature="std")] use std::vec;
+#[cfg(all(feature="alloc", not(feature="std")))] use alloc::vec::{self, Vec};
+// BTreeMap is not as fast in tests, but better than nothing.
+#[cfg(feature="std")] use std::collections::{HashSet};
+#[cfg(all(feature="alloc", not(feature="std")))] use alloc::collections::BTreeSet;
+
+#[cfg(feature="alloc")] use distributions::{Distribution, Uniform};
+use Rng;
+
+/// A vector of indices.
+/// 
+/// Multiple internal representations are possible.
+#[derive(Clone, Debug)]
+pub enum IndexVec {
+    #[doc(hidden)] U32(Vec<u32>),
+    #[doc(hidden)] USize(Vec<usize>),
+}
+
+impl IndexVec {
+    /// Returns the number of indices
+    pub fn len(&self) -> usize {
+        match self {
+            &IndexVec::U32(ref v) => v.len(),
+            &IndexVec::USize(ref v) => v.len(),
+        }
+    }
+    
+    /// Return the value at the given `index`.
+    /// 
+    /// (Note: we cannot implement `std::ops::Index` because of lifetime
+    /// restrictions.)
+    pub fn index(&self, index: usize) -> usize {
+        match self {
+            &IndexVec::U32(ref v) => v[index] as usize,
+            &IndexVec::USize(ref v) => v[index],
+        }
+    }
+
+    /// Return result as a `Vec<usize>`. Conversion may or may not be trivial.
+    pub fn into_vec(self) -> Vec<usize> {
+        match self {
+            IndexVec::U32(v) => v.into_iter().map(|i| i as usize).collect(),
+            IndexVec::USize(v) => v,
+        }
+    }
+
+    /// Iterate over the indices as a sequence of `usize` values
+    pub fn iter<'a>(&'a self) -> IndexVecIter<'a> {
+        match self {
+            &IndexVec::U32(ref v) => IndexVecIter::U32(v.iter()),
+            &IndexVec::USize(ref v) => IndexVecIter::USize(v.iter()),
+        }
+    }
+    
+    /// Convert into an iterator over the indices as a sequence of `usize` values
+    pub fn into_iter(self) -> IndexVecIntoIter {
+        match self {
+            IndexVec::U32(v) => IndexVecIntoIter::U32(v.into_iter()),
+            IndexVec::USize(v) => IndexVecIntoIter::USize(v.into_iter()),
+        }
+    }
+}
+
+impl PartialEq for IndexVec {
+    fn eq(&self, other: &IndexVec) -> bool {
+        use self::IndexVec::*;
+        match (self, other) {
+            (&U32(ref v1), &U32(ref v2)) => v1 == v2,
+            (&USize(ref v1), &USize(ref v2)) => v1 == v2,
+            (&U32(ref v1), &USize(ref v2)) => (v1.len() == v2.len())
+                && (v1.iter().zip(v2.iter()).all(|(x, y)| *x as usize == *y)),
+            (&USize(ref v1), &U32(ref v2)) => (v1.len() == v2.len())
+                && (v1.iter().zip(v2.iter()).all(|(x, y)| *x == *y as usize)),
+        }
+    }
+}
+
+impl From<Vec<u32>> for IndexVec {
+    fn from(v: Vec<u32>) -> Self {
+        IndexVec::U32(v)
+    }
+}
+
+impl From<Vec<usize>> for IndexVec {
+    fn from(v: Vec<usize>) -> Self {
+        IndexVec::USize(v)
+    }
+}
+
+/// Return type of `IndexVec::iter`.
+#[derive(Debug)]
+pub enum IndexVecIter<'a> {
+    #[doc(hidden)] U32(slice::Iter<'a, u32>),
+    #[doc(hidden)] USize(slice::Iter<'a, usize>),
+}
+
+impl<'a> Iterator for IndexVecIter<'a> {
+    type Item = usize;
+    fn next(&mut self) -> Option<usize> {
+        use self::IndexVecIter::*;
+        match self {
+            &mut U32(ref mut iter) => iter.next().map(|i| *i as usize),
+            &mut USize(ref mut iter) => iter.next().cloned(),
+        }
+    }
+    
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            &IndexVecIter::U32(ref v) => v.size_hint(),
+            &IndexVecIter::USize(ref v) => v.size_hint(),
+        }
+    }
+}
+
+impl<'a> ExactSizeIterator for IndexVecIter<'a> {}
+
+/// Return type of `IndexVec::into_iter`.
+#[derive(Clone, Debug)]
+pub enum IndexVecIntoIter {
+    #[doc(hidden)] U32(vec::IntoIter<u32>),
+    #[doc(hidden)] USize(vec::IntoIter<usize>),
+}
+
+impl Iterator for IndexVecIntoIter {
+    type Item = usize;
+    
+    fn next(&mut self) -> Option<Self::Item> {
+        use self::IndexVecIntoIter::*;
+        match self {
+            &mut U32(ref mut v) => v.next().map(|i| i as usize),
+            &mut USize(ref mut v) => v.next(),
+        }
+    }
+    
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        use self::IndexVecIntoIter::*;
+        match self {
+            &U32(ref v) => v.size_hint(),
+            &USize(ref v) => v.size_hint(),
+        }
+    }
+}
+
+impl ExactSizeIterator for IndexVecIntoIter {}
+
+
+/// Randomly sample exactly `amount` distinct indices from `0..length`.
+///
+/// If `shuffled == true` then the sampled values will be fully shuffled;
+/// otherwise the values may only partially shuffled, depending on the
+/// algorithm used (i.e. biases may exist in the ordering of sampled elements).
+/// Depending on the algorithm used internally, full shuffling may add
+/// significant overhead for `amount` > 10 or so, but not more than double
+/// the time and often much less.
+///
+/// This method is used internally by the slice sampling methods, but it can
+/// sometimes be useful to have the indices themselves so this is provided as
+/// an alternative.
+///
+/// The implementation used is not specified; we automatically select the
+/// fastest available implementation for the `length` and `amount` parameters
+/// (based on detailed profiling on an Intel Haswell CPU). Roughly speaking,
+/// complexity is `O(amount)`, except that when `amount` is small, performance
+/// is closer to `O(amount^2)`, and when `length` is close to `amount` then
+/// `O(length)`.
+///
+/// Note that performance is significantly better over `u32` indices than over
+/// `u64` indices. Because of this we hide the underlying type behind an
+/// abstraction, `IndexVec`.
+/// 
+/// If an allocation-free `no_std` function is required, it is suggested
+/// to adapt the internal `sample_floyd` implementation.
+///
+/// Panics if `amount > length`.
+pub fn sample<R>(rng: &mut R, length: usize, amount: usize,
+    shuffled: bool) -> IndexVec
+    where R: Rng + ?Sized,
+{
+    if amount > length {
+        panic!("`amount` of samples must be less than or equal to `length`");
+    }
+    if length > (::core::u32::MAX as usize) {
+        // We never want to use inplace here, but could use floyd's alg
+        // Lazy version: always use the cache alg.
+        return sample_rejection(rng, length, amount);
+    }
+    let amount = amount as u32;
+    let length = length as u32;
+    
+    // Choice of algorithm here depends on both length and amount. See:
+    // https://github.com/rust-lang-nursery/rand/pull/479
+    // We do some calculations with f32. Accuracy is not very important.
+
+    if amount < 442 {
+        const C: [[f32; 2]; 2] = [[1.2, 6.0/45.0], [10.0, 70.0/9.0]];
+        let j = if length < 500_000 { 0 } else { 1 };
+        let amount_fp = amount as f32;
+        let m4 = C[0][j] * amount_fp;
+        // Short-cut: when amount < 12, floyd's is always faster
+        if amount > 11 && (length as f32) < (C[1][j] + m4) * amount_fp {
+            sample_inplace(rng, length, amount)
+        } else {
+            sample_floyd(rng, length, amount, shuffled)
+        }
+    } else {
+        const C: [f32; 2] = [590.0, 600.0/9.0];
+        let j = if length < 500_000 { 0 } else { 1 };
+        if (length as f32) < C[j] * (amount as f32) {
+            sample_inplace(rng, length, amount)
+        } else {
+            // note: could have a specific u32 impl, but I'm lazy and
+            // generics don't have usable conversions
+            sample_rejection(rng, length as usize, amount as usize)
+        }
+    }
+}
+
+/// Randomly sample exactly `amount` indices from `0..length`, using Floyd's
+/// combination algorithm.
+/// 
+/// If `shuffled == false`, the values are only partially shuffled (i.e. biases
+/// exist in the ordering of sampled elements). If `shuffled == true`, the
+/// values are fully shuffled.
+///
+/// This implementation uses `O(amount)` memory and `O(amount^2)` time.
+fn sample_floyd<R>(rng: &mut R, length: u32, amount: u32, shuffled: bool) -> IndexVec
+    where R: Rng + ?Sized,
+{
+    debug_assert!(amount <= length);
+    let mut indices = Vec::with_capacity(amount as usize);
+    for j in length - amount .. length {
+        let t = rng.gen_range(0, j + 1);
+        if indices.contains(&t) {
+            indices.push(j)
+        } else {
+            indices.push(t)
+        };
+    }
+    if shuffled {
+        // Note that there is a variant of Floyd's algorithm with native full
+        // shuffling, but it is slow because it requires arbitrary insertions.
+        use super::SliceRandom;
+        indices.shuffle(rng);
+    }
+    IndexVec::from(indices)
+}
+
+/// Randomly sample exactly `amount` indices from `0..length`, using an inplace
+/// partial Fisher-Yates method.
+/// Sample an amount of indices using an inplace partial fisher yates method.
+///
+/// This allocates the entire `length` of indices and randomizes only the first `amount`.
+/// It then truncates to `amount` and returns.
+/// 
+/// This method is not appropriate for large `length` and potentially uses a lot
+/// of memory; because of this we only implement for `u32` index (which improves
+/// performance in all cases).
+///
+/// This is likely the fastest for small lengths since it avoids the need for
+/// allocations. Set-up is `O(length)` time and memory and shuffling is
+/// `O(amount)` time.
+fn sample_inplace<R>(rng: &mut R, length: u32, amount: u32) -> IndexVec
+    where R: Rng + ?Sized,
+{
+    debug_assert!(amount <= length);
+    let mut indices: Vec<u32> = Vec::with_capacity(length as usize);
+    indices.extend(0..length);
+    for i in 0..amount {
+        let j: u32 = rng.gen_range(i, length);
+        indices.swap(i as usize, j as usize);
+    }
+    indices.truncate(amount as usize);
+    debug_assert_eq!(indices.len(), amount as usize);
+    IndexVec::from(indices)
+}
+
+/// Randomly sample exactly `amount` indices from `0..length`, using rejection
+/// sampling.
+/// 
+/// Since `amount <<< length` there is a low chance of a random sample in
+/// `0..length` being a duplicate. We test for duplicates and resample where
+/// necessary. The algorithm is `O(amount)` time and memory.
+fn sample_rejection<R>(rng: &mut R, length: usize, amount: usize) -> IndexVec
+    where R: Rng + ?Sized,
+{
+    debug_assert!(amount < length);
+    #[cfg(feature="std")] let mut cache = HashSet::with_capacity(amount);
+    #[cfg(not(feature="std"))] let mut cache = BTreeSet::new();
+    let distr = Uniform::new(0, length);
+    let mut indices = Vec::with_capacity(amount);
+    for _ in 0..amount {
+        let mut pos = distr.sample(rng);
+        while !cache.insert(pos) {
+            pos = distr.sample(rng);
+        }
+        indices.push(pos);
+    }
+    
+    debug_assert_eq!(indices.len(), amount);
+    IndexVec::from(indices)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use {Rng, SeedableRng};
+    use prng::XorShiftRng;
+    
+    #[test]
+    fn test_sample_boundaries() {
+        let mut r = ::test::rng(404);
+        
+        assert_eq!(sample_inplace(&mut r, 0, 0).len(), 0);
+        assert_eq!(sample_inplace(&mut r, 1, 0).len(), 0);
+        assert_eq!(sample_inplace(&mut r, 1, 1).into_vec(), vec![0]);
+
+        assert_eq!(sample_rejection(&mut r, 1, 0).len(), 0);
+
+        assert_eq!(sample_floyd(&mut r, 0, 0, false).len(), 0);
+        assert_eq!(sample_floyd(&mut r, 1, 0, false).len(), 0);
+        assert_eq!(sample_floyd(&mut r, 1, 1, false).into_vec(), vec![0]);
+        
+        // These algorithms should be fast with big numbers. Test average.
+        let sum: usize = sample_rejection(&mut r, 1 << 25, 10)
+                .into_iter().sum();
+        assert!(1 << 25 < sum && sum < (1 << 25) * 25);
+        
+        let sum: usize = sample_floyd(&mut r, 1 << 25, 10, false)
+                .into_iter().sum();
+        assert!(1 << 25 < sum && sum < (1 << 25) * 25);
+    }
+    
+    #[test]
+    fn test_sample_alg() {
+        let xor_rng = XorShiftRng::from_seed;
+
+        let mut r = ::test::rng(403);
+        let mut seed = [0u8; 16];
+        
+        // We can't test which algorithm is used directly, but Floyd's alg
+        // should produce different results from the others. (Also, `inplace`
+        // and `cached` currently use different sizes thus produce different results.)
+        
+        // A small length and relatively large amount should use inplace
+        r.fill(&mut seed);
+        let (length, amount): (usize, usize) = (100, 50);
+        let v1 = sample(&mut xor_rng(seed), length, amount, true);
+        let v2 = sample_inplace(&mut xor_rng(seed), length as u32, amount as u32);
+        assert!(v1.iter().all(|e| e < length));
+        assert_eq!(v1, v2);
+        
+        // Test Floyd's alg does produce different results
+        let v3 = sample_floyd(&mut xor_rng(seed), length as u32, amount as u32, true);
+        assert!(v1 != v3);
+        
+        // A large length and small amount should use Floyd
+        r.fill(&mut seed);
+        let (length, amount): (usize, usize) = (1<<20, 50);
+        let v1 = sample(&mut xor_rng(seed), length, amount, true);
+        let v2 = sample_floyd(&mut xor_rng(seed), length as u32, amount as u32, true);
+        assert!(v1.iter().all(|e| e < length));
+        assert_eq!(v1, v2);
+        
+        // A large length and larger amount should use cache
+        r.fill(&mut seed);
+        let (length, amount): (usize, usize) = (1<<20, 600);
+        let v1 = sample(&mut xor_rng(seed), length, amount, true);
+        let v2 = sample_rejection(&mut xor_rng(seed), length, amount);
+        assert!(v1.iter().all(|e| e < length));
+        assert_eq!(v1, v2);
+    }
+}


### PR DESCRIPTION
Adapt #144 for sampling indices

This isn't the fully generic implementation that @burdges wrote; we could make this more generic. I'm guessing we could include an arbitrary lower bound without performance overhead (since the compiler can probably eliminate a constant of 0), and could also use generic typing.

I'm not really sure if it should be committed like this. It cleans up the code and improves performance in some cases, but isn't optimal in others. We could keep the old `sample_indices_inplace` and just replace `sample_indices_cache`.

```
# before
test gen_1k_sample_iter              ... bench:         390 ns/iter (+/- 4) = 2625 MB/s                                                
test misc_sample_indices_100_of_1k   ... bench:         806 ns/iter (+/- 8)                                                            
test misc_sample_indices_10_of_1k    ... bench:         594 ns/iter (+/- 9)                                                            
test misc_sample_indices_50_of_1k    ... bench:         472 ns/iter (+/- 8)                                                            
test misc_sample_iter_10_of_100      ... bench:       1,072 ns/iter (+/- 15)                                                           
test misc_sample_slice_10_of_100     ... bench:         160 ns/iter (+/- 2)                                                            
test misc_sample_slice_ref_10_of_100 ... bench:         160 ns/iter (+/- 2)                                                            
# after                                                                                                       
test gen_1k_sample_iter              ... bench:         391 ns/iter (+/- 27) = 2618 MB/s
test misc_sample_indices_100_of_1k   ... bench:       2,031 ns/iter (+/- 39)
test misc_sample_indices_10_of_1k    ... bench:          90 ns/iter (+/- 1)
test misc_sample_indices_50_of_1k    ... bench:         649 ns/iter (+/- 11)
test misc_sample_iter_10_of_100      ... bench:       1,083 ns/iter (+/- 16)
test misc_sample_slice_10_of_100     ... bench:         157 ns/iter (+/- 1)
test misc_sample_slice_ref_10_of_100 ... bench:         158 ns/iter (+/- 3)       
```

Edit: now:
```
test misc_sample_indices_100_of_1k           ... bench:         515 ns/iter (+/- 24)
test misc_sample_indices_10_of_1k            ... bench:          86 ns/iter (+/- 3)
test seq_iter_choose_multiple_10_of_100      ... bench:       1,137 ns/iter (+/- 319)
test seq_iter_choose_multiple_fill_10_of_100 ... bench:       1,088 ns/iter (+/- 35)
test seq_slice_choose_multiple_10_of_100     ... bench:         139 ns/iter (+/- 8)
````