### PR TITLE
Fix no-std alloc builds

### DIFF
--- a/src/seq.rs
+++ b/src/seq.rs
@@ -19,7 +19,7 @@
 #[cfg(all(feature="alloc", not(feature="std")))] use alloc::vec::Vec;
 // BTreeMap is not as fast in tests, but better than nothing.
 #[cfg(feature="std")] use std::collections::HashMap;
-#[cfg(all(feature="alloc", not(feature="std")))] use alloc::collections::BTreeMap;
+#[cfg(all(feature="alloc", not(feature="std")))] use alloc::btree_map::BTreeMap;
 
 use super::Rng;
 #[cfg(feature="alloc")] use distributions::uniform::{SampleUniform, SampleBorrow};


### PR DESCRIPTION
Currently `--no-default-features --features=alloc` builds from master are failing which makes all PRs fail tests.