### PR TITLE
Update to wasm-bindgen 0.2.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ fuchsia-zircon = { version = "0.3.2", optional = true }
 [target.wasm32-unknown-unknown.dependencies]
 # use with `--target wasm32-unknown-unknown --features=stdweb`
 stdweb = { version = "0.4", optional = true }
-wasm-bindgen = { version = "0.2", optional = true }
+wasm-bindgen = { version = "0.2.12", optional = true }
 
 [dev-dependencies]
 # This is for testing serde, unfortunately we can't specify feature-gated dev

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,7 +232,6 @@
 #![cfg_attr(feature = "stdweb", recursion_limit="128")]
 #![cfg_attr(feature = "wasm-bindgen", feature(use_extern_macros))]
 #![cfg_attr(feature = "wasm-bindgen", feature(wasm_import_module))]
-#![cfg_attr(feature = "wasm-bindgen", feature(wasm_custom_section))]
 
 #[cfg(feature="std")] extern crate std as core;
 #[cfg(all(feature = "alloc", not(feature="std")))] extern crate alloc;
@@ -911,6 +910,7 @@ pub mod __wbg_shims {
             #[wasm_bindgen(method, getter, structural)]
             pub fn crypto(me: &This) -> JsValue;
 
+            #[derive(Clone, Debug)]
             pub type BrowserCrypto;
 
             // TODO: these `structural` annotations here ideally wouldn't be here to
@@ -924,23 +924,11 @@ pub mod __wbg_shims {
             #[wasm_bindgen(js_name = require)]
             pub fn node_require(s: &str) -> NodeCrypto;
 
+            #[derive(Clone, Debug)]
             pub type NodeCrypto;
 
             #[wasm_bindgen(method, js_name = randomFillSync, structural)]
             pub fn random_fill_sync(me: &NodeCrypto, buf: &mut [u8]);
-        }
-
-        // TODO: replace with derive once rustwasm/wasm-bindgen#400 is merged
-        impl Clone for BrowserCrypto {
-            fn clone(&self) -> BrowserCrypto {
-                BrowserCrypto { obj: self.obj.clone() }
-            }
-        }
-
-        impl Clone for NodeCrypto {
-            fn clone(&self) -> NodeCrypto {
-                NodeCrypto { obj: self.obj.clone() }
-            }
         }
     }
 }

--- a/src/rngs/os.rs
+++ b/src/rngs/os.rs
@@ -1107,14 +1107,12 @@ mod imp {
           not(feature = "stdweb"),
           feature = "wasm-bindgen"))]
 mod imp {
-    use core::fmt;
-
     use __wbg_shims::*;
 
     use {Error, ErrorKind};
     use super::OsRngImpl;
 
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub enum OsRng {
         Node(NodeCrypto),
         Browser(BrowserCrypto),
@@ -1185,13 +1183,6 @@ mod imp {
                 OsRng::Node(_) => "crypto.randomFillSync",
                 OsRng::Browser(_) => "crypto.getRandomValues",
             }
-        }
-    }
-
-    // TODO: replace with derive once rustwasm/wasm-bindgen#399 is merged
-    impl fmt::Debug for OsRng {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            f.debug_struct("OsRng").finish()
         }
     }
 }


### PR DESCRIPTION
wasm-bindgen 0.2.12 is compatible with the latest nightly, which removed the `wasm_custom_section` feature. Also it allowed some clean-up.