### PR TITLE
Add support for wasm-bindgen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,12 @@ matrix:
 
     - rust: nightly
       install:
+        - rustup target add wasm32-unknown-unknown
+      script:
+        - cargo build --target wasm32-unknown-unknown --features wasm-bindgen
+
+    - rust: nightly
+      install:
         - rustup target add thumbv6m-none-eabi
       script:
         # Bare metal target; no std; only works on nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ fuchsia-zircon = { version = "0.3.2", optional = true }
 [target.wasm32-unknown-unknown.dependencies]
 # use with `--target wasm32-unknown-unknown --features=stdweb`
 stdweb = { version = "0.4", optional = true }
+wasm-bindgen = { version = "0.2", optional = true }
 
 [dev-dependencies]
 # This is for testing serde, unfortunately we can't specify feature-gated dev

--- a/README.md
+++ b/README.md
@@ -117,8 +117,12 @@ optional features are available:
 - `log` enables some logging via the `log` crate.
 - `nightly` enables all unstable features (`i128_support`).
 - `serde1` enables serialization for some types, via Serde version 1.
-- `stdweb` enables support for `OsRng` on `wasm-unknown-unknown` via `stdweb`
+- `stdweb` enables support for `OsRng` on `wasm32-unknown-unknown` via `stdweb`
   combined with `cargo-web`.
+- `wasm-bindgen` enables support for `OsRng` on `wasm32-unknown-unknown` via
+  [`wasm-bindgen`]
+
+[`wasm-bindgen`]: https://github.com/rustwasm/wasm-bindgen
 
 `no_std` mode is activated by setting `default-features = false`; this removes
 functionality depending on `std`:

--- a/src/deprecated.rs
+++ b/src/deprecated.rs
@@ -263,7 +263,8 @@ impl CryptoRng for StdRng {}
               target_os = "redox",
               target_os = "fuchsia",
               windows,
-              all(target_arch = "wasm32", feature = "stdweb")
+              all(target_arch = "wasm32", feature = "stdweb"),
+              all(target_arch = "wasm32", feature = "wasm-bindgen"),
 )))]
 #[derive(Clone, Debug)]
 #[deprecated(since="0.6.0", note="import with rand::rngs::OsRng instead")]
@@ -283,7 +284,8 @@ pub struct OsRng(rngs::OsRng);
               target_os = "redox",
               target_os = "fuchsia",
               windows,
-              all(target_arch = "wasm32", feature = "stdweb")
+              all(target_arch = "wasm32", feature = "stdweb"),
+              all(target_arch = "wasm32", feature = "wasm-bindgen"),
 )))]
 #[cfg(feature="std")]
 impl RngCore for OsRng {
@@ -322,7 +324,8 @@ impl RngCore for OsRng {
               target_os = "redox",
               target_os = "fuchsia",
               windows,
-              all(target_arch = "wasm32", feature = "stdweb")
+              all(target_arch = "wasm32", feature = "stdweb"),
+              all(target_arch = "wasm32", feature = "wasm-bindgen"),
 )))]
 #[cfg(feature="std")]
 impl OsRng {
@@ -345,7 +348,8 @@ impl OsRng {
               target_os = "redox",
               target_os = "fuchsia",
               windows,
-              all(target_arch = "wasm32", feature = "stdweb")
+              all(target_arch = "wasm32", feature = "stdweb"),
+              all(target_arch = "wasm32", feature = "wasm-bindgen"),
 )))]
 #[cfg(feature="std")]
 impl CryptoRng for OsRng {}

--- a/src/rngs/entropy.rs
+++ b/src/rngs/entropy.rs
@@ -24,7 +24,7 @@ use rngs;
 ///
 /// If no secure source of entropy is available `EntropyRng` will panic on use;
 /// i.e. it should never output predictable data.
-/// 
+///
 /// This is either a little slow ([`OsRng`] requires a system call) or extremely
 /// slow ([`JitterRng`] must use significant CPU time to generate sufficient
 /// jitter); for better performance it is common to seed a local PRNG from
@@ -207,7 +207,8 @@ impl EntropySource for NoSource {
               target_os = "redox",
               target_os = "fuchsia",
               windows,
-              all(target_arch = "wasm32", feature = "stdweb")
+              all(target_arch = "wasm32", feature = "stdweb"),
+              all(target_arch = "wasm32", feature = "wasm-bindgen"),
 )))]
 #[derive(Clone, Debug)]
 pub struct Os(rngs::OsRng);
@@ -226,7 +227,8 @@ pub struct Os(rngs::OsRng);
               target_os = "redox",
               target_os = "fuchsia",
               windows,
-              all(target_arch = "wasm32", feature = "stdweb")
+              all(target_arch = "wasm32", feature = "stdweb"),
+              all(target_arch = "wasm32", feature = "wasm-bindgen"),
 )))]
 impl EntropySource for Os {
     fn new_and_fill(dest: &mut [u8]) -> Result<Self, Error> {
@@ -254,7 +256,8 @@ impl EntropySource for Os {
                   target_os = "redox",
                   target_os = "fuchsia",
                   windows,
-                  all(target_arch = "wasm32", feature = "stdweb")
+                  all(target_arch = "wasm32", feature = "stdweb"),
+                  all(target_arch = "wasm32", feature = "wasm-bindgen"),
 ))))]
 type Os = NoSource;
 

--- a/src/rngs/mod.rs
+++ b/src/rngs/mod.rs
@@ -197,7 +197,8 @@ pub use self::std::StdRng;
               target_os = "redox",
               target_os = "fuchsia",
               windows,
-              all(target_arch = "wasm32", feature = "stdweb")
+              all(target_arch = "wasm32", feature = "stdweb"),
+              all(target_arch = "wasm32", feature = "wasm-bindgen"),
 )))]
 mod os;
 
@@ -215,6 +216,7 @@ mod os;
               target_os = "redox",
               target_os = "fuchsia",
               windows,
-              all(target_arch = "wasm32", feature = "stdweb")
+              all(target_arch = "wasm32", feature = "stdweb"),
+              all(target_arch = "wasm32", feature = "wasm-bindgen"),
 )))]
 pub use self::os::OsRng;


### PR DESCRIPTION
This commit adds support to implement the `rand` crate on the
wasm32-unknown-unknown target with the `wasm-bindgen`-based runtime. This
supports being run both in node.js as well as browsers by delegating
appropriately.

Closes #478