### PR TITLE
Complicate entropy rng 0.5

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,13 +281,60 @@ pub mod rngs;
 #[cfg(feature="std")] #[doc(hidden)] pub use rngs::adapter::read;
 #[doc(hidden)] pub use rngs::adapter::ReseedingRng;
 
-#[doc(hidden)] pub use rngs::jitter;
-#[cfg(feature="std")] #[doc(hidden)] pub use rngs::{os, EntropyRng, OsRng};
+#[allow(deprecated)]
+#[cfg(feature="std")] #[doc(hidden)] pub use rngs::EntropyRng;
+
+#[allow(deprecated)]
+#[cfg(all(feature="std",
+          any(target_os = "linux", target_os = "android",
+              target_os = "netbsd",
+              target_os = "dragonfly",
+              target_os = "haiku",
+              target_os = "emscripten",
+              target_os = "solaris",
+              target_os = "cloudabi",
+              target_os = "macos", target_os = "ios",
+              target_os = "freebsd",
+              target_os = "openbsd", target_os = "bitrig",
+              target_os = "redox",
+              target_os = "fuchsia",
+              windows,
+              all(target_arch = "wasm32", feature = "stdweb")
+)))]
+#[doc(hidden)]
+pub use rngs::OsRng;
 
 #[doc(hidden)] pub use prng::{ChaChaRng, IsaacRng, Isaac64Rng, XorShiftRng};
 #[doc(hidden)] pub use rngs::StdRng;
 
 
+#[allow(deprecated)]
+#[doc(hidden)]
+pub mod jitter {
+    pub use rngs::{JitterRng, TimerError};
+}
+#[allow(deprecated)]
+#[cfg(all(feature="std",
+          any(target_os = "linux", target_os = "android",
+              target_os = "netbsd",
+              target_os = "dragonfly",
+              target_os = "haiku",
+              target_os = "emscripten",
+              target_os = "solaris",
+              target_os = "cloudabi",
+              target_os = "macos", target_os = "ios",
+              target_os = "freebsd",
+              target_os = "openbsd", target_os = "bitrig",
+              target_os = "redox",
+              target_os = "fuchsia",
+              windows,
+              all(target_arch = "wasm32", feature = "stdweb")
+)))]
+#[doc(hidden)]
+pub mod os {
+    pub use rngs::OsRng;
+}
+#[allow(deprecated)]
 #[doc(hidden)]
 pub mod chacha {
     //! The ChaCha random number generator.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,11 +249,16 @@ extern crate stdweb;
 extern crate rand_core;
 
 #[cfg(feature = "log")] #[macro_use] extern crate log;
+#[allow(unused)]
 #[cfg(not(feature = "log"))] macro_rules! trace { ($($x:tt)*) => () }
+#[allow(unused)]
 #[cfg(not(feature = "log"))] macro_rules! debug { ($($x:tt)*) => () }
-#[cfg(all(feature="std", not(feature = "log")))] macro_rules! info { ($($x:tt)*) => () }
+#[allow(unused)]
+#[cfg(not(feature = "log"))] macro_rules! info { ($($x:tt)*) => () }
+#[allow(unused)]
 #[cfg(not(feature = "log"))] macro_rules! warn { ($($x:tt)*) => () }
-#[cfg(all(feature="std", not(feature = "log")))] macro_rules! error { ($($x:tt)*) => () }
+#[allow(unused)]
+#[cfg(not(feature = "log"))] macro_rules! error { ($($x:tt)*) => () }
 
 
 // Re-exports from rand_core

--- a/src/rngs/mod.rs
+++ b/src/rngs/mod.rs
@@ -169,7 +169,6 @@ pub mod adapter;
 #[doc(hidden)] pub mod jitter;
 pub mod mock;   // Public so we don't export `StepRng` directly, making it a bit
                 // more clear it is intended for testing.
-#[cfg(feature="std")] #[doc(hidden)] pub mod os;
 mod small;
 mod std;
 #[cfg(feature="std")] pub(crate) mod thread;
@@ -177,8 +176,43 @@ mod std;
 
 pub use self::jitter::{JitterRng, TimerError};
 #[cfg(feature="std")] pub use self::entropy::EntropyRng;
-#[cfg(feature="std")] pub use self::os::OsRng;
 
 pub use self::small::SmallRng;
 pub use self::std::StdRng;
 #[cfg(feature="std")] pub use self::thread::ThreadRng;
+
+#[cfg(all(feature="std",
+          any(target_os = "linux", target_os = "android",
+              target_os = "netbsd",
+              target_os = "dragonfly",
+              target_os = "haiku",
+              target_os = "emscripten",
+              target_os = "solaris",
+              target_os = "cloudabi",
+              target_os = "macos", target_os = "ios",
+              target_os = "freebsd",
+              target_os = "openbsd", target_os = "bitrig",
+              target_os = "redox",
+              target_os = "fuchsia",
+              windows,
+              all(target_arch = "wasm32", feature = "stdweb")
+)))]
+mod os;
+
+#[cfg(all(feature="std",
+          any(target_os = "linux", target_os = "android",
+              target_os = "netbsd",
+              target_os = "dragonfly",
+              target_os = "haiku",
+              target_os = "emscripten",
+              target_os = "solaris",
+              target_os = "cloudabi",
+              target_os = "macos", target_os = "ios",
+              target_os = "freebsd",
+              target_os = "openbsd", target_os = "bitrig",
+              target_os = "redox",
+              target_os = "fuchsia",
+              windows,
+              all(target_arch = "wasm32", feature = "stdweb")
+)))]
+pub use self::os::OsRng;


### PR DESCRIPTION
https://github.com/rust-lang-nursery/rand/pull/508 Rebased on the 0.5 branch.

>This is (in my opinion) the proper fix for https://github.com/rust-lang-nursery/rand/issues/503: make `OsRng` unavailable if the platform is not supported.
>
>This also makes `JitterRng::new` unavailable on Wasm.
>
>`EntropyRng` already had tricky logic. Making it work nicely when `OsRng` and/or `JitterRng` are not available at compile time complicates it further. And I didn't want to think how it was going to look when we want to add some configurable third entropy source.
>
>I have tried to rewrite `EntropyRng` to have hopefully simpler logic. Because we need wrappers for `OsRng` and `JitterRng` to make it compile on all platforms, I went all the way and added a little trait to ease implementation.