### PR TITLE
Avoid surrogates when generating `char` using Standard distribution

### DIFF
--- a/src/distributions/other.rs
+++ b/src/distributions/other.rs
@@ -44,15 +44,18 @@ pub struct Alphanumeric;
 impl Distribution<char> for Standard {
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> char {
-        let range = Uniform::new(0u32, 0x11_0000);
-        loop {
-            match char::from_u32(range.sample(rng)) {
-                Some(c) => return c,
-                // About 0.2% of numbers in the range 0..0x110000 are invalid
-                // codepoints (surrogates).
-                None => {}
-            }
+        // A valid `char` is either in the interval `[0, 0xD800)` or
+        // `(0xDFFF, 0x11_0000)`. All `char`s must therefore be in
+        // `[0, 0x11_0000)` but not in the "gap" `[0xD800, 0xDFFF]` which is
+        // reserved for surrogates. This is the size of that gap.
+        const GAP_SIZE: u32 = 0xDFFF - 0xD800 + 1;
+
+        let range = Uniform::new(GAP_SIZE, 0x11_0000);
+        let mut n = range.sample(rng);
+        if n <= 0xDFFF {
+            n -= GAP_SIZE;
         }
+        unsafe { char::from_u32_unchecked(n) }
     }
 }
 

--- a/src/distributions/other.rs
+++ b/src/distributions/other.rs
@@ -50,7 +50,10 @@ impl Distribution<char> for Standard {
         // reserved for surrogates. This is the size of that gap.
         const GAP_SIZE: u32 = 0xDFFF - 0xD800 + 1;
 
+        // Uniform::new(0, 0x11_0000 - GAP_SIZE) can also be used but it
+        // seemed slower.
         let range = Uniform::new(GAP_SIZE, 0x11_0000);
+
         let mut n = range.sample(rng);
         if n <= 0xDFFF {
             n -= GAP_SIZE;


### PR DESCRIPTION
This probably isn't performance critical but I thought it seemed wasteful to have a loop (that could theoretically go on forever) just to generate a char. The new version also seems faster when I benchmarked it.
````
test misc_gen_chars_old       ... bench:       1,031 ns/iter (+/- 177) = 496 MB/s
test misc_gen_chars_new       ... bench:         920 ns/iter (+/- 978) = 556 MB/s
````