### PR TITLE
Move `XorShiftRng` to its own crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ matrix:
         # TODO: use --tests instead of --lib on more recent compiler
         - cargo test --lib --no-default-features
         - cargo test --package rand_core --no-default-features
+        - cargo test --package rand_isaac --no-default-features
+        - cargo test --package rand_isaac --features serde1,std
+        - cargo test --package rand_xorshift --no-default-features
+        - cargo test --package rand_xorshift --features serde1,std
         - cargo test --features serde1,log
     - rust: stable
       os: osx
@@ -21,12 +25,20 @@ matrix:
       script:
         - cargo test --tests --no-default-features
         - cargo test --package rand_core --no-default-features
+        - cargo test --package rand_isaac --no-default-features
+        - cargo test --package rand_isaac --features serde1,std
+        - cargo test --package rand_xorshift --no-default-features
+        - cargo test --package rand_xorshift --features serde1,std
         - cargo test --features serde1,log
     - rust: beta
       install:
       script:
         - cargo test --tests --no-default-features
         - cargo test --package rand_core --no-default-features
+        - cargo test --package rand_isaac --no-default-features
+        - cargo test --package rand_isaac --features serde1,std
+        - cargo test --package rand_xorshift --no-default-features
+        - cargo test --package rand_xorshift --features serde1,std
         - cargo test --features serde1,log
     - rust: nightly
       install:
@@ -37,7 +49,7 @@ matrix:
         - cargo test --tests --no-default-features --features=alloc
         - cargo test --package rand_core --no-default-features --features=alloc,serde1
         - cargo test --features serde1,log,nightly,alloc
-        - cargo test --all --benches
+        - cargo test --all --all-features --benches
         # remove cached documentation, otherwise files from previous PRs can get included
         - rm -rf target/doc
         - cargo doc --no-deps --all --all-features

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,8 @@ matrix:
         # TODO: use --tests instead of --lib on more recent compiler
         - cargo test --lib --no-default-features
         - cargo test --package rand_core --no-default-features
-        - cargo test --package rand_isaac --no-default-features
-        - cargo test --package rand_isaac --features serde1,std
-        - cargo test --package rand_xorshift --no-default-features
-        - cargo test --package rand_xorshift --features serde1,std
+        - cargo test --package rand_isaac --features serde1
+        - cargo test --package rand_xorshift --features serde1
         - cargo test --features serde1,log
     - rust: stable
       os: osx
@@ -25,20 +23,16 @@ matrix:
       script:
         - cargo test --tests --no-default-features
         - cargo test --package rand_core --no-default-features
-        - cargo test --package rand_isaac --no-default-features
-        - cargo test --package rand_isaac --features serde1,std
-        - cargo test --package rand_xorshift --no-default-features
-        - cargo test --package rand_xorshift --features serde1,std
+        - cargo test --package rand_isaac --features serde1
+        - cargo test --package rand_xorshift --features serde1
         - cargo test --features serde1,log
     - rust: beta
       install:
       script:
         - cargo test --tests --no-default-features
         - cargo test --package rand_core --no-default-features
-        - cargo test --package rand_isaac --no-default-features
-        - cargo test --package rand_isaac --features serde1,std
-        - cargo test --package rand_xorshift --no-default-features
-        - cargo test --package rand_xorshift --features serde1,std
+        - cargo test --package rand_isaac --features serde1
+        - cargo test --package rand_xorshift --features serde1
         - cargo test --features serde1,log
     - rust: nightly
       install:
@@ -49,7 +43,7 @@ matrix:
         - cargo test --tests --no-default-features --features=alloc
         - cargo test --package rand_core --no-default-features --features=alloc,serde1
         - cargo test --features serde1,log,nightly,alloc
-        - cargo test --all --all-features --benches
+        - cargo test --all --benches
         # remove cached documentation, otherwise files from previous PRs can get included
         - rm -rf target/doc
         - cargo doc --no-deps --all --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ appveyor = { repository = "alexcrichton/rand" }
 [features]
 default = ["std" ] # without "std" rand uses libcore
 nightly = ["i128_support", "simd_support"] # enables all features requiring nightly rust
-std = ["rand_core/std", "rand_isaac/std", "rand_xorshift/std", "alloc", "libc", "winapi", "cloudabi", "fuchsia-zircon"]
+std = ["rand_core/std", "alloc", "libc", "winapi", "cloudabi", "fuchsia-zircon"]
 alloc = ["rand_core/alloc"]  # enables Vec and Box support (without std)
 i128_support = [] # enables i128 and u128 support
 simd_support = [] # enables SIMD support

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ std = ["rand_core/std", "rand_isaac/std", "rand_xorshift/std", "alloc", "libc", 
 alloc = ["rand_core/alloc"]  # enables Vec and Box support (without std)
 i128_support = [] # enables i128 and u128 support
 simd_support = [] # enables SIMD support
-serde1 = ["serde", "serde_derive", "rand_core/serde1", "rand_isaac/serde1", "rand_xorshift/serde1"] # enables serialization for PRNGs
+serde1 = ["rand_core/serde1", "rand_isaac/serde1", "rand_xorshift/serde1"] # enables serialization for PRNGs
 
 [workspace]
 members = ["rand_core", "rand_isaac", "rand_xorshift"]
@@ -35,8 +35,6 @@ rand_core = { path = "rand_core", version = "0.2", default-features = false }
 rand_isaac = { path = "rand_isaac", version = "0.1" }
 rand_xorshift = { path = "rand_xorshift", version = "0.1" }
 log = { version = "0.4", optional = true }
-serde = { version = "1", optional = true }
-serde_derive = { version = "1", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2", optional = true }
@@ -54,11 +52,6 @@ fuchsia-zircon = { version = "0.3.2", optional = true }
 # use with `--target wasm32-unknown-unknown --features=stdweb`
 stdweb = { version = "0.4", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
-
-[dev-dependencies]
-# This is for testing serde, unfortunately we can't specify feature-gated dev
-# deps yet, see: https://github.com/rust-lang/cargo/issues/1596
-bincode = "1.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,13 @@ simd_support = [] # enables SIMD support
 serde1 = ["serde", "serde_derive", "rand_core/serde1"] # enables serialization for PRNGs
 
 [workspace]
-members = ["rand_core", "rand_isaac"]
+members = ["rand_core", "rand_isaac", "rand_xorshift"]
 
 [dependencies]
 rand_core = { path = "rand_core", version = "0.2", default-features = false }
 # only for deprecations and benches:
 rand_isaac = { path = "rand_isaac", version = "0.1", default-features = false }
+rand_xorshift = { path = "rand_xorshift", version = "0.1", default-features = false }
 log = { version = "0.4", optional = true }
 serde = { version = "1", optional = true }
 serde_derive = { version = "1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ appveyor = { repository = "alexcrichton/rand" }
 [features]
 default = ["std" ] # without "std" rand uses libcore
 nightly = ["i128_support", "simd_support"] # enables all features requiring nightly rust
-std = ["rand_core/std", "alloc", "libc", "winapi", "cloudabi", "fuchsia-zircon"]
+std = ["rand_core/std", "rand_isaac/std", "rand_xorshift/std", "alloc", "libc", "winapi", "cloudabi", "fuchsia-zircon"]
 alloc = ["rand_core/alloc"]  # enables Vec and Box support (without std)
 i128_support = [] # enables i128 and u128 support
 simd_support = [] # enables SIMD support
-serde1 = ["serde", "serde_derive", "rand_core/serde1"] # enables serialization for PRNGs
+serde1 = ["serde", "serde_derive", "rand_core/serde1", "rand_isaac/serde1", "rand_xorshift/serde1"] # enables serialization for PRNGs
 
 [workspace]
 members = ["rand_core", "rand_isaac", "rand_xorshift"]
@@ -32,8 +32,8 @@ members = ["rand_core", "rand_isaac", "rand_xorshift"]
 [dependencies]
 rand_core = { path = "rand_core", version = "0.2", default-features = false }
 # only for deprecations and benches:
-rand_isaac = { path = "rand_isaac", version = "0.1", default-features = false }
-rand_xorshift = { path = "rand_xorshift", version = "0.1", default-features = false }
+rand_isaac = { path = "rand_isaac", version = "0.1" }
+rand_xorshift = { path = "rand_xorshift", version = "0.1" }
 log = { version = "0.4", optional = true }
 serde = { version = "1", optional = true }
 serde_derive = { version = "1", optional = true }

--- a/benches/distributions.rs
+++ b/benches/distributions.rs
@@ -4,6 +4,7 @@
 
 extern crate test;
 extern crate rand;
+extern crate rand_xorshift;
 
 const RAND_BENCH_N: u64 = 1000;
 
@@ -11,7 +12,7 @@ use std::mem::size_of;
 use test::Bencher;
 
 use rand::{Rng, FromEntropy};
-use rand::prng::XorShiftRng;
+use rand_xorshift::XorShiftRng;
 use rand::distributions::*;
 
 macro_rules! distr_int {

--- a/benches/distributions.rs
+++ b/benches/distributions.rs
@@ -4,7 +4,6 @@
 
 extern crate test;
 extern crate rand;
-extern crate rand_xorshift;
 
 const RAND_BENCH_N: u64 = 1000;
 
@@ -12,14 +11,14 @@ use std::mem::size_of;
 use test::Bencher;
 
 use rand::{Rng, FromEntropy};
-use rand_xorshift::XorShiftRng;
+use rand::rngs::SmallRng;
 use rand::distributions::*;
 
 macro_rules! distr_int {
     ($fnn:ident, $ty:ty, $distr:expr) => {
         #[bench]
         fn $fnn(b: &mut Bencher) {
-            let mut rng = XorShiftRng::from_entropy();
+            let mut rng = SmallRng::from_entropy();
             let distr = $distr;
 
             b.iter(|| {
@@ -39,7 +38,7 @@ macro_rules! distr_float {
     ($fnn:ident, $ty:ty, $distr:expr) => {
         #[bench]
         fn $fnn(b: &mut Bencher) {
-            let mut rng = XorShiftRng::from_entropy();
+            let mut rng = SmallRng::from_entropy();
             let distr = $distr;
 
             b.iter(|| {
@@ -59,7 +58,7 @@ macro_rules! distr {
     ($fnn:ident, $ty:ty, $distr:expr) => {
         #[bench]
         fn $fnn(b: &mut Bencher) {
-            let mut rng = XorShiftRng::from_entropy();
+            let mut rng = SmallRng::from_entropy();
             let distr = $distr;
 
             b.iter(|| {
@@ -127,7 +126,7 @@ macro_rules! gen_range_int {
     ($fnn:ident, $ty:ident, $low:expr, $high:expr) => {
         #[bench]
         fn $fnn(b: &mut Bencher) {
-            let mut rng = XorShiftRng::from_entropy();
+            let mut rng = SmallRng::from_entropy();
 
             b.iter(|| {
                 let mut high = $high;
@@ -156,7 +155,7 @@ macro_rules! gen_range_float {
     ($fnn:ident, $ty:ident, $low:expr, $high:expr) => {
         #[bench]
         fn $fnn(b: &mut Bencher) {
-            let mut rng = XorShiftRng::from_entropy();
+            let mut rng = SmallRng::from_entropy();
 
             b.iter(|| {
                 let mut high = $high;
@@ -180,7 +179,7 @@ gen_range_float!(gen_range_f64, f64, 123.456f64, 7890.12);
 
 #[bench]
 fn dist_iter(b: &mut Bencher) {
-    let mut rng = XorShiftRng::from_entropy();
+    let mut rng = SmallRng::from_entropy();
     let distr = Normal::new(-2.71828, 3.14159);
     let mut iter = distr.sample_iter(&mut rng);
 

--- a/benches/generators.rs
+++ b/benches/generators.rs
@@ -3,6 +3,7 @@
 extern crate test;
 extern crate rand;
 extern crate rand_isaac;
+extern crate rand_xorshift;
 
 const RAND_BENCH_N: u64 = 1000;
 const BYTES_LEN: usize = 1024;
@@ -11,11 +12,12 @@ use std::mem::size_of;
 use test::{black_box, Bencher};
 
 use rand::prelude::*;
-use rand::prng::{XorShiftRng, Hc128Rng, ChaChaRng};
+use rand::prng::{Hc128Rng, ChaChaRng};
 use rand::prng::hc128::Hc128Core;
 use rand::rngs::adapter::ReseedingRng;
 use rand::rngs::{OsRng, JitterRng, EntropyRng};
 use rand_isaac::{IsaacRng, Isaac64Rng};
+use rand_xorshift::XorShiftRng;
 
 macro_rules! gen_bytes {
     ($fnn:ident, $gen:expr) => {

--- a/rand_isaac/Cargo.toml
+++ b/rand_isaac/Cargo.toml
@@ -18,9 +18,15 @@ travis-ci = { repository = "rust-lang-nursery/rand" }
 appveyor = { repository = "alexcrichton/rand" }
 
 [features]
-serde1 = ["serde", "serde_derive"] # enables serde for BlockRng wrapper
+serde1 = ["serde", "serde_derive", "rand_core/serde1"]
+std = []
 
 [dependencies]
 rand_core = { path = "../rand_core", version = "0.2", default-features=false }
 serde = { version = "1", optional = true }
 serde_derive = { version = "^1.0.38", optional = true }
+
+[dev-dependencies]
+# This is for testing serde, unfortunately we can't specify feature-gated dev
+# deps yet, see: https://github.com/rust-lang/cargo/issues/1596
+bincode = "1"

--- a/rand_isaac/Cargo.toml
+++ b/rand_isaac/Cargo.toml
@@ -19,7 +19,6 @@ appveyor = { repository = "alexcrichton/rand" }
 
 [features]
 serde1 = ["serde", "serde_derive", "rand_core/serde1"]
-std = []
 
 [dependencies]
 rand_core = { path = "../rand_core", version = "0.2", default-features=false }

--- a/rand_isaac/src/isaac.rs
+++ b/rand_isaac/src/isaac.rs
@@ -453,7 +453,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(all(feature="serde1"))]
+    #[cfg(feature="serde1")]
     fn test_isaac_serde() {
         use bincode;
         use std::io::{BufWriter, BufReader};

--- a/rand_isaac/src/isaac.rs
+++ b/rand_isaac/src/isaac.rs
@@ -453,7 +453,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(all(feature="serde1", feature="std"))]
+    #[cfg(all(feature="serde1"))]
     fn test_isaac_serde() {
         use bincode;
         use std::io::{BufWriter, BufReader};

--- a/rand_isaac/src/isaac64.rs
+++ b/rand_isaac/src/isaac64.rs
@@ -445,7 +445,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(all(feature="serde1"))]
+    #[cfg(feature="serde1")]
     fn test_isaac64_serde() {
         use bincode;
         use std::io::{BufWriter, BufReader};

--- a/rand_isaac/src/isaac64.rs
+++ b/rand_isaac/src/isaac64.rs
@@ -445,7 +445,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(all(feature="serde1", feature="std"))]
+    #[cfg(all(feature="serde1"))]
     fn test_isaac64_serde() {
         use bincode;
         use std::io::{BufWriter, BufReader};

--- a/rand_isaac/src/lib.rs
+++ b/rand_isaac/src/lib.rs
@@ -18,14 +18,16 @@
 #![deny(missing_debug_implementations)]
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 
-#![cfg_attr(not(feature="std"), no_std)]
+#![cfg_attr(not(all(feature="serde1", test)), no_std)]
 
-#[cfg(feature="std")] extern crate std as core;
 extern crate rand_core;
 
-#[cfg(all(feature="serde1", test))] extern crate bincode;
 #[cfg(feature="serde1")] extern crate serde;
 #[cfg(feature="serde1")] #[macro_use] extern crate serde_derive;
+
+// To test serialization we need bincode and the standard library
+#[cfg(all(feature="serde1", test))] extern crate bincode;
+#[cfg(all(feature="serde1", test))] extern crate std as core;
 
 pub mod isaac;
 pub mod isaac64;

--- a/rand_isaac/src/lib.rs
+++ b/rand_isaac/src/lib.rs
@@ -18,11 +18,12 @@
 #![deny(missing_debug_implementations)]
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 
-#![no_std]
+#![cfg_attr(not(feature="std"), no_std)]
 
+#[cfg(feature="std")] extern crate std as core;
 extern crate rand_core;
 
-#[cfg(test)] #[cfg(feature="serde1")] extern crate bincode;
+#[cfg(all(feature="serde1", test))] extern crate bincode;
 #[cfg(feature="serde1")] extern crate serde;
 #[cfg(feature="serde1")] #[macro_use] extern crate serde_derive;
 

--- a/rand_xorshift/CHANGELOG.md
+++ b/rand_xorshift/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2018-07-16
+- Initial release

--- a/rand_xorshift/Cargo.toml
+++ b/rand_xorshift/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "rand_xorshift"
+version = "0.1.0" # NB: When modifying, also modify html_root_url in lib.rs
+authors = ["The Rust Project Developers"]
+license = "MIT/Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/rust-lang-nursery/rand"
+documentation = "https://docs.rs/rand_isaac"
+homepage = "https://crates.io/crates/rand_isaac"
+description = """
+Xorshift random number generator
+"""
+keywords = ["rng"]
+categories = ["algorithms", "no-std"]
+
+[badges]
+travis-ci = { repository = "rust-lang-nursery/rand" }
+appveyor = { repository = "alexcrichton/rand" }
+
+[features]
+serde1 = ["serde", "serde_derive"] # enables serde for BlockRng wrapper
+
+[dependencies]
+rand_core = { path = "../rand_core", version = "0.2", default-features=false }
+serde = { version = "1", optional = true }
+serde_derive = { version = "^1.0.38", optional = true }

--- a/rand_xorshift/Cargo.toml
+++ b/rand_xorshift/Cargo.toml
@@ -18,9 +18,15 @@ travis-ci = { repository = "rust-lang-nursery/rand" }
 appveyor = { repository = "alexcrichton/rand" }
 
 [features]
-serde1 = ["serde", "serde_derive"] # enables serde for BlockRng wrapper
+serde1 = ["serde", "serde_derive"]
+std = []
 
 [dependencies]
 rand_core = { path = "../rand_core", version = "0.2", default-features=false }
 serde = { version = "1", optional = true }
 serde_derive = { version = "^1.0.38", optional = true }
+
+[dev-dependencies]
+# This is for testing serde, unfortunately we can't specify feature-gated dev
+# deps yet, see: https://github.com/rust-lang/cargo/issues/1596
+bincode = "1"

--- a/rand_xorshift/Cargo.toml
+++ b/rand_xorshift/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://crates.io/crates/rand_isaac"
 description = """
 Xorshift random number generator
 """
-keywords = ["rng"]
+keywords = ["random", "rng", "xorshift"]
 categories = ["algorithms", "no-std"]
 
 [badges]

--- a/rand_xorshift/Cargo.toml
+++ b/rand_xorshift/Cargo.toml
@@ -19,7 +19,6 @@ appveyor = { repository = "alexcrichton/rand" }
 
 [features]
 serde1 = ["serde", "serde_derive"]
-std = []
 
 [dependencies]
 rand_core = { path = "../rand_core", version = "0.2", default-features=false }

--- a/rand_xorshift/LICENSE-APACHE
+++ b/rand_xorshift/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     https://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/rand_xorshift/LICENSE-MIT
+++ b/rand_xorshift/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2018 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/rand_xorshift/README.md
+++ b/rand_xorshift/README.md
@@ -1,0 +1,43 @@
+# rand_xorshift
+
+[![Build Status](https://travis-ci.org/rust-lang-nursery/rand.svg)](https://travis-ci.org/rust-lang-nursery/rand)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/rust-lang-nursery/rand?svg=true)](https://ci.appveyor.com/project/alexcrichton/rand)
+[![Latest version](https://img.shields.io/crates/v/rand_xorshift.svg)](https://crates.io/crates/rand_xorshift)
+[![Documentation](https://docs.rs/rand_xorshift/badge.svg)](https://docs.rs/rand_xorshift)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.22+-yellow.svg)](https://github.com/rust-lang-nursery/rand#rust-version-requirements)
+[![License](https://img.shields.io/crates/l/rand_xorshift.svg)](https://github.com/rust-lang-nursery/rand/tree/master/rand_xorshift#license)
+
+Implements the Xorshift random number generator.
+
+The Xorshift[^1] algorithm is not suitable for cryptographic purposes
+but is very fast. If you do not know for sure that it fits your
+requirements, use a more secure one such as `StdRng` or `OsRng`.
+
+[^1]: Marsaglia, George (July 2003).
+      ["Xorshift RNGs"](https://www.jstatsoft.org/v08/i14/paper).
+      *Journal of Statistical Software*. Vol. 8 (Issue 14).
+
+Documentation:
+[master branch](https://rust-lang-nursery.github.io/rand/rand_xorshift/index.html),
+[by release](https://docs.rs/rand_isaac)
+
+[Changelog](CHANGELOG.md)
+
+[rand]: https://crates.io/crates/rand
+
+
+## Crate Features
+
+`rand_xorshift` is `no_std` compatible. It does not require any functionality
+outside of the `core` lib, thus there are no features to configure.
+
+The `serde1` feature includes implementations of `Serialize` and `Deserialize`
+for the included RNGs.
+
+
+## License
+
+`rand_xorshift` is distributed under the terms of both the MIT license and the
+Apache License (Version 2.0).
+
+See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.

--- a/rand_xorshift/src/lib.rs
+++ b/rand_xorshift/src/lib.rs
@@ -1,0 +1,31 @@
+// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// https://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! The xorshift random number generator.
+
+#![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
+       html_favicon_url = "https://www.rust-lang.org/favicon.ico",
+       html_root_url = "https://docs.rs/rand_xorshift/0.1.0")]
+
+#![deny(missing_docs)]
+#![deny(missing_debug_implementations)]
+#![doc(test(attr(allow(unused_variables), deny(warnings))))]
+
+#![no_std]
+
+extern crate rand_core;
+
+#[cfg(test)] #[cfg(feature="serde1")] extern crate bincode;
+#[cfg(feature="serde1")] extern crate serde;
+#[cfg(feature="serde1")] #[macro_use] extern crate serde_derive;
+
+mod xorshift;
+
+pub use self::xorshift::XorShiftRng;

--- a/rand_xorshift/src/lib.rs
+++ b/rand_xorshift/src/lib.rs
@@ -18,13 +18,14 @@
 #![deny(missing_debug_implementations)]
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 
-#![no_std]
+#![cfg_attr(not(feature="std"), no_std)]
 
+#[cfg(feature="std")] extern crate std as core;
 extern crate rand_core;
 
-#[cfg(test)] #[cfg(feature="serde1")] extern crate bincode;
 #[cfg(feature="serde1")] extern crate serde;
 #[cfg(feature="serde1")] #[macro_use] extern crate serde_derive;
+#[cfg(all(feature="serde1", test))] extern crate bincode;
 
 mod xorshift;
 

--- a/rand_xorshift/src/lib.rs
+++ b/rand_xorshift/src/lib.rs
@@ -18,14 +18,16 @@
 #![deny(missing_debug_implementations)]
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 
-#![cfg_attr(not(feature="std"), no_std)]
+#![cfg_attr(not(all(feature="serde1", test)), no_std)]
 
-#[cfg(feature="std")] extern crate std as core;
 extern crate rand_core;
 
 #[cfg(feature="serde1")] extern crate serde;
 #[cfg(feature="serde1")] #[macro_use] extern crate serde_derive;
+
+// To test serialization we need bincode and the standard library
 #[cfg(all(feature="serde1", test))] extern crate bincode;
+#[cfg(all(feature="serde1", test))] extern crate std as core;
 
 mod xorshift;
 

--- a/rand_xorshift/src/xorshift.rs
+++ b/rand_xorshift/src/xorshift.rs
@@ -112,7 +112,7 @@ impl SeedableRng for XorShiftRng {
 
 #[cfg(test)]
 mod tests {
-    use {RngCore, SeedableRng};
+    use ::rand_core::{RngCore, SeedableRng};
     use super::XorShiftRng;
 
     #[test]

--- a/rand_xorshift/src/xorshift.rs
+++ b/rand_xorshift/src/xorshift.rs
@@ -178,7 +178,7 @@ mod tests {
         }
     }
 
-    #[cfg(all(feature="serde1"))]
+    #[cfg(feature="serde1")]
     #[test]
     fn test_xorshift_serde() {
         use bincode;

--- a/rand_xorshift/src/xorshift.rs
+++ b/rand_xorshift/src/xorshift.rs
@@ -18,7 +18,7 @@ use rand_core::{RngCore, SeedableRng, Error, impls, le};
 ///
 /// The Xorshift[^1] algorithm is not suitable for cryptographic purposes
 /// but is very fast. If you do not know for sure that it fits your
-/// requirements, use a more secure one such as `IsaacRng` or `OsRng`.
+/// requirements, use a more secure one such as `StdRng` or `OsRng`.
 ///
 /// [^1]: Marsaglia, George (July 2003).
 ///       ["Xorshift RNGs"](https://www.jstatsoft.org/v08/i14/paper).

--- a/rand_xorshift/src/xorshift.rs
+++ b/rand_xorshift/src/xorshift.rs
@@ -178,7 +178,7 @@ mod tests {
         }
     }
 
-    #[cfg(all(feature="serde1", feature="std"))]
+    #[cfg(all(feature="serde1"))]
     #[test]
     fn test_xorshift_serde() {
         use bincode;

--- a/src/deprecated.rs
+++ b/src/deprecated.rs
@@ -170,8 +170,8 @@ impl CryptoRng for ChaChaRng {}
 
 
 #[derive(Clone, Debug)]
-#[deprecated(since="0.6.0", note="import with rand::prng::XorShiftRng instead")]
-pub struct XorShiftRng(prng::XorShiftRng);
+#[deprecated(since="0.6.0", note="import from rand_xorshift crate instead")]
+pub struct XorShiftRng(::rand_xorshift::XorShiftRng);
 
 impl RngCore for XorShiftRng {
     #[inline(always)]
@@ -196,14 +196,14 @@ impl RngCore for XorShiftRng {
 }
 
 impl SeedableRng for XorShiftRng {
-    type Seed = <prng::XorShiftRng as SeedableRng>::Seed;
+    type Seed = <::rand_xorshift::XorShiftRng as SeedableRng>::Seed;
 
     fn from_seed(seed: Self::Seed) -> Self {
-        XorShiftRng(prng::XorShiftRng::from_seed(seed))
+        XorShiftRng(::rand_xorshift::XorShiftRng::from_seed(seed))
     }
 
     fn from_rng<R: RngCore>(rng: R) -> Result<Self, Error> {
-        prng::XorShiftRng::from_rng(rng).map(XorShiftRng)
+        ::rand_xorshift::XorShiftRng::from_rng(rng).map(XorShiftRng)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,9 +237,6 @@
 #[cfg(feature="std")] extern crate std as core;
 #[cfg(all(feature = "alloc", not(feature="std")))] extern crate alloc;
 
-#[cfg(all(feature="serde1", test))] extern crate bincode;
-#[cfg(feature="serde1")] extern crate serde;
-
 #[cfg(all(target_arch="wasm32", not(target_os="emscripten"), feature="stdweb"))]
 #[macro_use]
 extern crate stdweb;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,7 @@
 #[cfg(feature="std")] extern crate std as core;
 #[cfg(all(feature = "alloc", not(feature="std")))] extern crate alloc;
 
-#[cfg(test)] #[cfg(feature="serde1")] extern crate bincode;
+#[cfg(all(feature="serde1", test))] extern crate bincode;
 #[cfg(feature="serde1")] extern crate serde;
 
 #[cfg(all(target_arch="wasm32", not(target_os="emscripten"), feature="stdweb"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,6 +250,7 @@ extern crate wasm_bindgen;
 
 extern crate rand_core;
 extern crate rand_isaac;    // only for deprecations
+extern crate rand_xorshift;
 
 #[cfg(feature = "log")] #[macro_use] extern crate log;
 #[allow(unused)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,7 +239,6 @@
 
 #[cfg(test)] #[cfg(feature="serde1")] extern crate bincode;
 #[cfg(feature="serde1")] extern crate serde;
-#[cfg(feature="serde1")] #[macro_use] extern crate serde_derive;
 
 #[cfg(all(target_arch="wasm32", not(target_os="emscripten"), feature="stdweb"))]
 #[macro_use]

--- a/src/prng/mod.rs
+++ b/src/prng/mod.rs
@@ -321,9 +321,10 @@ pub mod hc128;
 
 pub use self::chacha::ChaChaRng;
 pub use self::hc128::Hc128Rng;
-pub use ::rand_xorshift::XorShiftRng;
 
 // Deprecations (to be removed in 0.7)
+#[doc(hidden)] #[allow(deprecated)]
+pub use deprecated::XorShiftRng;
 #[doc(hidden)] pub mod isaac {
     // Note: we miss `IsaacCore` here but probably unimportant.
     #[allow(deprecated)] pub use deprecated::IsaacRng;

--- a/src/prng/mod.rs
+++ b/src/prng/mod.rs
@@ -299,7 +299,7 @@
 //! [`rngs` module]: ../rngs/index.html
 //! [basic PRNGs]: #basic-pseudo-random-number-generators-prngs
 //! [CSPRNGs]: #cryptographically-secure-pseudo-random-number-generators-csprngs
-//! [`XorShiftRng`]: struct.XorShiftRng.html
+//! [`XorShiftRng`]: ../../rand_xorshift/struct.XorShiftRng.html
 //! [`ChaChaRng`]: chacha/struct.ChaChaRng.html
 //! [`Hc128Rng`]: hc128/struct.Hc128Rng.html
 //! [`IsaacRng`]: ../../rand_isaac/isaac/struct.IsaacRng.html
@@ -318,11 +318,10 @@
 
 pub mod chacha;
 pub mod hc128;
-mod xorshift;
 
 pub use self::chacha::ChaChaRng;
 pub use self::hc128::Hc128Rng;
-pub use self::xorshift::XorShiftRng;
+pub use ::rand_xorshift::XorShiftRng;
 
 // Deprecations (to be removed in 0.7)
 #[doc(hidden)] pub mod isaac {

--- a/src/rngs/small.rs
+++ b/src/rngs/small.rs
@@ -63,8 +63,8 @@ use ::rand_xorshift::XorShiftRng;
 /// [`FromEntropy`]: ../trait.FromEntropy.html
 /// [`StdRng`]: struct.StdRng.html
 /// [`thread_rng`]: ../fn.thread_rng.html
-/// [Xorshift]: ../prng/struct.XorShiftRng.html
-/// [`XorShiftRng`]: ../prng/struct.XorShiftRng.html
+/// [Xorshift]: ../../rand_xorshift/struct.XorShiftRng.html
+/// [`XorShiftRng`]: ../../rand_xorshift/struct.XorShiftRng.html
 #[derive(Clone, Debug)]
 pub struct SmallRng(XorShiftRng);
 

--- a/src/rngs/small.rs
+++ b/src/rngs/small.rs
@@ -11,7 +11,7 @@
 //! A small fast RNG
 
 use {RngCore, SeedableRng, Error};
-use prng::XorShiftRng;
+use ::rand_xorshift::XorShiftRng;
 
 /// An RNG recommended when small state, cheap initialization and good
 /// performance are required. The PRNG algorithm in `SmallRng` is chosen to be

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -598,7 +598,7 @@ fn sample_indices_cache<R>(
 mod test {
     use super::*;
     #[cfg(feature = "alloc")] use {Rng, SeedableRng};
-    #[cfg(feature = "alloc")] use prng::XorShiftRng;
+    #[cfg(feature = "alloc")] use ::rand_xorshift::XorShiftRng;
     #[cfg(all(feature="alloc", not(feature="std")))]
     use alloc::vec::Vec;
 


### PR DESCRIPTION
Also recommend `StdRng` rather than the deprecated `IsaacRng`.

The main motivation for this is that we can remove the generator from Rand and that it is still possible to reproduce the results.