### PR TITLE
Rename `s` -> `dest` on OpenBSD and bitrig

### DIFF
--- a/src/rngs/os.rs
+++ b/src/rngs/os.rs
@@ -879,7 +879,7 @@ mod imp {
 
         fn fill_chunk(&mut self, dest: &mut [u8]) -> Result<(), Error> {
             let ret = unsafe {
-                libc::getentropy(s.as_mut_ptr() as *mut libc::c_void, s.len())
+                libc::getentropy(dest.as_mut_ptr() as *mut libc::c_void, dest.len())
             };
             if ret == -1 {
                 return Err(Error::with_cause(


### PR DESCRIPTION
This fixes a failing build on OpenBSD and bitrig. Some refactoring in 8c67fc44415ec8d142502ae7b101864bc002c512 missed some variable renaming in the `getentropy` backend.