### PR TITLE
Add WeightedError

### DIFF
--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -177,7 +177,7 @@ use Rng;
 #[doc(inline)] pub use self::uniform::Uniform;
 #[doc(inline)] pub use self::float::{OpenClosed01, Open01};
 #[cfg(feature="alloc")]
-#[doc(inline)] pub use self::weighted::WeightedIndex;
+#[doc(inline)] pub use self::weighted::{WeightedIndex, WeightedError};
 #[cfg(feature="std")]
 #[doc(inline)] pub use self::gamma::{Gamma, ChiSquared, FisherF, StudentT};
 #[cfg(feature="std")]


### PR DESCRIPTION
This fixes #535. I didn't add a `impl From<WeightedError> for Error { .. }` since I'm not sure how that's used, and so didn't know how to write/test an implementation. Happy to add one if anyone has pointers.

It's a little irky to have `choose` and `choose_weighted` indicate errors in different ways (one through `Option` and one through `Result`). However negative weights are substantially different than anything that `choose` has to deal with, so it does make sense.