### PR TITLE
Several OsRng improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 You may also find the [Update Guide](UPDATING.md) useful.
 
 
+## [0.5.1] - Unreleased
+
+### Platform support and `OsRng`
+- Remove blanket Unix implementation. (#484)
+- Remove Wasm unimplemented stub. (#484)
+- Dragonfly BSD: read from `/dev/random`. (#484)
+- Bitrig: use `getentropy` like OpenBSD. (#484)
+- Solaris: (untested) use `getrandom` if available, otherwise `/dev/random`. (#484)
+- Emscripten, `stdweb`: split the read up in chunks. (#484)
+- Emscripten, Haiku: don't do an extra blocking read from `/dev/random`. (#484)
+- Linux, NetBSD, Solaris: read in blocking mode on first use in `fill_bytes`. (#484)
+- Fuchsia, CloudABI: fix compilation (broken in Rand 0.5). (#484)
+
 ## [0.5.0] - 2018-05-21
 
 ### Crate features and organisation

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ optional features are available:
 - `log` enables some logging via the `log` crate.
 - `nightly` enables all unstable features (`i128_support`).
 - `serde1` enables serialization for some types, via Serde version 1.
-- `stdweb` enables support for `OsRng` on WASM via stdweb.
+- `stdweb` enables support for `OsRng` on `wasm-unknown-unknown` via `stdweb`
+  combined with `cargo-web`.
 
 `no_std` mode is activated by setting `default-features = false`; this removes
 functionality depending on `std`:

--- a/src/rngs/os.rs
+++ b/src/rngs/os.rs
@@ -535,7 +535,9 @@ mod imp {
 }
 
 
-#[cfg(any(target_os = "dragonfly", target_os = "haiku"))]
+#[cfg(any(target_os = "dragonfly",
+          target_os = "haiku",
+          target_os = "emscripten"))]
 mod imp {
     use Error;
     use super::random_device;
@@ -555,31 +557,7 @@ mod imp {
             random_device::read(dest)
         }
 
-        fn method_str(&self) -> &'static str { "/dev/random" }
-    }
-}
-
-
-#[cfg(target_os = "emscripten")]
-mod imp {
-    use Error;
-    use super::random_device;
-    use super::OsRngImpl;
-    use std::fs::File;
-
-    #[derive(Clone, Debug)]
-    pub struct OsRng();
-
-    impl OsRngImpl for OsRng {
-        fn new() -> Result<OsRng, Error> {
-            random_device::open("/dev/random", &|p| File::open(p))?;
-            Ok(OsRng())
-        }
-
-        fn fill_chunk(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-            random_device::read(dest)
-        }
-
+        #[cfg(target_os = "emscripten")]
         fn max_chunk_size(&self) -> usize {
             // `Crypto.getRandomValues` documents `dest` should be at most 65536
             // bytes. `crypto.randomBytes` documents: "To minimize threadpool


### PR DESCRIPTION
- Documentation links to the relevant man pages.
- A bit more explanation around wasm, as it turns out to be a bit confusing.
- Removed the blanket Unix implementation of reading from `/dev/urandom`. Besides Linux (which it is pretty specialized for), it was only 'correct' for NetBSD. I think it is better to not compile, and add support for a platform, than to have a default implementation. Then we can make sure it is tested, and matches the recommendations for that platform.
- NetBSD: now uses a simple zero-sized struct for `OsRng`.
- Dragonfly BSD: reads from `/dev/random`. `/dev/urandom` is faster, but using IBAA, the predecessor of ISAAC, of which the security is unknown.
- Added support for Bitrig. It is obsolete, but costs us nothing, as it is the same as OpenBSD.
- Emscripten: reads from `/dev/urandom`, without testing `/dev/random`, and splits the read up in chunks.
- `stdweb` split the read up in chunks of 65536 bytes.
- Moved shared code around reading from a random device to a `unix` module.
- Removed the WASM without `stdweb` stub (never understood why we should have it).
- Added test that reading 0 bytes works.

Fixes https://github.com/rust-lang-nursery/rand/issues/332.