### PR TITLE
Complicate entropy rng

### DIFF
--- a/src/deprecated.rs
+++ b/src/deprecated.rs
@@ -249,11 +249,42 @@ impl SeedableRng for StdRng {
 impl CryptoRng for StdRng {}
 
 
-#[cfg(feature="std")]
+#[cfg(all(feature="std",
+          any(target_os = "linux", target_os = "android",
+              target_os = "netbsd",
+              target_os = "dragonfly",
+              target_os = "haiku",
+              target_os = "emscripten",
+              target_os = "solaris",
+              target_os = "cloudabi",
+              target_os = "macos", target_os = "ios",
+              target_os = "freebsd",
+              target_os = "openbsd", target_os = "bitrig",
+              target_os = "redox",
+              target_os = "fuchsia",
+              windows,
+              all(target_arch = "wasm32", feature = "stdweb")
+)))]
 #[derive(Clone, Debug)]
 #[deprecated(since="0.6.0", note="import with rand::rngs::OsRng instead")]
 pub struct OsRng(rngs::OsRng);
 
+#[cfg(all(feature="std",
+          any(target_os = "linux", target_os = "android",
+              target_os = "netbsd",
+              target_os = "dragonfly",
+              target_os = "haiku",
+              target_os = "emscripten",
+              target_os = "solaris",
+              target_os = "cloudabi",
+              target_os = "macos", target_os = "ios",
+              target_os = "freebsd",
+              target_os = "openbsd", target_os = "bitrig",
+              target_os = "redox",
+              target_os = "fuchsia",
+              windows,
+              all(target_arch = "wasm32", feature = "stdweb")
+)))]
 #[cfg(feature="std")]
 impl RngCore for OsRng {
     #[inline(always)]
@@ -277,6 +308,22 @@ impl RngCore for OsRng {
     }
 }
 
+#[cfg(all(feature="std",
+          any(target_os = "linux", target_os = "android",
+              target_os = "netbsd",
+              target_os = "dragonfly",
+              target_os = "haiku",
+              target_os = "emscripten",
+              target_os = "solaris",
+              target_os = "cloudabi",
+              target_os = "macos", target_os = "ios",
+              target_os = "freebsd",
+              target_os = "openbsd", target_os = "bitrig",
+              target_os = "redox",
+              target_os = "fuchsia",
+              windows,
+              all(target_arch = "wasm32", feature = "stdweb")
+)))]
 #[cfg(feature="std")]
 impl OsRng {
     pub fn new() -> Result<Self, Error> {
@@ -284,6 +331,22 @@ impl OsRng {
     }
 }
 
+#[cfg(all(feature="std",
+          any(target_os = "linux", target_os = "android",
+              target_os = "netbsd",
+              target_os = "dragonfly",
+              target_os = "haiku",
+              target_os = "emscripten",
+              target_os = "solaris",
+              target_os = "cloudabi",
+              target_os = "macos", target_os = "ios",
+              target_os = "freebsd",
+              target_os = "openbsd", target_os = "bitrig",
+              target_os = "redox",
+              target_os = "fuchsia",
+              windows,
+              all(target_arch = "wasm32", feature = "stdweb")
+)))]
 #[cfg(feature="std")]
 impl CryptoRng for OsRng {}
 

--- a/src/deprecated.rs
+++ b/src/deprecated.rs
@@ -361,7 +361,7 @@ impl RngCore for JitterRng {
 }
 
 impl JitterRng {
-    #[cfg(feature="std")]
+    #[cfg(all(feature="std", not(target_arch = "wasm32")))]
     pub fn new() -> Result<JitterRng, rngs::TimerError> {
         rngs::JitterRng::new().map(JitterRng)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,7 +284,27 @@ pub mod rngs;
 #[doc(hidden)] pub use deprecated::ReseedingRng;
 
 #[allow(deprecated)]
-#[cfg(feature="std")] #[doc(hidden)] pub use deprecated::{EntropyRng, OsRng};
+#[cfg(feature="std")] #[doc(hidden)] pub use deprecated::EntropyRng;
+
+#[allow(deprecated)]
+#[cfg(all(feature="std",
+          any(target_os = "linux", target_os = "android",
+              target_os = "netbsd",
+              target_os = "dragonfly",
+              target_os = "haiku",
+              target_os = "emscripten",
+              target_os = "solaris",
+              target_os = "cloudabi",
+              target_os = "macos", target_os = "ios",
+              target_os = "freebsd",
+              target_os = "openbsd", target_os = "bitrig",
+              target_os = "redox",
+              target_os = "fuchsia",
+              windows,
+              all(target_arch = "wasm32", feature = "stdweb")
+)))]
+#[doc(hidden)]
+pub use deprecated::OsRng;
 
 #[allow(deprecated)]
 #[doc(hidden)] pub use deprecated::{ChaChaRng, IsaacRng, Isaac64Rng, XorShiftRng};
@@ -299,7 +319,22 @@ pub mod jitter {
     pub use rngs::TimerError;
 }
 #[allow(deprecated)]
-#[cfg(feature="std")]
+#[cfg(all(feature="std",
+          any(target_os = "linux", target_os = "android",
+              target_os = "netbsd",
+              target_os = "dragonfly",
+              target_os = "haiku",
+              target_os = "emscripten",
+              target_os = "solaris",
+              target_os = "cloudabi",
+              target_os = "macos", target_os = "ios",
+              target_os = "freebsd",
+              target_os = "openbsd", target_os = "bitrig",
+              target_os = "redox",
+              target_os = "fuchsia",
+              windows,
+              all(target_arch = "wasm32", feature = "stdweb")
+)))]
 #[doc(hidden)]
 pub mod os {
     pub use deprecated::OsRng;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,11 +249,16 @@ extern crate stdweb;
 extern crate rand_core;
 
 #[cfg(feature = "log")] #[macro_use] extern crate log;
+#[allow(unused)]
 #[cfg(not(feature = "log"))] macro_rules! trace { ($($x:tt)*) => () }
+#[allow(unused)]
 #[cfg(not(feature = "log"))] macro_rules! debug { ($($x:tt)*) => () }
-#[cfg(all(feature="std", not(feature = "log")))] macro_rules! info { ($($x:tt)*) => () }
+#[allow(unused)]
+#[cfg(not(feature = "log"))] macro_rules! info { ($($x:tt)*) => () }
+#[allow(unused)]
 #[cfg(not(feature = "log"))] macro_rules! warn { ($($x:tt)*) => () }
-#[cfg(all(feature="std", not(feature = "log")))] macro_rules! error { ($($x:tt)*) => () }
+#[allow(unused)]
+#[cfg(not(feature = "log"))] macro_rules! error { ($($x:tt)*) => () }
 
 
 // Re-exports from rand_core

--- a/src/rngs/jitter.rs
+++ b/src/rngs/jitter.rs
@@ -24,7 +24,7 @@
 use rand_core::{RngCore, CryptoRng, Error, ErrorKind, impls};
 
 use core::{fmt, mem, ptr};
-#[cfg(feature="std")]
+#[cfg(all(feature="std", not(target_arch = "wasm32")))]
 use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
 
 const MEMORY_BLOCKS: usize = 64;
@@ -53,6 +53,10 @@ const MEMORY_SIZE: usize = MEMORY_BLOCKS * MEMORY_BLOCKSIZE;
 ///
 /// This implementation is based on
 /// [Jitterentropy](http://www.chronox.de/jent.html) version 2.1.0.
+///
+/// Note: There is no accurate timer available on Wasm platforms, to help
+/// prevent fingerprinting or timing side-channel attacks. Therefore
+/// [`JitterRng::new()`] is not available on Wasm.
 ///
 /// # Quality testing
 ///
@@ -268,7 +272,7 @@ impl From<TimerError> for Error {
 }
 
 // Initialise to zero; must be positive
-#[cfg(feature="std")]
+#[cfg(all(feature="std", not(target_arch = "wasm32")))]
 static JITTER_ROUNDS: AtomicUsize = ATOMIC_USIZE_INIT;
 
 impl JitterRng {
@@ -279,7 +283,7 @@ impl JitterRng {
     /// During initialization CPU execution timing jitter is measured a few
     /// hundred times. If this does not pass basic quality tests, an error is
     /// returned. The test result is cached to make subsequent calls faster.
-    #[cfg(feature="std")]
+    #[cfg(all(feature="std", not(target_arch = "wasm32")))]
     pub fn new() -> Result<JitterRng, TimerError> {
         let mut state = JitterRng::new_with_timer(platform::get_nstime);
         let mut rounds = JITTER_ROUNDS.load(Ordering::Relaxed) as u8;
@@ -771,8 +775,9 @@ impl JitterRng {
 
 #[cfg(feature="std")]
 mod platform {
-    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "windows",
-                  all(target_arch = "wasm32", not(target_os = "emscripten")))))]
+    #[cfg(not(any(target_os = "macos", target_os = "ios",
+                  target_os = "windows",
+                  target_arch = "wasm32")))]
     pub fn get_nstime() -> u64 {
         use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -804,16 +809,6 @@ mod platform {
             winapi::um::profileapi::QueryPerformanceCounter(&mut t);
             *t.QuadPart() as u64
         }
-    }
-
-    #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-    pub fn get_nstime() -> u64 {
-        // We don't use the timer from the standard library, because it panics
-        // at runtime.
-        //
-        // There is no accurate timer available on Wasm platforms, to help
-        // prevent fingerprinting or timing side-channel attacks.
-        0 // Will make `test_timer` fail with `NoTimer`.
     }
 }
 
@@ -865,7 +860,7 @@ impl CryptoRng for JitterRng {}
 mod test_jitter_init {
     use super::JitterRng;
 
-    #[cfg(feature="std")]
+    #[cfg(all(feature="std", not(target_arch = "wasm32")))]
     #[test]
     fn test_jitter_init() {
         use RngCore;

--- a/src/rngs/mod.rs
+++ b/src/rngs/mod.rs
@@ -169,7 +169,7 @@ pub mod adapter;
 mod jitter;
 pub mod mock;   // Public so we don't export `StepRng` directly, making it a bit
                 // more clear it is intended for testing.
-#[cfg(feature="std")] mod os;
+
 mod small;
 mod std;
 #[cfg(feature="std")] pub(crate) mod thread;
@@ -177,8 +177,43 @@ mod std;
 
 pub use self::jitter::{JitterRng, TimerError};
 #[cfg(feature="std")] pub use self::entropy::EntropyRng;
-#[cfg(feature="std")] pub use self::os::OsRng;
 
 pub use self::small::SmallRng;
 pub use self::std::StdRng;
 #[cfg(feature="std")] pub use self::thread::ThreadRng;
+
+#[cfg(all(feature="std",
+          any(target_os = "linux", target_os = "android",
+              target_os = "netbsd",
+              target_os = "dragonfly",
+              target_os = "haiku",
+              target_os = "emscripten",
+              target_os = "solaris",
+              target_os = "cloudabi",
+              target_os = "macos", target_os = "ios",
+              target_os = "freebsd",
+              target_os = "openbsd", target_os = "bitrig",
+              target_os = "redox",
+              target_os = "fuchsia",
+              windows,
+              all(target_arch = "wasm32", feature = "stdweb")
+)))]
+mod os;
+
+#[cfg(all(feature="std",
+          any(target_os = "linux", target_os = "android",
+              target_os = "netbsd",
+              target_os = "dragonfly",
+              target_os = "haiku",
+              target_os = "emscripten",
+              target_os = "solaris",
+              target_os = "cloudabi",
+              target_os = "macos", target_os = "ios",
+              target_os = "freebsd",
+              target_os = "openbsd", target_os = "bitrig",
+              target_os = "redox",
+              target_os = "fuchsia",
+              windows,
+              all(target_arch = "wasm32", feature = "stdweb")
+)))]
+pub use self::os::OsRng;


### PR DESCRIPTION
This is (in my opinion) the proper fix for https://github.com/rust-lang-nursery/rand/issues/503: make `OsRng` unavailable if the platform is not supported.

This also makes `JitterRng::new` unavailable on Wasm.

`EntropyRng` already had tricky logic. Making it work nicely when `OsRng` and/or `JitterRng` are not available at compile time complicates it further. And I didn't want to think how it was going to look when we want to add some configurable third entropy source.

I have tried to rewrite `EntropyRng` to have hopefully simpler logic. Because we need wrappers for `OsRng` and `JitterRng` to make it compile on all platforms, I went all the way and added a little trait to ease implementation.