### PR TITLE
Add API for getting a bool with chance of exactly 1-in-10 or 2-in-3

### DIFF
--- a/benches/misc.rs
+++ b/benches/misc.rs
@@ -37,6 +37,30 @@ fn misc_gen_bool_var(b: &mut Bencher) {
 }
 
 #[bench]
+fn misc_gen_ratio_const(b: &mut Bencher) {
+    let mut rng = StdRng::from_rng(&mut thread_rng()).unwrap();
+    b.iter(|| {
+        let mut accum = true;
+        for _ in 0..::RAND_BENCH_N {
+            accum ^= rng.gen_ratio(2, 3);
+        }
+        accum
+    })
+}
+
+#[bench]
+fn misc_gen_ratio_var(b: &mut Bencher) {
+    let mut rng = StdRng::from_rng(&mut thread_rng()).unwrap();
+    b.iter(|| {
+        let mut accum = true;
+        for i in 2..(::RAND_BENCH_N as u32 + 2) {
+            accum ^= rng.gen_ratio(i, i + 1);
+        }
+        accum
+    })
+}
+
+#[bench]
 fn misc_bernoulli_const(b: &mut Bencher) {
     let mut rng = StdRng::from_rng(&mut thread_rng()).unwrap();
     let d = rand::distributions::Bernoulli::new(0.18);


### PR DESCRIPTION
The `gen_weighted_bool` function is being deprecated in 0.5 since it's not very flexible and can only generate a bool with ratios 1-in-N.

However the `gen_bool` replacement has the problem that it can't generate bools with exact ratios. So for example `rng.gen_bool(0.1)` won't return `true` exactly 10% of the time, since an f64 can't express exactly the value 0.1. Additionally since the implementation of `Bernoulli` introduce further bias in the multiplication with u64::MAX and rounding to u64.

Another way to look at it is that since the implementation of `Bernoulli` generate an u64 without rejecting any values, it's impossible to generate an unbiased 1/10 distribution.

Same thing with `rng.gen_bool(2/3)` or any other ratio.

This PR adds a `rng.gen_ratio(numerator, denominator)` function, which take two numbers and generate boolean which is `true` exactly `numerator/denominator` of the time. Or at least as exactly as our `Uniform` implementation is for the given type. So `rng.gen_ratio(2u8, 3u8)` will be unbiased, whereas `rng.gen_ratio(2f32, 3f32)` will suffer some rounding errors.

This PR also adds `Bernoulli::new_ratio` which creates a `Distribution<bool>` with the same property.

I'm not a particularly big fan of the name `gen_ratio` and `new_ratio`. Happy for better suggestions.