### PR TITLE
Add dummy implementation for unsupported OsRng platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 You may also find the [Update Guide](UPDATING.md) useful.
 
 
+## [0.5.2] - 2018-06-13
+### Changed
+- Add back dummy implementation for `OsRng` on unsupported platforms (temporary fix). (#505)
+
+
 ## [0.5.1] - 2018-06-08
 
 ### New distributions
@@ -25,6 +30,7 @@ You may also find the [Update Guide](UPDATING.md) useful.
 - Emscripten, Haiku: don't do an extra blocking read from `/dev/random`. (#484)
 - Linux, NetBSD, Solaris: read in blocking mode on first use in `fill_bytes`. (#484)
 - Fuchsia, CloudABI: fix compilation (broken in Rand 0.5). (#484)
+
 
 ## [0.5.0] - 2018-05-21
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.5.1" # NB: When modifying, also modify html_root_url in lib.rs
+version = "0.5.2" # NB: When modifying, also modify html_root_url in lib.rs
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,7 +223,7 @@
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-       html_root_url = "https://docs.rs/rand/0.5.1")]
+       html_root_url = "https://docs.rs/rand/0.5.2")]
 
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]

--- a/src/rngs/os.rs
+++ b/src/rngs/os.rs
@@ -1103,6 +1103,43 @@ mod imp {
 }
 
 
+#[cfg(not(any(target_os = "linux", target_os = "android",
+              target_os = "netbsd",
+              target_os = "dragonfly",
+              target_os = "haiku",
+              target_os = "emscripten",
+              target_os = "solaris",
+              target_os = "cloudabi",
+              target_os = "macos", target_os = "ios",
+              target_os = "freebsd",
+              target_os = "openbsd", target_os = "bitrig",
+              target_os = "redox",
+              target_os = "fuchsia",
+              windows,
+              all(target_arch = "wasm32", feature = "stdweb")
+)))]
+mod imp {
+    use {Error, ErrorKind};
+    use super::OsRngImpl;
+
+    #[derive(Clone, Debug)]
+    pub struct OsRng;
+
+    impl OsRngImpl for OsRng {
+        fn new() -> Result<OsRng, Error> {
+            Err(Error::new(ErrorKind::Unavailable,
+               "not supported on this platform"))
+        }
+
+        fn fill_chunk(&mut self, _dest: &mut [u8]) -> Result<(), Error> {
+            unreachable!()
+        }
+
+        fn method_str(&self) -> &'static str { unreachable!() }
+    }
+}
+
+
 #[cfg(test)]
 mod test {
     use RngCore;


### PR DESCRIPTION
Fixes https://github.com/rust-lang-nursery/rand/issues/503.