### PR TITLE
Deprecate Rng::sample and Rng::sample_iter

### DIFF
--- a/benches/misc.rs
+++ b/benches/misc.rs
@@ -66,7 +66,7 @@ fn misc_bernoulli_const(b: &mut Bencher) {
         let d = rand::distributions::Bernoulli::new(0.18);
         let mut accum = true;
         for _ in 0..::RAND_BENCH_N {
-            accum ^= rng.sample(d);
+            accum ^= d.sample(&mut rng);
         }
         accum
     })
@@ -80,7 +80,7 @@ fn misc_bernoulli_var(b: &mut Bencher) {
         let mut p = 0.18;
         for _ in 0..::RAND_BENCH_N {
             let d = rand::distributions::Bernoulli::new(p);
-            accum ^= rng.sample(d);
+            accum ^= d.sample(&mut rng);
             p += 0.0001;
         }
         accum
@@ -95,7 +95,7 @@ macro_rules! sample_binomial {
             let (n, p) = ($n, $p);
             b.iter(|| {
                 let d = rand::distributions::Binomial::new(n, p);
-                rng.sample(d)
+                d.sample(&mut rng)
             })
         }
     }

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -120,7 +120,6 @@ impl Distribution<bool> for Bernoulli {
 
 #[cfg(test)]
 mod test {
-    use Rng;
     use distributions::Distribution;
     use super::Bernoulli;
 
@@ -130,10 +129,8 @@ mod test {
         let always_false = Bernoulli::new(0.0);
         let always_true = Bernoulli::new(1.0);
         for _ in 0..5 {
-            assert_eq!(r.sample::<bool, _>(&always_false), false);
-            assert_eq!(r.sample::<bool, _>(&always_true), true);
-            assert_eq!(Distribution::<bool>::sample(&always_false, &mut r), false);
-            assert_eq!(Distribution::<bool>::sample(&always_true, &mut r), true);
+            assert_eq!(always_false.sample(&mut r), false);
+            assert_eq!(always_true.sample(&mut r), true);
         }
     }
 

--- a/src/distributions/binomial.rs
+++ b/src/distributions/binomial.rs
@@ -64,7 +64,7 @@ impl Distribution<u64> for Binomial {
             let mut result = 0;
             let d = Bernoulli::new(self.p);
             for _ in 0 .. self.n {
-                result += rng.sample(d) as u32;
+                result += d.sample(rng) as u32;
             }
             return result as u64;
         }
@@ -96,7 +96,7 @@ impl Distribution<u64> for Binomial {
             let mut comp_dev: f64;
             loop {
                 // draw from the Cauchy distribution
-                comp_dev = rng.sample(cauchy);
+                comp_dev = cauchy.sample(rng);
                 // shift the peak of the comparison ditribution
                 lresult = expected + sq * comp_dev;
                 // repeat the drawing until we are in the range of possible values
@@ -166,8 +166,8 @@ mod test {
     #[test]
     fn test_binomial_end_points() {
         let mut rng = ::test::rng(352);
-        assert_eq!(rng.sample(Binomial::new(20, 0.0)), 0);
-        assert_eq!(rng.sample(Binomial::new(20, 1.0)), 20);
+        assert_eq!(Binomial::new(20, 0.0).sample(&mut rng), 0);
+        assert_eq!(Binomial::new(20, 1.0).sample(&mut rng), 20);
     }
 
     #[test]

--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -34,7 +34,7 @@ use distributions::utils::ziggurat;
 /// use rand::prelude::*;
 /// use rand::distributions::Exp1;
 ///
-/// let val: f64 = SmallRng::from_entropy().sample(Exp1);
+/// let val: f64 = Exp1.sample(&mut SmallRng::from_entropy());
 /// println!("{}", val);
 /// ```
 #[derive(Clone, Copy, Debug)]
@@ -92,7 +92,7 @@ impl Exp {
 
 impl Distribution<f64> for Exp {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> f64 {
-        let n: f64 = rng.sample(Exp1);
+        let n: f64 = Exp1.sample(rng);
         n * self.lambda_inverse
     }
 }

--- a/src/distributions/gamma.rs
+++ b/src/distributions/gamma.rs
@@ -142,7 +142,7 @@ impl Distribution<f64> for Gamma {
 }
 impl Distribution<f64> for GammaSmallShape {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> f64 {
-        let u: f64 = rng.sample(Open01);
+        let u: f64 = Open01.sample(rng);
 
         self.large_shape.sample(rng) * u.powf(self.inv_shape)
     }
@@ -150,14 +150,14 @@ impl Distribution<f64> for GammaSmallShape {
 impl Distribution<f64> for GammaLargeShape {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> f64 {
         loop {
-            let x = rng.sample(StandardNormal);
+            let x = StandardNormal.sample(rng);
             let v_cbrt = 1.0 + self.c * x;
             if v_cbrt <= 0.0 { // a^3 <= 0 iff a <= 0
                 continue
             }
 
             let v = v_cbrt * v_cbrt * v_cbrt;
-            let u: f64 = rng.sample(Open01);
+            let u: f64 = Open01.sample(rng);
 
             let x_sqr = x * x;
             if u < 1.0 - 0.0331 * x_sqr * x_sqr ||
@@ -217,7 +217,7 @@ impl Distribution<f64> for ChiSquared {
         match self.repr {
             DoFExactlyOne => {
                 // k == 1 => N(0,1)^2
-                let norm = rng.sample(StandardNormal);
+                let norm = StandardNormal.sample(rng);
                 norm * norm
             }
             DoFAnythingElse(ref g) => g.sample(rng)
@@ -300,7 +300,7 @@ impl StudentT {
 }
 impl Distribution<f64> for StudentT {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> f64 {
-        let norm = rng.sample(StandardNormal);
+        let norm = StandardNormal.sample(rng);
         norm * (self.dof / self.chi.sample(rng)).sqrt()
     }
 }

--- a/src/distributions/integer.rs
+++ b/src/distributions/integer.rs
@@ -122,27 +122,26 @@ simd_impl!(512, u8x64, i8x64, u16x32, i16x32, u32x16, i32x16, u64x8, i64x8,);
 
 #[cfg(test)]
 mod tests {
-    use Rng;
-    use distributions::{Standard};
+    use distributions::{Distribution, Standard};
     
     #[test]
     fn test_integers() {
-        let mut rng = ::test::rng(806);
+        let rng = &mut ::test::rng(806);
         
-        rng.sample::<isize, _>(Standard);
-        rng.sample::<i8, _>(Standard);
-        rng.sample::<i16, _>(Standard);
-        rng.sample::<i32, _>(Standard);
-        rng.sample::<i64, _>(Standard);
+        let _: isize = Standard.sample(rng);
+        let _: i8 = Standard.sample(rng);
+        let _: i16 = Standard.sample(rng);
+        let _: i32 = Standard.sample(rng);
+        let _: i64 = Standard.sample(rng);
         #[cfg(feature = "i128_support")]
-        rng.sample::<i128, _>(Standard);
+        let _: i128 = Standard.sample(rng);
         
-        rng.sample::<usize, _>(Standard);
-        rng.sample::<u8, _>(Standard);
-        rng.sample::<u16, _>(Standard);
-        rng.sample::<u32, _>(Standard);
-        rng.sample::<u64, _>(Standard);
+        let _: usize = Standard.sample(rng);
+        let _: u8 = Standard.sample(rng);
+        let _: u16 = Standard.sample(rng);
+        let _: u32 = Standard.sample(rng);
+        let _: u64 = Standard.sample(rng);
         #[cfg(feature = "i128_support")]
-        rng.sample::<u128, _>(Standard);
+        let _: u128 = Standard.sample(rng);
     }
 }

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -106,11 +106,11 @@
 //! Sampling from a distribution:
 //!
 //! ```
-//! use rand::{thread_rng, Rng};
+//! use rand::prelude::*;
 //! use rand::distributions::Exp;
 //!
 //! let exp = Exp::new(2.0);
-//! let v = thread_rng().sample(exp);
+//! let v = exp.sample(&mut thread_rng());
 //! println!("{} is from an Exp(2) distribution", v);
 //! ```
 //!
@@ -220,6 +220,20 @@ mod utils;
 /// [`sample_iter`]: trait.Distribution.html#method.sample_iter
 pub trait Distribution<T> {
     /// Generate a random value of `T`, using `rng` as the source of randomness.
+    ///
+    /// ### Example
+    ///
+    /// ```
+    /// use rand::prelude::*;
+    /// use rand::distributions::Uniform;
+    ///
+    /// let mut rng = thread_rng();
+    /// let distr = Uniform::new(10u32, 15);
+    /// for _ in 0..10 {
+    ///     let x = distr.sample(&mut rng);
+    ///     println!("{}", x);
+    /// }
+    /// ```
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> T;
 
     /// Create an iterator that generates random values of `T`, using `rng` as
@@ -329,7 +343,7 @@ impl<'a, D, R, T> Iterator for DistIter<'a, D, R, T>
 /// use rand::prelude::*;
 /// use rand::distributions::Standard;
 ///
-/// let val: f32 = SmallRng::from_entropy().sample(Standard);
+/// let val: f32 = Standard.sample(&mut SmallRng::from_entropy());
 /// println!("f32 from [0, 1): {}", val);
 /// ```
 ///

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -32,7 +32,7 @@ use distributions::utils::ziggurat;
 /// use rand::prelude::*;
 /// use rand::distributions::StandardNormal;
 ///
-/// let val: f64 = SmallRng::from_entropy().sample(StandardNormal);
+/// let val: f64 = StandardNormal.sample(&mut SmallRng::from_entropy());
 /// println!("{}", val);
 /// ```
 #[derive(Clone, Copy, Debug)]
@@ -56,8 +56,8 @@ impl Distribution<f64> for StandardNormal {
             let mut y = 0.0f64;
 
             while -2.0 * y < x * x {
-                let x_: f64 = rng.sample(Open01);
-                let y_: f64 = rng.sample(Open01);
+                let x_: f64 = Open01.sample(rng);
+                let y_: f64 = Open01.sample(rng);
 
                 x = x_.ln() / ziggurat_tables::ZIG_NORM_R;
                 y = y_.ln();
@@ -112,7 +112,7 @@ impl Normal {
 }
 impl Distribution<f64> for Normal {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> f64 {
-        let n = rng.sample(StandardNormal);
+        let n = StandardNormal.sample(rng);
         self.mean + self.std_dev * n
     }
 }

--- a/src/distributions/other.rs
+++ b/src/distributions/other.rs
@@ -25,12 +25,12 @@ use distributions::{Distribution, Standard, Uniform};
 ///
 /// ```
 /// use std::iter;
-/// use rand::{Rng, thread_rng};
+/// use rand::prelude::*;
 /// use rand::distributions::Alphanumeric;
 /// 
 /// let mut rng = thread_rng();
 /// let chars: String = iter::repeat(())
-///         .map(|()| rng.sample(Alphanumeric))
+///         .map(|()| Alphanumeric.sample(&mut rng))
 ///         .take(7)
 ///         .collect();
 /// println!("Random chars: {}", chars);
@@ -178,21 +178,22 @@ impl<T> Distribution<Wrapping<T>> for Standard where Standard: Distribution<T> {
 
 #[cfg(test)]
 mod tests {
-    use {Rng, RngCore, Standard};
-    use distributions::Alphanumeric;
+    use Standard;
+    use distributions::{Distribution, Alphanumeric};
     #[cfg(all(not(feature="std"), feature="alloc"))] use alloc::string::String;
 
     #[test]
     fn test_misc() {
-        let rng: &mut RngCore = &mut ::test::rng(820);
+        let rng = &mut ::test::rng(820);
         
-        rng.sample::<char, _>(Standard);
-        rng.sample::<bool, _>(Standard);
+        let _: char = Standard.sample(rng);
+        let _: bool = Standard.sample(rng);
     }
     
     #[cfg(feature="alloc")]
     #[test]
     fn test_chars() {
+        use Rng;
         use core::iter;
         let mut rng = ::test::rng(805);
 
@@ -211,7 +212,7 @@ mod tests {
         // take the rejection sampling path.
         let mut incorrect = false;
         for _ in 0..100 {
-            let c = rng.sample(Alphanumeric);
+            let c = Alphanumeric.sample(&mut rng);
             incorrect |= !((c >= '0' && c <= '9') ||
                            (c >= 'A' && c <= 'Z') ||
                            (c >= 'a' && c <= 'z') );

--- a/src/distributions/pareto.rs
+++ b/src/distributions/pareto.rs
@@ -20,7 +20,7 @@ use distributions::{Distribution, OpenClosed01};
 /// use rand::prelude::*;
 /// use rand::distributions::Pareto;
 ///
-/// let val: f64 = SmallRng::from_entropy().sample(Pareto::new(1., 2.));
+/// let val: f64 = Pareto::new(1., 2.).sample(&mut SmallRng::from_entropy());
 /// println!("{}", val);
 /// ```
 #[derive(Clone, Copy, Debug)]
@@ -46,7 +46,7 @@ impl Pareto {
 
 impl Distribution<f64> for Pareto {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> f64 {
-        let u: f64 = rng.sample(OpenClosed01);
+        let u: f64 = OpenClosed01.sample(rng);
         self.scale * u.powf(self.inv_neg_shape)
     }
 }

--- a/src/distributions/poisson.rs
+++ b/src/distributions/poisson.rs
@@ -82,7 +82,7 @@ impl Distribution<u64> for Poisson {
 
                 loop {
                     // draw from the Cauchy distribution
-                    comp_dev = rng.sample(cauchy);
+                    comp_dev = cauchy.sample(rng);
                     // shift the peak of the comparison ditribution
                     result = self.sqrt_2lambda * comp_dev + self.lambda;
                     // repeat the drawing until we are in the range of possible values

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,49 +461,20 @@ pub trait Rng: RngCore {
 
     /// Sample a new value, using the given distribution.
     ///
-    /// ### Example
+    /// Deprecated: use [`Distribution::sample`] instead.
     ///
-    /// ```
-    /// use rand::{thread_rng, Rng};
-    /// use rand::distributions::Uniform;
-    ///
-    /// let mut rng = thread_rng();
-    /// let x = rng.sample(Uniform::new(10u32, 15));
-    /// // Type annotation requires two types, the type and distribution; the
-    /// // distribution can be inferred.
-    /// let y = rng.sample::<u16, _>(Uniform::new(10, 15));
-    /// ```
+    /// [`Distribution::sample`]: distributions/trait.Distribution.html#method.sample
+    #[deprecated(since="0.6.0", note="use Distribution::sample instead")]
     fn sample<T, D: Distribution<T>>(&mut self, distr: D) -> T {
         distr.sample(self)
     }
 
     /// Create an iterator that generates values using the given distribution.
     ///
-    /// # Example
+    /// Deprecated: use [`Distribution::sample_iter`] instead.
     ///
-    /// ```
-    /// use rand::{thread_rng, Rng};
-    /// use rand::distributions::{Alphanumeric, Uniform, Standard};
-    ///
-    /// let mut rng = thread_rng();
-    ///
-    /// // Vec of 16 x f32:
-    /// let v: Vec<f32> = thread_rng().sample_iter(&Standard).take(16).collect();
-    ///
-    /// // String:
-    /// let s: String = rng.sample_iter(&Alphanumeric).take(7).collect();
-    ///
-    /// // Combined values
-    /// println!("{:?}", thread_rng().sample_iter(&Standard).take(5)
-    ///                              .collect::<Vec<(f64, bool)>>());
-    ///
-    /// // Dice-rolling:
-    /// let die_range = Uniform::new_inclusive(1, 6);
-    /// let mut roll_die = rng.sample_iter(&die_range);
-    /// while roll_die.next().unwrap() != 6 {
-    ///     println!("Not a 6; rolling again!");
-    /// }
-    /// ```
+    /// [`Distribution::sample_iter`]: distributions/trait.Distribution.html#method.sample_iter
+    #[deprecated(since="0.6.0", note="use Distribution::sample_iter instead")]
     fn sample_iter<'a, T, D: Distribution<T>>(&'a mut self, distr: &'a D)
         -> distributions::DistIter<'a, D, Self, T> where Self: Sized
     {
@@ -597,7 +568,7 @@ pub trait Rng: RngCore {
     #[inline]
     fn gen_bool(&mut self, p: f64) -> bool {
         let d = distributions::Bernoulli::new(p);
-        self.sample(d)
+        d.sample(self)
     }
 
     /// Return a bool with a probability of `numerator/denominator` of being
@@ -626,7 +597,7 @@ pub trait Rng: RngCore {
     #[inline]
     fn gen_ratio(&mut self, numerator: u32, denominator: u32) -> bool {
         let d = distributions::Bernoulli::from_ratio(numerator, denominator);
-        self.sample(d)
+        d.sample(self)
     }
 
     /// Return a random element from `values`.


### PR DESCRIPTION
In #483 we deprecated `Rng::choose` and `Rng::choose_mut` in favor of `SliceRandom::choose` and `SliceRandom::choose_mut`. The argument ([presented here](https://github.com/dhardy/rand/issues/82#issuecomment-392271783)) was that we can think of the the rng object as a source of data. So functions (like `gen_range`) which generate data should live on the `Rng` trait. Whereas when we're operating on other data (like `choose`), we should stick functions on those data objects and take the `Rng` as a parameter.

I.e. `vec.choose(rng)` rather than `rng.choose(vec)`.

I think that argument also argues for doing `distribution.sample(rng)` rather than `rng.sample(distribution)`. The name `sample` reinforces that the distribution is the source of the data that we're sampling from.

I also think it's generally a bad idea to have two functions that do the same thing. Feels like a source of confusion where it's easy to wonder what the difference is or why one should choose one over the other.

Same goes for `sample_iter`.

This PR deprecates `Rng::sample` and `Rng::sample_iter` and changes all internal callers (mostly tests) to use `Distribution::sample` instead (there were no internal callers of `Rng::sample_iter`).

With this change, all functions on `Rng` generate new values, making the trait feel more coherent. The values are either returned (most functions) or written to a passed in buffer (`fill`, `try_fill`).