### PR TITLE
Rename gen_bool and gen_ratio to with_probability and with_ratio

### DIFF
--- a/benches/misc.rs
+++ b/benches/misc.rs
@@ -10,25 +10,25 @@ use test::Bencher;
 use rand::prelude::*;
 
 #[bench]
-fn misc_gen_bool_const(b: &mut Bencher) {
+fn misc_with_probability_const(b: &mut Bencher) {
     let mut rng = StdRng::from_rng(&mut thread_rng()).unwrap();
     b.iter(|| {
         let mut accum = true;
         for _ in 0..::RAND_BENCH_N {
-            accum ^= rng.gen_bool(0.18);
+            accum ^= rng.with_probability(0.18);
         }
         accum
     })
 }
 
 #[bench]
-fn misc_gen_bool_var(b: &mut Bencher) {
+fn misc_with_probability_var(b: &mut Bencher) {
     let mut rng = StdRng::from_rng(&mut thread_rng()).unwrap();
     b.iter(|| {
         let mut accum = true;
         let mut p = 0.18;
         for _ in 0..::RAND_BENCH_N {
-            accum ^= rng.gen_bool(p);
+            accum ^= rng.with_probability(p);
             p += 0.0001;
         }
         accum
@@ -36,24 +36,24 @@ fn misc_gen_bool_var(b: &mut Bencher) {
 }
 
 #[bench]
-fn misc_gen_ratio_const(b: &mut Bencher) {
+fn misc_with_ratio_const(b: &mut Bencher) {
     let mut rng = StdRng::from_rng(&mut thread_rng()).unwrap();
     b.iter(|| {
         let mut accum = true;
         for _ in 0..::RAND_BENCH_N {
-            accum ^= rng.gen_ratio(2, 3);
+            accum ^= rng.with_ratio(2, 3);
         }
         accum
     })
 }
 
 #[bench]
-fn misc_gen_ratio_var(b: &mut Bencher) {
+fn misc_with_ratio_var(b: &mut Bencher) {
     let mut rng = StdRng::from_rng(&mut thread_rng()).unwrap();
     b.iter(|| {
         let mut accum = true;
         for i in 2..(::RAND_BENCH_N as u32 + 2) {
-            accum ^= rng.gen_ratio(i, i + 1);
+            accum ^= rng.with_ratio(i, i + 1);
         }
         accum
     })

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -98,7 +98,7 @@ impl Bernoulli {
     /// If `denominator == 0` or `numerator > denominator`.
     ///
     #[inline]
-    pub fn from_ratio(numerator: u32, denominator: u32) -> Bernoulli {
+    pub fn with_ratio(numerator: u32, denominator: u32) -> Bernoulli {
         assert!(numerator <= denominator);
         if numerator == denominator {
             return Bernoulli { p_int: ::core::u64::MAX }
@@ -143,7 +143,7 @@ mod test {
         const NUM: u32 = 3;
         const DENOM: u32 = 10;
         let d1 = Bernoulli::new(P);
-        let d2 = Bernoulli::from_ratio(NUM, DENOM);
+        let d2 = Bernoulli::with_ratio(NUM, DENOM);
         const N: u32 = 100_000;
 
         let mut sum1: u32 = 0;

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -86,7 +86,7 @@
 //!   - [`Cauchy`] distribution
 //! - Related to Bernoulli trials (yes/no events, with a given probability):
 //!   - [`Binomial`] distribution
-//!   - [`Bernoulli`] distribution, similar to [`Rng::gen_bool`].
+//!   - [`Bernoulli`] distribution, similar to [`Rng::with_probability`].
 //! - Related to positive real-valued quantities that grow exponentially
 //!   (e.g. prices, incomes, populations):
 //!   - [`LogNormal`] distribution
@@ -140,7 +140,7 @@
 //! [`sample`]: ../trait.Rng.html#method.sample
 //! [`new_inclusive`]: struct.Uniform.html#method.new_inclusive
 //! [`random()`]: ../fn.random.html
-//! [`Rng::gen_bool`]: ../trait.Rng.html#method.gen_bool
+//! [`Rng::with_probability`]: ../trait.Rng.html#method.with_probability
 //! [`Rng::gen_range`]: ../trait.Rng.html#method.gen_range
 //! [`Rng::gen()`]: ../trait.Rng.html#method.gen
 //! [`Rng`]: ../trait.Rng.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@
 //!
 //! - [`Rng::sample_iter`] allows iterating over values from a chosen
 //!   distribution.
-//! - [`Rng::gen_bool`] generates boolean "events" with a given probability.
+//! - [`Rng::with_probability`] generates boolean "events" with a given probability.
 //! - [`Rng::fill`] and [`Rng::try_fill`] are fast alternatives to fill a slice
 //!   of integers.
 //! - [`Rng::shuffle`] randomly shuffles elements in a slice.
@@ -194,7 +194,7 @@
 //! [`ReadRng`]: rngs/adapter/struct.ReadRng.html
 //! [`Rng::choose`]: trait.Rng.html#method.choose
 //! [`Rng::fill`]: trait.Rng.html#method.fill
-//! [`Rng::gen_bool`]: trait.Rng.html#method.gen_bool
+//! [`Rng::with_probability`]: trait.Rng.html#method.with_probability
 //! [`Rng::gen`]: trait.Rng.html#method.gen
 //! [`Rng::sample_iter`]: trait.Rng.html#method.sample_iter
 //! [`Rng::shuffle`]: trait.Rng.html#method.shuffle
@@ -586,7 +586,7 @@ pub trait Rng: RngCore {
     /// use rand::{thread_rng, Rng};
     ///
     /// let mut rng = thread_rng();
-    /// println!("{}", rng.gen_bool(1.0 / 3.0));
+    /// println!("{}", rng.with_probability(1.0 / 3.0));
     /// ```
     ///
     /// # Panics
@@ -595,13 +595,22 @@ pub trait Rng: RngCore {
     ///
     /// [`Bernoulli`]: distributions/bernoulli/struct.Bernoulli.html
     #[inline]
-    fn gen_bool(&mut self, p: f64) -> bool {
+    fn with_probability(&mut self, p: f64) -> bool {
         let d = distributions::Bernoulli::new(p);
         self.sample(d)
     }
 
+    /// Return a bool with a probability `p` of being true.
+    ///
+    /// Deprecated: renamed to `with_probability`.
+    #[inline]
+    #[deprecated(since="0.6.0", note="renamed to with_probability")]
+    fn gen_bool(&mut self, p: f64) -> bool {
+        self.with_probability(p)
+    }
+
     /// Return a bool with a probability of `numerator/denominator` of being
-    /// true. I.e. `gen_ratio(2, 3)` has chance of 2 in 3, or about 67%, of
+    /// true. I.e. `with_ratio(2, 3)` has chance of 2 in 3, or about 67%, of
     /// returning true. If `numerator == denominator`, then the returned value
     /// is guaranteed to be `true`. If `numerator == 0`, then the returned
     /// value is guaranteed to be `false`.
@@ -619,13 +628,13 @@ pub trait Rng: RngCore {
     /// use rand::{thread_rng, Rng};
     ///
     /// let mut rng = thread_rng();
-    /// println!("{}", rng.gen_ratio(2, 3));
+    /// println!("{}", rng.with_ratio(2, 3));
     /// ```
     ///
     /// [`Bernoulli`]: distributions/bernoulli/struct.Bernoulli.html
     #[inline]
-    fn gen_ratio(&mut self, numerator: u32, denominator: u32) -> bool {
-        let d = distributions::Bernoulli::from_ratio(numerator, denominator);
+    fn with_ratio(&mut self, numerator: u32, denominator: u32) -> bool {
+        let d = distributions::Bernoulli::with_ratio(numerator, denominator);
         self.sample(d)
     }
 
@@ -1069,11 +1078,11 @@ mod test {
     }
 
     #[test]
-    fn test_gen_bool() {
+    fn test_with_probability() {
         let mut r = rng(105);
         for _ in 0..5 {
-            assert_eq!(r.gen_bool(0.0), false);
-            assert_eq!(r.gen_bool(1.0), true);
+            assert_eq!(r.with_probability(0.0), false);
+            assert_eq!(r.with_probability(1.0), true);
         }
     }
 
@@ -1116,7 +1125,7 @@ mod test {
     }
 
     #[test]
-    fn test_gen_ratio_average() {
+    fn test_with_ratio_average() {
         const NUM: u32 = 3;
         const DENOM: u32 = 10;
         const N: u32 = 100_000;
@@ -1124,7 +1133,7 @@ mod test {
         let mut sum: u32 = 0;
         let mut rng = rng(111);
         for _ in 0..N {
-            if rng.gen_ratio(NUM, DENOM) {
+            if rng.with_ratio(NUM, DENOM) {
                 sum += 1;
             }
         }

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -203,7 +203,7 @@ pub trait IteratorRandom: Iterator + Sized {
             // Continue until the iterator is exhausted
             for (i, elem) in self.enumerate() {
                 let denom = (i + 2) as f64; // accurate to 2^53 elements
-                if rng.gen_bool(1.0 / denom) {
+                if rng.with_probability(1.0 / denom) {
                     result = elem;
                 }
             }


### PR DESCRIPTION
The `gen_bool` and `gen_ratio` functions will most commonly be used in situations like

```rust
if rng.gen_bool(0.42) {
    ...
}
```

However the name of that those functions feel awkward when used in this scenario. Not only is the "gen" part redundant, since that's what rng objects generally do (and what the "g" in "rng" stands for). But the fact that we're branching on a boolean value doesn't actually say anything about how that boolean is created.

Likewise `gen_ratio` doesn't actually generate a ratio, it generates a boolean with a probability expressed as a ratio.

This PR renames `gen_bool` and `gen_ratio` to `with_probability` and `with_ratio`. So code instead reads as:

```rust
if rng.with_probability(0.42) {
    ...
}
```
and

```rust
if rng.with_ratio(2, 5) {
    ...
}
```

The old names are kept for now, but with a deprecation warning.
