### PR TITLE
Fix ambiguity issues in use of Borrow<T>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,9 +323,8 @@ pub mod read {
 
 
 use core::{mem, slice};
-use core::borrow::Borrow;
 use distributions::{Distribution, Standard};
-use distributions::uniform::{SampleUniform, UniformSampler};
+use distributions::uniform::{SampleUniform, UniformSampler, SampleBorrow};
 
 /// An automatically-implemented extension trait on [`RngCore`] providing high-level
 /// generic methods for sampling values and other convenience methods.
@@ -411,8 +410,8 @@ pub trait Rng: RngCore {
     ///
     /// [`Uniform`]: distributions/uniform/struct.Uniform.html
     fn gen_range<T: SampleUniform, B1, B2>(&mut self, low: B1, high: B2) -> T
-        where B1: Borrow<T> + Sized,
-              B2: Borrow<T> + Sized {
+        where B1: SampleBorrow<T> + Sized,
+              B2: SampleBorrow<T> + Sized {
         T::Sampler::sample_single(low, high, self)
     }
 
@@ -969,6 +968,8 @@ mod test {
             assert!(a >= 10u16 && a < 99u16);
             let a = r.gen_range(-100i32, &2000);
             assert!(a >= -100i32 && a < 2000i32);
+            let a = r.gen_range(&12u32, &24u32);
+            assert!(a >= 12u32 && a < 24u32);
 
             assert_eq!(r.gen_range(0u32, 1), 0u32);
             assert_eq!(r.gen_range(-12i64, -11), -12i64);


### PR DESCRIPTION
There's a big problem with #506 which I missed during both authoring and testing. All of the following work fine:

```rust
rng.gen_range(5, 10);
rng.gen_range(&5, 10);
rng.gen_range(5, &10);
```

However the following does not
```rust
rng.gen_range(&5, &10);
```
It fails because `&usize` implement both `Borrow<usize>` and `Borrow<&usize>`. And so there are two solution to `gen_range`'s bound `where B1: Borrow<T>, B2: Borrow<T>` resulting in a disambiguation error. I.e. rustc doesn't know if we want `T=usize` or `T=&usize`.

Even though `gen_range` also says `where T: SampleUniform`, which is only satisfied for `T=usize`, that apparently does not help.

The problem could be solved by writing `gen_range::<usize, _, _>(&5, &10)`, but that's obviously not something we want to require.

This PR instead implements a `SampleBorrow` trait. Which is essentially an exact copy of `Borrow`, except that it's only implemented where `T=SampleUniform`. So `&usize` implements `SampleBorrow<usize>`, but not `SampleBorrow<&usize>`, resolving the ambiguity.

This adds no complexity at callsites. Implementations of `SampleUniform` will have to write `SampleBorrow` instead of `Borrow`, but otherwise will write exactly the same code.

It's a bummer that we can't use the standard `Borrow`, but I don't know of any way to solve that.

And `SampleBorrow` does give us more flexibility. For example we could enable passing `&&5`, or `&Box::new(5)` if we wanted (which can sometime occur with iterators). But that'd be a separate PR if so.