### PR TITLE
use `self` instead of `window` in JS

### DIFF
--- a/src/rngs/os.rs
+++ b/src/rngs/os.rs
@@ -1023,9 +1023,9 @@ mod imp {
             let result = js! {
                 try {
                     if (
-                        typeof window === "object" &&
-                        typeof window.crypto === "object" &&
-                        typeof window.crypto.getRandomValues === "function"
+                        typeof self === "object" &&
+                        typeof self.crypto === "object" &&
+                        typeof self.crypto.getRandomValues === "function"
                     ) {
                         return { success: true, ty: 1 };
                     }
@@ -1063,7 +1063,7 @@ mod imp {
                 OsRngMethod::Browser => js! {
                     try {
                         let array = new Uint8Array(@{ len });
-                        window.crypto.getRandomValues(array);
+                        self.crypto.getRandomValues(array);
                         HEAPU8.set(array, @{ ptr });
 
                         return { success: true };


### PR DESCRIPTION
ran into this issue when attempting to use rand via wasm/stdweb from a WebWorker -- because there's no `window` global in a worker, the JS parts fail despite `crypto.getRandomValues` existing. this can be solved by using `self` instead, which always exists in the browser.

this allows the same code to work in both windowed contexts (ie, the usual browser stuff) and in non-windowed contexts (like web workers). see https://developer.mozilla.org/en-US/docs/Web/API/Window/self

node doesn't have `window` or `self`, so it shouldn't matter either way on that platform.