### PR TITLE
Cauchy distribution: optimise sampling

### DIFF
--- a/src/distributions/cauchy.rs
+++ b/src/distributions/cauchy.rs
@@ -50,12 +50,9 @@ impl Cauchy {
 impl Distribution<f64> for Cauchy {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> f64 {
         // sample from [0, 1)
-        let mut x = rng.gen::<f64>();
-        // guard against the extremely unlikely case we get the invalid 0.5
-        while x == 0.5 {
-            x = rng.gen::<f64>();
-        }
+        let x = rng.gen::<f64>();
         // get standard cauchy random number
+        // note that π/2 is not exactly representable, even if x=0.5 the result is finite
         let comp_dev = (PI * x).tan();
         // shift and scale according to parameters
         let result = self.median + self.scale * comp_dev;


### PR DESCRIPTION
@MaximoB this presumably uses 1 bit less precision but is quite a bit faster
```
# previously
test distr_cauchy                ... bench:      48,639 ns/iter (+/- 1,411) = 164 MB/s                                                 
# now
test distr_cauchy                ... bench:      36,224 ns/iter (+/- 654) = 220 MB/s
```
Optimisers are weird, but as I guessed, it seems we get a free subtraction operation when using `Open01`.

I considered checking that the result is finite with a loop, but I'm fairly sure it must be anyway since π is irrational. Do you agree?