### PR TITLE
Implement various choose() methods

### DIFF
--- a/benches/misc.rs
+++ b/benches/misc.rs
@@ -8,7 +8,6 @@ const RAND_BENCH_N: u64 = 1000;
 use test::Bencher;
 
 use rand::prelude::*;
-use rand::seq::*;
 
 #[bench]
 fn misc_gen_bool_const(b: &mut Bencher) {
@@ -107,59 +106,6 @@ sample_binomial!(misc_binomial_10, 10, 0.9);
 sample_binomial!(misc_binomial_100, 100, 0.99);
 sample_binomial!(misc_binomial_1000, 1000, 0.01);
 sample_binomial!(misc_binomial_1e12, 1000_000_000_000, 0.2);
-
-#[bench]
-fn misc_shuffle_100(b: &mut Bencher) {
-    let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
-    let x : &mut [usize] = &mut [1; 100];
-    b.iter(|| {
-        rng.shuffle(x);
-        x[0]
-    })
-}
-
-#[bench]
-fn misc_sample_iter_10_of_100(b: &mut Bencher) {
-    let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
-    let x : &[usize] = &[1; 100];
-    b.iter(|| {
-        sample_iter(&mut rng, x, 10).unwrap_or_else(|e| e)
-    })
-}
-
-#[bench]
-fn misc_sample_slice_10_of_100(b: &mut Bencher) {
-    let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
-    let x : &[usize] = &[1; 100];
-    b.iter(|| {
-        sample_slice(&mut rng, x, 10)
-    })
-}
-
-#[bench]
-fn misc_sample_slice_ref_10_of_100(b: &mut Bencher) {
-    let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
-    let x : &[usize] = &[1; 100];
-    b.iter(|| {
-        sample_slice_ref(&mut rng, x, 10)
-    })
-}
-
-macro_rules! sample_indices {
-    ($name:ident, $amount:expr, $length:expr) => {
-        #[bench]
-        fn $name(b: &mut Bencher) {
-            let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
-            b.iter(|| {
-                sample_indices(&mut rng, $length, $amount)
-            })
-        }
-    }
-}
-
-sample_indices!(misc_sample_indices_10_of_1k, 10, 1000);
-sample_indices!(misc_sample_indices_50_of_1k, 50, 1000);
-sample_indices!(misc_sample_indices_100_of_1k, 100, 1000);
 
 #[bench]
 fn gen_1k_iter_repeat(b: &mut Bencher) {

--- a/benches/seq.rs
+++ b/benches/seq.rs
@@ -19,12 +19,12 @@ fn seq_shuffle_100(b: &mut Bencher) {
 }
 
 #[bench]
-fn seq_slice_choose_multiple_10_of_100(b: &mut Bencher) {
+fn seq_slice_sample_10_of_100(b: &mut Bencher) {
     let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
     let x : &[usize] = &[1; 100];
     let mut buf = [0; 10];
     b.iter(|| {
-        for (v, slot) in x.choose_multiple(&mut rng, buf.len()).zip(buf.iter_mut()) {
+        for (v, slot) in x.sample(&mut rng, buf.len()).zip(buf.iter_mut()) {
             *slot = *v;
         }
         buf
@@ -41,21 +41,21 @@ fn seq_iter_choose_from_100(b: &mut Bencher) {
 }
 
 #[bench]
-fn seq_iter_choose_multiple_10_of_100(b: &mut Bencher) {
+fn seq_iter_sample_10_of_100(b: &mut Bencher) {
     let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
     let x : &[usize] = &[1; 100];
     b.iter(|| {
-        x.iter().cloned().choose_multiple(&mut rng, 10) /*.unwrap_or_else(|e| e)*/
+        x.iter().cloned().sample(&mut rng, 10) /*.unwrap_or_else(|e| e)*/
     })
 }
 
 #[bench]
-fn seq_iter_choose_multiple_fill_10_of_100(b: &mut Bencher) {
+fn seq_iter_sample_fill_10_of_100(b: &mut Bencher) {
     let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
     let x : &[usize] = &[1; 100];
     let mut buf = [0; 10];
     b.iter(|| {
-        x.iter().cloned().choose_multiple_fill(&mut rng, &mut buf)
+        x.iter().cloned().sample_fill(&mut rng, &mut buf)
     })
 }
 

--- a/benches/seq.rs
+++ b/benches/seq.rs
@@ -1,0 +1,62 @@
+#![feature(test)]
+
+extern crate test;
+extern crate rand;
+
+use test::Bencher;
+
+use rand::prelude::*;
+use rand::seq::*;
+
+#[bench]
+fn misc_shuffle_100(b: &mut Bencher) {
+    let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
+    let x : &mut [usize] = &mut [1; 100];
+    b.iter(|| {
+        rng.shuffle(x);
+        x[0]
+    })
+}
+
+#[bench]
+fn misc_sample_iter_10_of_100(b: &mut Bencher) {
+    let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
+    let x : &[usize] = &[1; 100];
+    b.iter(|| {
+        sample_iter(&mut rng, x, 10).unwrap_or_else(|e| e)
+    })
+}
+
+#[bench]
+fn misc_sample_slice_10_of_100(b: &mut Bencher) {
+    let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
+    let x : &[usize] = &[1; 100];
+    b.iter(|| {
+        sample_slice(&mut rng, x, 10)
+    })
+}
+
+#[bench]
+fn misc_sample_slice_ref_10_of_100(b: &mut Bencher) {
+    let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
+    let x : &[usize] = &[1; 100];
+    b.iter(|| {
+        sample_slice_ref(&mut rng, x, 10)
+    })
+}
+
+macro_rules! sample_indices {
+    ($name:ident, $amount:expr, $length:expr) => {
+        #[bench]
+        fn $name(b: &mut Bencher) {
+            let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
+            b.iter(|| {
+                sample_indices(&mut rng, $length, $amount)
+            })
+        }
+    }
+}
+
+sample_indices!(misc_sample_indices_10_of_1k, 10, 1000);
+sample_indices!(misc_sample_indices_50_of_1k, 50, 1000);
+sample_indices!(misc_sample_indices_100_of_1k, 100, 1000);

--- a/benches/seq.rs
+++ b/benches/seq.rs
@@ -9,39 +9,44 @@ use rand::prelude::*;
 use rand::seq::*;
 
 #[bench]
-fn misc_shuffle_100(b: &mut Bencher) {
+fn seq_shuffle_100(b: &mut Bencher) {
     let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
     let x : &mut [usize] = &mut [1; 100];
     b.iter(|| {
-        rng.shuffle(x);
+        x.shuffle(&mut rng);
         x[0]
     })
 }
 
 #[bench]
-fn misc_sample_iter_10_of_100(b: &mut Bencher) {
+fn seq_slice_choose_multiple_10_of_100(b: &mut Bencher) {
     let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
     let x : &[usize] = &[1; 100];
+    let mut buf = [0; 10];
     b.iter(|| {
-        sample_iter(&mut rng, x, 10).unwrap_or_else(|e| e)
+        for (v, slot) in x.choose_multiple(&mut rng, buf.len()).zip(buf.iter_mut()) {
+            *slot = *v;
+        }
+        buf
     })
 }
 
 #[bench]
-fn misc_sample_slice_10_of_100(b: &mut Bencher) {
+fn seq_iter_choose_multiple_10_of_100(b: &mut Bencher) {
     let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
     let x : &[usize] = &[1; 100];
     b.iter(|| {
-        sample_slice(&mut rng, x, 10)
+        x.iter().cloned().choose_multiple(&mut rng, 10) /*.unwrap_or_else(|e| e)*/
     })
 }
 
 #[bench]
-fn misc_sample_slice_ref_10_of_100(b: &mut Bencher) {
+fn seq_iter_choose_multiple_fill_10_of_100(b: &mut Bencher) {
     let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
     let x : &[usize] = &[1; 100];
+    let mut buf = [0; 10];
     b.iter(|| {
-        sample_slice_ref(&mut rng, x, 10)
+        x.iter().cloned().choose_multiple_fill(&mut rng, &mut buf)
     })
 }
 
@@ -57,6 +62,6 @@ macro_rules! sample_indices {
     }
 }
 
-sample_indices!(misc_sample_indices_10_of_1k, 10, 1000);
-sample_indices!(misc_sample_indices_50_of_1k, 50, 1000);
-sample_indices!(misc_sample_indices_100_of_1k, 100, 1000);
+sample_indices!(seq_sample_indices_10_of_1k, 10, 1000);
+sample_indices!(seq_sample_indices_50_of_1k, 50, 1000);
+sample_indices!(seq_sample_indices_100_of_1k, 100, 1000);

--- a/benches/seq.rs
+++ b/benches/seq.rs
@@ -32,6 +32,15 @@ fn seq_slice_choose_multiple_10_of_100(b: &mut Bencher) {
 }
 
 #[bench]
+fn seq_iter_choose_from_100(b: &mut Bencher) {
+    let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
+    let x : &[usize] = &[1; 100];
+    b.iter(|| {
+        x.iter().cloned().choose(&mut rng)
+    })
+}
+
+#[bench]
 fn seq_iter_choose_multiple_10_of_100(b: &mut Bencher) {
     let mut rng = SmallRng::from_rng(thread_rng()).unwrap();
     let x : &[usize] = &[1; 100];

--- a/examples/monty-hall.rs
+++ b/examples/monty-hall.rs
@@ -63,7 +63,7 @@ fn simulate<R: Rng>(random_door: &Uniform<u32>, rng: &mut R)
 // Returns the door the game host opens given our choice and knowledge of
 // where the car is. The game host will never open the door with the car.
 fn game_host_open<R: Rng>(car: u32, choice: u32, rng: &mut R) -> u32 {
-    use rand::seq::SliceExt;
+    use rand::seq::SliceRandom;
     *free_doors(&[car, choice]).choose(rng).unwrap()
 }
 

--- a/examples/monty-hall.rs
+++ b/examples/monty-hall.rs
@@ -63,8 +63,8 @@ fn simulate<R: Rng>(random_door: &Uniform<u32>, rng: &mut R)
 // Returns the door the game host opens given our choice and knowledge of
 // where the car is. The game host will never open the door with the car.
 fn game_host_open<R: Rng>(car: u32, choice: u32, rng: &mut R) -> u32 {
-    let choices = free_doors(&[car, choice]);
-    rand::seq::sample_slice(rng, &choices, 1)[0]
+    use rand::seq::SliceExt;
+    *free_doors(&[car, choice]).choose(rng).unwrap()
 }
 
 // Returns the door we switch to, given our current choice and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,7 +268,7 @@ pub mod distributions;
 pub mod prelude;
 pub mod prng;
 pub mod rngs;
-#[cfg(feature = "alloc")] pub mod seq;
+pub mod seq;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Compatibility re-exports. Documentation is hidden; will be removed eventually.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -563,34 +563,34 @@ pub trait Rng: RngCore {
 
     /// Return a random element from `values`.
     ///
-    /// Deprecated: use [`SliceExt::choose`] instead.
+    /// Deprecated: use [`SliceRandom::choose`] instead.
     /// 
-    /// [`SliceExt::choose`]: seq/trait.SliceExt.html#method.choose
-    #[deprecated(since="0.6.0", note="use SliceExt::choose instead")]
+    /// [`SliceRandom::choose`]: seq/trait.SliceRandom.html#method.choose
+    #[deprecated(since="0.6.0", note="use SliceRandom::choose instead")]
     fn choose<'a, T>(&mut self, values: &'a [T]) -> Option<&'a T> {
-        use seq::SliceExt;
+        use seq::SliceRandom;
         values.choose(self)
     }
 
     /// Return a mutable pointer to a random element from `values`.
     ///
-    /// Deprecated: use [`SliceExt::choose_mut`] instead.
+    /// Deprecated: use [`SliceRandom::choose_mut`] instead.
     /// 
-    /// [`SliceExt::choose_mut`]: seq/trait.SliceExt.html#method.choose_mut
-    #[deprecated(since="0.6.0", note="use SliceExt::choose_mut instead")]
+    /// [`SliceRandom::choose_mut`]: seq/trait.SliceRandom.html#method.choose_mut
+    #[deprecated(since="0.6.0", note="use SliceRandom::choose_mut instead")]
     fn choose_mut<'a, T>(&mut self, values: &'a mut [T]) -> Option<&'a mut T> {
-        use seq::SliceExt;
+        use seq::SliceRandom;
         values.choose_mut(self)
     }
 
     /// Shuffle a mutable slice in place.
     ///
-    /// Deprecated: use [`SliceExt::shuffle`] instead.
+    /// Deprecated: use [`SliceRandom::shuffle`] instead.
     /// 
-    /// [`SliceExt::shuffle`]: seq/trait.SliceExt.html#method.shuffle
-    #[deprecated(since="0.6.0", note="use SliceExt::shuffle instead")]
+    /// [`SliceRandom::shuffle`]: seq/trait.SliceRandom.html#method.shuffle
+    #[deprecated(since="0.6.0", note="use SliceRandom::shuffle instead")]
     fn shuffle<T>(&mut self, values: &mut [T]) {
-        use seq::SliceExt;
+        use seq::SliceRandom;
         values.shuffle(self)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -563,64 +563,35 @@ pub trait Rng: RngCore {
 
     /// Return a random element from `values`.
     ///
-    /// Return `None` if `values` is empty.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use rand::{thread_rng, Rng};
-    ///
-    /// let choices = [1, 2, 4, 8, 16, 32];
-    /// let mut rng = thread_rng();
-    /// println!("{:?}", rng.choose(&choices));
-    /// assert_eq!(rng.choose(&choices[..0]), None);
-    /// ```
+    /// Deprecated: use [`SliceExt::choose`] instead.
+    /// 
+    /// [`SliceExt::choose`]: seq/trait.SliceExt.html#method.choose
+    #[deprecated(since="0.6.0", note="use SliceExt::choose instead")]
     fn choose<'a, T>(&mut self, values: &'a [T]) -> Option<&'a T> {
-        if values.is_empty() {
-            None
-        } else {
-            Some(&values[self.gen_range(0, values.len())])
-        }
+        use seq::SliceExt;
+        values.choose(self)
     }
 
     /// Return a mutable pointer to a random element from `values`.
     ///
-    /// Return `None` if `values` is empty.
+    /// Deprecated: use [`SliceExt::choose_mut`] instead.
+    /// 
+    /// [`SliceExt::choose_mut`]: seq/trait.SliceExt.html#method.choose_mut
+    #[deprecated(since="0.6.0", note="use SliceExt::choose_mut instead")]
     fn choose_mut<'a, T>(&mut self, values: &'a mut [T]) -> Option<&'a mut T> {
-        if values.is_empty() {
-            None
-        } else {
-            let len = values.len();
-            Some(&mut values[self.gen_range(0, len)])
-        }
+        use seq::SliceExt;
+        values.choose_mut(self)
     }
 
     /// Shuffle a mutable slice in place.
     ///
-    /// This applies Durstenfeld's algorithm for the [Fisher–Yates shuffle](
-    /// https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm)
-    /// which produces an unbiased permutation.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use rand::{thread_rng, Rng};
-    ///
-    /// let mut rng = thread_rng();
-    /// let mut y = [1, 2, 3];
-    /// rng.shuffle(&mut y);
-    /// println!("{:?}", y);
-    /// rng.shuffle(&mut y);
-    /// println!("{:?}", y);
-    /// ```
+    /// Deprecated: use [`SliceExt::shuffle`] instead.
+    /// 
+    /// [`SliceExt::shuffle`]: seq/trait.SliceExt.html#method.shuffle
+    #[deprecated(since="0.6.0", note="use SliceExt::shuffle instead")]
     fn shuffle<T>(&mut self, values: &mut [T]) {
-        let mut i = values.len();
-        while i >= 2 {
-            // invariant: elements with index >= i have been locked in place.
-            i -= 1;
-            // lock element i in place.
-            values.swap(i, self.gen_range(0, i + 1));
-        }
+        use seq::SliceExt;
+        values.shuffle(self)
     }
 }
 
@@ -974,45 +945,12 @@ mod test {
     }
 
     #[test]
-    fn test_choose() {
-        let mut r = rng(107);
-        assert_eq!(r.choose(&[1, 1, 1]).map(|&x|x), Some(1));
-
-        let v: &[isize] = &[];
-        assert_eq!(r.choose(v), None);
-    }
-
-    #[test]
-    fn test_shuffle() {
-        let mut r = rng(108);
-        let empty: &mut [isize] = &mut [];
-        r.shuffle(empty);
-        let mut one = [1];
-        r.shuffle(&mut one);
-        let b: &[_] = &[1];
-        assert_eq!(one, b);
-
-        let mut two = [1, 2];
-        r.shuffle(&mut two);
-        assert!(two == [1, 2] || two == [2, 1]);
-
-        let mut x = [1, 1, 1];
-        r.shuffle(&mut x);
-        let b: &[_] = &[1, 1, 1];
-        assert_eq!(x, b);
-    }
-
-    #[test]
     fn test_rng_trait_object() {
         use distributions::{Distribution, Standard};
         let mut rng = rng(109);
         let mut r = &mut rng as &mut RngCore;
         r.next_u32();
         r.gen::<i32>();
-        let mut v = [1, 1, 1];
-        r.shuffle(&mut v);
-        let b: &[_] = &[1, 1, 1];
-        assert_eq!(v, b);
         assert_eq!(r.gen_range(0, 1), 0);
         let _c: u8 = Standard.sample(&mut r);
     }
@@ -1025,10 +963,6 @@ mod test {
         let mut r = Box::new(rng) as Box<RngCore>;
         r.next_u32();
         r.gen::<i32>();
-        let mut v = [1, 1, 1];
-        r.shuffle(&mut v);
-        let b: &[_] = &[1, 1, 1];
-        assert_eq!(v, b);
         assert_eq!(r.gen_range(0, 1), 0);
         let _c: u8 = Standard.sample(&mut r);
     }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -26,3 +26,4 @@
 #[doc(no_inline)] #[cfg(feature="std")] pub use rngs::ThreadRng;
 #[doc(no_inline)] pub use {Rng, RngCore, CryptoRng, SeedableRng};
 #[doc(no_inline)] #[cfg(feature="std")] pub use {FromEntropy, random, thread_rng};
+#[doc(no_inline)] pub use seq::{SliceRandom, IteratorRandom};

--- a/src/rngs/thread.rs
+++ b/src/rngs/thread.rs
@@ -132,10 +132,6 @@ mod test {
         use Rng;
         let mut r = ::thread_rng();
         r.gen::<i32>();
-        let mut v = [1, 1, 1];
-        r.shuffle(&mut v);
-        let b: &[_] = &[1, 1, 1];
-        assert_eq!(v, b);
         assert_eq!(r.gen_range(0, 1), 0);
     }
 }

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -271,7 +271,23 @@ impl<T> SliceExt for [T] {
     fn partial_shuffle<R>(&mut self, rng: &mut R, amount: usize)
         -> (&mut [Self::Item], &mut [Self::Item]) where R: Rng + ?Sized
     {
-        unimplemented!()
+        // This applies Durstenfeld's algorithm for the
+        // [Fisher–Yates shuffle](https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm)
+        // for an unbiased permutation, but exits early after choosing `amount`
+        // elements.
+        
+        let len = self.len();
+        let mut i = len;
+        let end = if amount >= len { 0 } else { len - amount };
+        
+        while i > end {
+            // invariant: elements with index > i have been locked in place.
+            i -= 1;
+            // lock element i in place.
+            self.swap(i, rng.gen_range(0, i + 1));
+        }
+        let r = self.split_at_mut(i);
+        (r.1, r.0)
     }
 }
 
@@ -530,6 +546,22 @@ mod test {
         x.shuffle(&mut r);
         let b: &[_] = &[1, 1, 1];
         assert_eq!(x, b);
+    }
+    
+    #[test]
+    fn test_partial_shuffle() {
+        let mut r = ::test::rng(118);
+        
+        let mut empty: [u32; 0] = [];
+        let res = empty.partial_shuffle(&mut r, 10);
+        assert_eq!((res.0.len(), res.1.len()), (0, 0));
+        
+        let mut v = [1, 2, 3, 4, 5];
+        let res = v.partial_shuffle(&mut r, 2);
+        assert_eq!((res.0.len(), res.1.len()), (2, 3));
+        assert!(res.0[0] != res.0[1]);
+        // First elements are only modified if selected, so at least one isn't modified:
+        assert!(res.1[0] == 1 || res.1[1] == 2 || res.1[2] == 3);
     }
 
     #[test]

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -9,6 +9,8 @@
 // except according to those terms.
 
 //! Functions for randomly accessing and sampling sequences.
+//! 
+//! TODO: module doc
 
 use super::Rng;
 
@@ -18,6 +20,158 @@ use super::Rng;
 #[cfg(not(feature="std"))] use alloc::btree_map::BTreeMap;
 
 #[cfg(not(feature="std"))] use alloc::Vec;
+
+
+/// Extension trait on slices, providing random mutation and sampling methods.
+/// 
+/// An implementation is provided for slices. This may also be implementable for
+/// other types.
+pub trait SliceExt {
+    /// The element type.
+    type Item;
+
+    /// Returns a reference to one random element of the slice, or `None` if the
+    /// slice is empty.
+    /// 
+    /// Depending on the implementation, complexity is expected to be `O(1)`.
+    fn choose<R>(&self, rng: &mut R) -> Option<&Self::Item>
+        where R: Rng + ?Sized;
+
+    /// Returns a mutable reference to one random element of the slice, or
+    /// `None` if the slice is empty.
+    /// 
+    /// Depending on the implementation, complexity is expected to be `O(1)`.
+    fn choose_mut<R>(&mut self, rng: &mut R) -> Option<&mut Self::Item>
+        where R: Rng + ?Sized;
+
+    /// Produces an iterator that chooses `amount` elements from the slice at
+    /// random without repeating any.
+    ///
+    /// In case this API is not sufficiently flexible, use `sample_indices` then
+    /// apply the indices to the slice.
+    /// 
+    /// Although the elements are selected randomly, the order of returned
+    /// elements is neither stable nor fully random. If random ordering is
+    /// desired, either use `partial_shuffle` or use this method and shuffle
+    /// the result. If stable order is desired, use `sample_indices`, sort the
+    /// result, then apply to the slice.
+    /// 
+    /// Complexity is expected to be the same as `sample_indices`.
+    fn choose_multiple<R>(&self, rng: &mut R, amount: usize) -> Vec<&Self::Item>
+        where R: Rng + ?Sized;
+
+    /// Shuffle a slice in place.
+    /// 
+    /// Depending on the implementation, complexity is expected to be `O(1)`.
+    fn shuffle<R>(&mut self, rng: &mut R) where R: Rng + ?Sized;
+
+    /// Shuffle a slice in place, but exit early.
+    ///
+    /// Returns two mutable slices from the source slice. The first contains
+    /// `amount` elements randomly permuted. The second has the remaining
+    /// elements that are not fully shuffled.
+    ///
+    /// This is an efficient method to select `amount` elements at random from
+    /// the slice, provided the slice may be mutated.
+    ///
+    /// If you only need to chose elements randomly and `amount > self.len()/2`
+    /// then you may improve performance by taking
+    /// `amount = values.len() - amount` and using only the second slice.
+    ///
+    /// If `amount` is greater than the number of elements in the slice, this
+    /// will perform a full shuffle.
+    ///
+    /// Depending on the implementation, complexity is expected to be `O(m)`,
+    /// where `m = amount`.
+    fn partial_shuffle<R>(&mut self, rng: &mut R, amount: usize)
+        -> (&mut [Self::Item], &mut [Self::Item]) where R: Rng + ?Sized;
+}
+
+/// Extension trait on iterators, providing random sampling methods.
+pub trait IteratorExt: Iterator + Sized {
+    /// Choose one element at random from the iterator.
+    ///
+    /// Returns `None` if and only if the iterator is empty.
+    /// 
+    /// Complexity is `O(n)`, where `n` is the length of the iterator.
+    /// This likely consumes multiple random numbers, but the exact number
+    /// is unspecified.
+    fn choose<R>(self, rng: &mut R) -> Option<Self::Item>
+        where R: Rng + ?Sized
+    {
+        unimplemented!()
+    }
+
+    /// Collects `amount` values at random from the iterator into a supplied
+    /// buffer.
+    ///
+    /// Returns the number of elements added to the buffer. This equals `amount`
+    /// unless the iterator contains insufficient elements, in which case this
+    /// equals the number of elements available.
+    /// 
+    /// Complexity is TODO
+    fn choose_multiple_fill<R>(self, rng: &mut R, amount: usize) -> usize
+        where R: Rng + ?Sized
+    {
+        unimplemented!()
+    }
+
+    /// Collects `amount` values at random from the iterator into a vector.
+    ///
+    /// This is a convenience wrapper around `choose_multiple_fill`.
+    ///
+    /// The length of the returned vector equals `amount` unless the iterator
+    /// contains insufficient elements, in which case it equals the number of
+    /// elements available.
+    /// 
+    /// Complexity is TODO
+    #[cfg(any(feature="std", feature="alloc"))]
+    fn choose_multiple<R>(self, rng: &mut R, amount: usize) -> Vec<Self::Item>
+        where R: Rng + ?Sized
+    {
+        // Note: I think this must use unsafe to create an uninitialised buffer, then restrict length
+        unimplemented!()
+    }
+}
+
+
+impl<T> SliceExt for [T] {
+    type Item = T;
+
+    fn choose<R>(&self, rng: &mut R) -> Option<&Self::Item>
+        where R: Rng + ?Sized
+    {
+        unimplemented!()
+    }
+
+    fn choose_mut<R>(&mut self, rng: &mut R) -> Option<&mut Self::Item>
+        where R: Rng + ?Sized
+    {
+        unimplemented!()
+    }
+
+    fn choose_multiple<R>(&self, rng: &mut R, amount: usize) -> Vec<&Self::Item>
+        where R: Rng + ?Sized
+    {
+        unimplemented!()
+    }
+
+    fn shuffle<R>(&mut self, rng: &mut R) where R: Rng + ?Sized
+    {
+        unimplemented!()
+    }
+
+    fn partial_shuffle<R>(&mut self, rng: &mut R, amount: usize)
+        -> (&mut [Self::Item], &mut [Self::Item]) where R: Rng + ?Sized
+    {
+        unimplemented!()
+    }
+}
+
+// ———
+// TODO: remove below methods once implemented above
+// TODO: also revise signature of `sample_indices`?
+// ———
 
 /// Randomly sample `amount` elements from a finite iterator.
 ///

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -148,8 +148,9 @@ pub trait IteratorExt: Iterator + Sized {
             
             // Continue until the iterator is exhausted
             for (i, elem) in self.enumerate() {
-                // TODO: benchmark using gen_ratio instead
-                if rng.gen_range(0, i + 2) == 0 {
+                let denom = (i + 2) as u32;
+                assert_eq!(denom as usize, i + 2);  // check against overflow
+                if rng.gen_ratio(1, denom) {
                     result = elem;
                 }
             }

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -351,16 +351,11 @@ pub fn sample_iter<T, I, R>(rng: &mut R, iterable: I, amount: usize) -> Result<V
 ///
 /// Panics if `amount > slice.len()`
 ///
-/// # Example
-///
-/// ```
-/// use rand::{thread_rng, seq};
-///
-/// let mut rng = thread_rng();
-/// let values = vec![5, 6, 1, 3, 4, 6, 7];
-/// println!("{:?}", seq::sample_slice(&mut rng, &values, 3));
-/// ```
+/// Deprecated: use [`SliceExt::choose_multiple`] instead.
+/// 
+/// [`SliceExt::choose_multiple`]: trait.SliceExt.html#method.choose_multiple
 #[cfg(feature = "alloc")]
+#[deprecated(since="0.6.0", note="use SliceExt::choose_multiple instead")]
 pub fn sample_slice<R, T>(rng: &mut R, slice: &[T], amount: usize) -> Vec<T>
     where R: Rng + ?Sized,
           T: Clone
@@ -380,16 +375,11 @@ pub fn sample_slice<R, T>(rng: &mut R, slice: &[T], amount: usize) -> Vec<T>
 ///
 /// Panics if `amount > slice.len()`
 ///
-/// # Example
-///
-/// ```
-/// use rand::{thread_rng, seq};
-///
-/// let mut rng = thread_rng();
-/// let values = vec![5, 6, 1, 3, 4, 6, 7];
-/// println!("{:?}", seq::sample_slice_ref(&mut rng, &values, 3));
-/// ```
+/// Deprecated: use [`SliceExt::choose_multiple`] instead.
+/// 
+/// [`SliceExt::choose_multiple`]: trait.SliceExt.html#method.choose_multiple
 #[cfg(feature = "alloc")]
+#[deprecated(since="0.6.0", note="use SliceExt::choose_multiple instead")]
 pub fn sample_slice_ref<'a, R, T>(rng: &mut R, slice: &'a [T], amount: usize) -> Vec<&'a T>
     where R: Rng + ?Sized
 {
@@ -586,6 +576,7 @@ mod test {
     }
     #[test]
     #[cfg(feature = "alloc")]
+    #[allow(deprecated)]
     fn test_sample_slice_boundaries() {
         let empty: &[u8] = &[];
 
@@ -631,6 +622,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "alloc")]
+    #[allow(deprecated)]
     fn test_sample_slice() {
         let xor_rng = XorShiftRng::from_seed;
 

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -258,7 +258,8 @@ impl<T> SliceRandom for [T] {
         if self.is_empty() {
             None
         } else {
-            Some(&mut self[rng.gen_range(0, self.len())])
+            let len = self.len();
+            Some(&mut self[rng.gen_range(0, len)])
         }
     }
 

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -27,7 +27,7 @@ use super::Rng;
 /// 
 /// An implementation is provided for slices. This may also be implementable for
 /// other types.
-pub trait SliceExt {
+pub trait SliceRandom {
     /// The element type.
     type Item;
 
@@ -40,7 +40,7 @@ pub trait SliceExt {
     ///
     /// ```
     /// use rand::thread_rng;
-    /// use rand::seq::SliceExt;
+    /// use rand::seq::SliceRandom;
     ///
     /// let choices = [1, 2, 4, 8, 16, 32];
     /// let mut rng = thread_rng();
@@ -73,7 +73,7 @@ pub trait SliceExt {
     /// 
     /// # Example
     /// ```
-    /// use rand::seq::SliceExt;
+    /// use rand::seq::SliceRandom;
     /// 
     /// let mut rng = &mut rand::thread_rng();
     /// let sample = "Hello, audience!".as_bytes();
@@ -99,7 +99,7 @@ pub trait SliceExt {
     ///
     /// ```
     /// use rand::thread_rng;
-    /// use rand::seq::SliceExt;
+    /// use rand::seq::SliceRandom;
     ///
     /// let mut rng = thread_rng();
     /// let mut y = [1, 2, 3, 4, 5];
@@ -132,7 +132,7 @@ pub trait SliceExt {
 }
 
 /// Extension trait on iterators, providing random sampling methods.
-pub trait IteratorExt: Iterator + Sized {
+pub trait IteratorRandom: Iterator + Sized {
     /// Choose one element at random from the iterator.
     ///
     /// Returns `None` if and only if the iterator is empty.
@@ -239,7 +239,7 @@ pub trait IteratorExt: Iterator + Sized {
 }
 
 
-impl<T> SliceExt for [T] {
+impl<T> SliceRandom for [T] {
     type Item = T;
 
     fn choose<R>(&self, rng: &mut R) -> Option<&Self::Item>
@@ -302,11 +302,11 @@ impl<T> SliceExt for [T] {
     }
 }
 
-impl<I> IteratorExt for I where I: Iterator + Sized {}
+impl<I> IteratorRandom for I where I: Iterator + Sized {}
 
 
-/// Iterator over multiple choices, as returned by [`SliceExt::choose_multiple](
-/// trait.SliceExt.html#method.choose_multiple).
+/// Iterator over multiple choices, as returned by [`SliceRandom::choose_multiple](
+/// trait.SliceRandom.html#method.choose_multiple).
 #[cfg(feature = "alloc")]
 #[derive(Debug)]
 pub struct SliceChooseIter<'a, S: ?Sized + 'a, T: 'a> {
@@ -345,16 +345,16 @@ impl<'a, S: Index<usize, Output = T> + ?Sized + 'a, T: 'a> ExactSizeIterator
 
 /// Randomly sample `amount` elements from a finite iterator.
 ///
-/// Deprecated: use [`IteratorExt::choose_multiple`] instead.
+/// Deprecated: use [`IteratorRandom::choose_multiple`] instead.
 /// 
-/// [`IteratorExt::choose_multiple`]: trait.IteratorExt.html#method.choose_multiple
+/// [`IteratorRandom::choose_multiple`]: trait.IteratorRandom.html#method.choose_multiple
 #[cfg(feature = "alloc")]
-#[deprecated(since="0.6.0", note="use IteratorExt::choose_multiple instead")]
+#[deprecated(since="0.6.0", note="use IteratorRandom::choose_multiple instead")]
 pub fn sample_iter<T, I, R>(rng: &mut R, iterable: I, amount: usize) -> Result<Vec<T>, Vec<T>>
     where I: IntoIterator<Item=T>,
           R: Rng + ?Sized,
 {
-    use seq::IteratorExt;
+    use seq::IteratorRandom;
     let iter = iterable.into_iter();
     let result = iter.choose_multiple(rng, amount);
     if result.len() == amount {
@@ -372,11 +372,11 @@ pub fn sample_iter<T, I, R>(rng: &mut R, iterable: I, amount: usize) -> Result<V
 ///
 /// Panics if `amount > slice.len()`
 ///
-/// Deprecated: use [`SliceExt::choose_multiple`] instead.
+/// Deprecated: use [`SliceRandom::choose_multiple`] instead.
 /// 
-/// [`SliceExt::choose_multiple`]: trait.SliceExt.html#method.choose_multiple
+/// [`SliceRandom::choose_multiple`]: trait.SliceRandom.html#method.choose_multiple
 #[cfg(feature = "alloc")]
-#[deprecated(since="0.6.0", note="use SliceExt::choose_multiple instead")]
+#[deprecated(since="0.6.0", note="use SliceRandom::choose_multiple instead")]
 pub fn sample_slice<R, T>(rng: &mut R, slice: &[T], amount: usize) -> Vec<T>
     where R: Rng + ?Sized,
           T: Clone
@@ -396,11 +396,11 @@ pub fn sample_slice<R, T>(rng: &mut R, slice: &[T], amount: usize) -> Vec<T>
 ///
 /// Panics if `amount > slice.len()`
 ///
-/// Deprecated: use [`SliceExt::choose_multiple`] instead.
+/// Deprecated: use [`SliceRandom::choose_multiple`] instead.
 /// 
-/// [`SliceExt::choose_multiple`]: trait.SliceExt.html#method.choose_multiple
+/// [`SliceRandom::choose_multiple`]: trait.SliceRandom.html#method.choose_multiple
 #[cfg(feature = "alloc")]
-#[deprecated(since="0.6.0", note="use SliceExt::choose_multiple instead")]
+#[deprecated(since="0.6.0", note="use SliceRandom::choose_multiple instead")]
 pub fn sample_slice_ref<'a, R, T>(rng: &mut R, slice: &'a [T], amount: usize) -> Vec<&'a T>
     where R: Rng + ?Sized
 {
@@ -517,7 +517,7 @@ fn sample_indices_cache<R>(
 #[cfg(test)]
 mod test {
     use super::*;
-    use super::IteratorExt;
+    use super::IteratorRandom;
     #[cfg(feature = "alloc")]
     use {XorShiftRng, Rng, SeedableRng};
     #[cfg(all(feature="alloc", not(feature="std")))]

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -76,19 +76,19 @@ pub trait SliceRandom {
     /// use rand::seq::SliceRandom;
     /// 
     /// let mut rng = &mut rand::thread_rng();
-    /// let sample = "Hello, audience!".as_bytes();
+    /// let sequence = "Hello, audience!".as_bytes();
     /// 
     /// // collect the results into a vector:
-    /// let v: Vec<u8> = sample.choose_multiple(&mut rng, 3).cloned().collect();
+    /// let v: Vec<u8> = sequence.sample(&mut rng, 3).cloned().collect();
     /// 
     /// // store in a buffer:
     /// let mut buf = [0u8; 5];
-    /// for (b, slot) in sample.choose_multiple(&mut rng, buf.len()).zip(buf.iter_mut()) {
+    /// for (b, slot) in sequence.sample(&mut rng, buf.len()).zip(buf.iter_mut()) {
     ///     *slot = *b;
     /// }
     /// ```
     #[cfg(feature = "alloc")]
-    fn choose_multiple<R>(&self, rng: &mut R, amount: usize) -> SliceChooseIter<Self, Self::Item>
+    fn sample<R>(&self, rng: &mut R, amount: usize) -> SliceChooseIter<Self, Self::Item>
         where R: Rng + ?Sized;
 
     /// Shuffle a mutable slice in place.
@@ -173,7 +173,7 @@ pub trait IteratorRandom: Iterator + Sized {
     /// equals the number of elements available.
     /// 
     /// Complexity is `O(n)` where `n` is the length of the iterator.
-    fn choose_multiple_fill<R>(mut self, rng: &mut R, buf: &mut [Self::Item])
+    fn sample_fill<R>(mut self, rng: &mut R, buf: &mut [Self::Item])
         -> usize where R: Rng + ?Sized
     {
         let amount = buf.len();
@@ -200,7 +200,7 @@ pub trait IteratorRandom: Iterator + Sized {
 
     /// Collects `amount` values at random from the iterator into a vector.
     ///
-    /// This is equivalent to `choose_multiple_fill` except for the result type.
+    /// This is equivalent to `sample_fill` except for the result type.
     ///
     /// Although the elements are selected randomly, the order of elements in
     /// the buffer is neither stable nor fully random. If random ordering is
@@ -212,7 +212,7 @@ pub trait IteratorRandom: Iterator + Sized {
     /// 
     /// Complexity is `O(n)` where `n` is the length of the iterator.
     #[cfg(feature = "alloc")]
-    fn choose_multiple<R>(mut self, rng: &mut R, amount: usize) -> Vec<Self::Item>
+    fn sample<R>(mut self, rng: &mut R, amount: usize) -> Vec<Self::Item>
         where R: Rng + ?Sized
     {
         let mut reservoir = Vec::with_capacity(amount);
@@ -264,7 +264,7 @@ impl<T> SliceRandom for [T] {
     }
 
     #[cfg(feature = "alloc")]
-    fn choose_multiple<R>(&self, rng: &mut R, amount: usize) -> SliceChooseIter<Self, Self::Item>
+    fn sample<R>(&self, rng: &mut R, amount: usize) -> SliceChooseIter<Self, Self::Item>
         where R: Rng + ?Sized
     {
         let amount = ::core::cmp::min(amount, self.len());
@@ -306,8 +306,8 @@ impl<T> SliceRandom for [T] {
 impl<I> IteratorRandom for I where I: Iterator + Sized {}
 
 
-/// Iterator over multiple choices, as returned by [`SliceRandom::choose_multiple](
-/// trait.SliceRandom.html#method.choose_multiple).
+/// Iterator over multiple choices, as returned by [`SliceRandom::sample](
+/// trait.SliceRandom.html#method.sample).
 #[cfg(feature = "alloc")]
 #[derive(Debug)]
 pub struct SliceChooseIter<'a, S: ?Sized + 'a, T: 'a> {
@@ -346,18 +346,18 @@ impl<'a, S: Index<usize, Output = T> + ?Sized + 'a, T: 'a> ExactSizeIterator
 
 /// Randomly sample `amount` elements from a finite iterator.
 ///
-/// Deprecated: use [`IteratorRandom::choose_multiple`] instead.
+/// Deprecated: use [`IteratorRandom::sample`] instead.
 /// 
-/// [`IteratorRandom::choose_multiple`]: trait.IteratorRandom.html#method.choose_multiple
+/// [`IteratorRandom::sample`]: trait.IteratorRandom.html#method.sample
 #[cfg(feature = "alloc")]
-#[deprecated(since="0.6.0", note="use IteratorRandom::choose_multiple instead")]
+#[deprecated(since="0.6.0", note="use IteratorRandom::sample instead")]
 pub fn sample_iter<T, I, R>(rng: &mut R, iterable: I, amount: usize) -> Result<Vec<T>, Vec<T>>
     where I: IntoIterator<Item=T>,
           R: Rng + ?Sized,
 {
     use seq::IteratorRandom;
     let iter = iterable.into_iter();
-    let result = iter.choose_multiple(rng, amount);
+    let result = iter.sample(rng, amount);
     if result.len() == amount {
         Ok(result)
     } else {
@@ -373,11 +373,11 @@ pub fn sample_iter<T, I, R>(rng: &mut R, iterable: I, amount: usize) -> Result<V
 ///
 /// Panics if `amount > slice.len()`
 ///
-/// Deprecated: use [`SliceRandom::choose_multiple`] instead.
+/// Deprecated: use [`SliceRandom::sample`] instead.
 /// 
-/// [`SliceRandom::choose_multiple`]: trait.SliceRandom.html#method.choose_multiple
+/// [`SliceRandom::sample`]: trait.SliceRandom.html#method.sample
 #[cfg(feature = "alloc")]
-#[deprecated(since="0.6.0", note="use SliceRandom::choose_multiple instead")]
+#[deprecated(since="0.6.0", note="use SliceRandom::sample instead")]
 pub fn sample_slice<R, T>(rng: &mut R, slice: &[T], amount: usize) -> Vec<T>
     where R: Rng + ?Sized,
           T: Clone
@@ -397,11 +397,11 @@ pub fn sample_slice<R, T>(rng: &mut R, slice: &[T], amount: usize) -> Vec<T>
 ///
 /// Panics if `amount > slice.len()`
 ///
-/// Deprecated: use [`SliceRandom::choose_multiple`] instead.
+/// Deprecated: use [`SliceRandom::sample`] instead.
 /// 
-/// [`SliceRandom::choose_multiple`]: trait.SliceRandom.html#method.choose_multiple
+/// [`SliceRandom::sample`]: trait.SliceRandom.html#method.sample
 #[cfg(feature = "alloc")]
-#[deprecated(since="0.6.0", note="use SliceRandom::choose_multiple instead")]
+#[deprecated(since="0.6.0", note="use SliceRandom::sample instead")]
 pub fn sample_slice_ref<'a, R, T>(rng: &mut R, slice: &'a [T], amount: usize) -> Vec<&'a T>
     where R: Rng + ?Sized
 {
@@ -584,8 +584,8 @@ mod test {
 
         let mut r = ::test::rng(401);
         let vals = (min_val..max_val).collect::<Vec<i32>>();
-        let small_sample = vals.iter().choose_multiple(&mut r, 5);
-        let large_sample = vals.iter().choose_multiple(&mut r, vals.len() + 5);
+        let small_sample = vals.iter().sample(&mut r, 5);
+        let large_sample = vals.iter().sample(&mut r, vals.len() + 5);
 
         assert_eq!(small_sample.len(), 5);
         assert_eq!(large_sample.len(), vals.len());


### PR DESCRIPTION
On top of the existing `Rng.choose()` and `Rng.choose_mut()`, this implements `Rng.choose_from_iterator()`, `Rng.choose_weighted()`, `Rng.choose_weighted_with_total()`, `SliceRandom.choose()`, `SliceRandom.choose_mut()`, and `IteratorRandom.choose()`.


Regarding the `vec.shuffle(rng)` vs. `rng.shuffle(vec)` issue, my strategy for where to stick functions was basically:
* Stick all functions on the `Rng` trait. Since this helps with documentation and discoverability.
* For functions that can reasonably be used in chains like `get_stuff().do_random_op(&mut rng).do_other_stuff()`, I've also added functions on `SliceRandom` and `IteratorRandom` which forward to the implementation on the `Rng` trait.

This seems like a reasonable trade-off to me. But happy to discuss more.

Also, this patch relies on that issue #476 will be fixed. Otherwise using floating point weights will on very rare occasions panic.