### PR TITLE
Replace `i128_support` feature with compile-time detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,26 @@ You may also find the [Update Guide](UPDATING.md) useful.
 
 ## [0.6.0] - Unreleased
 
+### Crate features and organisation
+- The ISAAC and Xorshift RNGs have been moved to their own crates: `rand_isaac`
+  and `rand_xorshift`. (#551, #557)
+- `Uniform` supports inclusive ranges: `Uniform::from(a..=b)`. This is
+  automatically enabled for Rust >= 1.27. (#566)
+- Support for `i128` and `u128` is automatically enabled for Rust >= 1.26. This
+  renders the `i128_support` feature obsolete. It still exists for backwards
+  compatibility but does not have any effect. This breaks programs using Rand
+  with `i128_support` on nightlies older than Rust 1.26. (#571)
+
+### New distributions
+- Added sampling from the unit sphere and circle. (#567)
+
 ### Sequences module
 - Optimised and changed return type of the `sample_indices` function. (#479)
+- Added weighted sampling. (#518)
+
+### Platform support
+- Added support for wasm-bindgen. (#541)
+- Added basic SIMD support. (#523)
 
 ## [0.5.4] - 2018-07-11
 ### Platform support

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ appveyor = { repository = "alexcrichton/rand" }
 
 [features]
 default = ["std" ] # without "std" rand uses libcore
-nightly = ["i128_support", "simd_support"] # enables all features requiring nightly rust
+nightly = ["simd_support"] # enables all features requiring nightly rust
 std = ["rand_core/std", "alloc", "libc", "winapi", "cloudabi", "fuchsia-zircon"]
 alloc = ["rand_core/alloc"]  # enables Vec and Box support (without std)
-i128_support = [] # enables i128 and u128 support
+i128_support = [] # dummy feature for backwards compatibility
 simd_support = ["packed_simd"] # enables SIMD support
 serde1 = ["rand_core/serde1", "rand_isaac/serde1", "rand_xorshift/serde1"] # enables serialization for PRNGs
 

--- a/README.md
+++ b/README.md
@@ -115,9 +115,8 @@ Rand is built with only the `std` feature enabled by default. The following
 optional features are available:
 
 - `alloc` can be used instead of `std` to provide `Vec` and `Box`.
-- `i128_support` enables support for generating `u128` and `i128` values.
 - `log` enables some logging via the `log` crate.
-- `nightly` enables all unstable features (`i128_support`, `simd_support`).
+- `nightly` enables all unstable features (`simd_support`).
 - `serde1` enables serialization for some types, via Serde version 1.
 - `simd_support` enables uniform sampling of SIMD types (integers and floats).
 - `stdweb` enables support for `OsRng` on `wasm32-unknown-unknown` via `stdweb`

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,9 @@ extern crate rustc_version;
 use rustc_version::{version, Version};
 
 fn main() {
+    if version().unwrap() >= Version::parse("1.26.0").unwrap() {
+        println!("cargo:rustc-cfg=rust_1_26");
+    }
     if version().unwrap() >= Version::parse("1.27.0").unwrap() {
         println!("cargo:rustc-cfg=rust_1_27");
     }

--- a/src/deprecated.rs
+++ b/src/deprecated.rs
@@ -151,12 +151,12 @@ impl SeedableRng for ChaChaRng {
 }
 
 impl ChaChaRng {
-    #[cfg(feature = "i128_support")]
+    #[cfg(rust_1_26)]
     pub fn get_word_pos(&self) -> u128 {
         self.0.get_word_pos()
     }
 
-    #[cfg(feature = "i128_support")]
+    #[cfg(rust_1_26)]
     pub fn set_word_pos(&mut self, word_offset: u128) {
         self.0.set_word_pos(word_offset)
     }

--- a/src/distributions/integer.rs
+++ b/src/distributions/integer.rs
@@ -43,7 +43,7 @@ impl Distribution<u64> for Standard {
     }
 }
 
-#[cfg(feature = "i128_support")]
+#[cfg(rust_1_26)]
 impl Distribution<u128> for Standard {
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> u128 {
@@ -83,7 +83,7 @@ impl_int_from_uint! { i8, u8 }
 impl_int_from_uint! { i16, u16 }
 impl_int_from_uint! { i32, u32 }
 impl_int_from_uint! { i64, u64 }
-#[cfg(feature = "i128_support")] impl_int_from_uint! { i128, u128 }
+#[cfg(rust_1_26)] impl_int_from_uint! { i128, u128 }
 impl_int_from_uint! { isize, usize }
 
 #[cfg(feature="simd_support")]
@@ -134,7 +134,7 @@ mod tests {
         rng.sample::<i16, _>(Standard);
         rng.sample::<i32, _>(Standard);
         rng.sample::<i64, _>(Standard);
-        #[cfg(feature = "i128_support")]
+        #[cfg(rust_1_26)]
         rng.sample::<i128, _>(Standard);
         
         rng.sample::<usize, _>(Standard);
@@ -142,7 +142,7 @@ mod tests {
         rng.sample::<u16, _>(Standard);
         rng.sample::<u32, _>(Standard);
         rng.sample::<u64, _>(Standard);
-        #[cfg(feature = "i128_support")]
+        #[cfg(rust_1_26)]
         rng.sample::<u128, _>(Standard);
     }
 }

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -471,7 +471,7 @@ uniform_int_impl! { i8, i8, u8, i32, u32 }
 uniform_int_impl! { i16, i16, u16, i32, u32 }
 uniform_int_impl! { i32, i32, u32, i32, u32 }
 uniform_int_impl! { i64, i64, u64, i64, u64 }
-#[cfg(feature = "i128_support")]
+#[cfg(rust_1_26)]
 uniform_int_impl! { i128, i128, u128, u128, u128 }
 uniform_int_impl! { isize, isize, usize, isize, usize }
 uniform_int_impl! { u8, i8, u8, i32, u32 }
@@ -479,7 +479,7 @@ uniform_int_impl! { u16, i16, u16, i32, u32 }
 uniform_int_impl! { u32, i32, u32, i32, u32 }
 uniform_int_impl! { u64, i64, u64, i64, u64 }
 uniform_int_impl! { usize, isize, usize, isize, usize }
-#[cfg(feature = "i128_support")]
+#[cfg(rust_1_26)]
 uniform_int_impl! { u128, u128, u128, i128, u128 }
 
 
@@ -859,7 +859,7 @@ mod tests {
         }
         t!(i8, i16, i32, i64, isize,
            u8, u16, u32, u64, usize);
-        #[cfg(feature = "i128_support")]
+        #[cfg(rust_1_26)]
         t!(i128, u128)
     }
 

--- a/src/distributions/utils.rs
+++ b/src/distributions/utils.rs
@@ -40,7 +40,7 @@ macro_rules! wmul_impl {
 wmul_impl! { u8, u16, 8 }
 wmul_impl! { u16, u32, 16 }
 wmul_impl! { u32, u64, 32 }
-#[cfg(feature = "i128_support")]
+#[cfg(rust_1_26)]
 wmul_impl! { u64, u128, 64 }
 
 // This code is a translation of the __mulddi3 function in LLVM's
@@ -75,9 +75,9 @@ macro_rules! wmul_impl_large {
         }
     }
 }
-#[cfg(not(feature = "i128_support"))]
+#[cfg(not(rust_1_26))]
 wmul_impl_large! { u64, 32 }
-#[cfg(feature = "i128_support")]
+#[cfg(rust_1_26)]
 wmul_impl_large! { u128, 64 }
 
 macro_rules! wmul_impl_usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,8 +226,6 @@
 
 #![cfg_attr(not(feature="std"), no_std)]
 #![cfg_attr(all(feature="alloc", not(feature="std")), feature(alloc))]
-#![cfg_attr(all(feature="i128_support", feature="nightly"), allow(stable_features))] // stable since 2018-03-27
-#![cfg_attr(all(feature="i128_support", feature="nightly"), feature(i128_type, i128))]
 #![cfg_attr(all(feature="simd_support", feature="nightly"), feature(stdsimd))]
 #![cfg_attr(feature = "stdweb", recursion_limit="128")]
 #![cfg_attr(feature = "wasm-bindgen", feature(use_extern_macros))]
@@ -718,13 +716,13 @@ macro_rules! impl_as_byte_slice {
 impl_as_byte_slice!(u16);
 impl_as_byte_slice!(u32);
 impl_as_byte_slice!(u64);
-#[cfg(feature="i128_support")] impl_as_byte_slice!(u128);
+#[cfg(rust_1_26)] impl_as_byte_slice!(u128);
 impl_as_byte_slice!(usize);
 impl_as_byte_slice!(i8);
 impl_as_byte_slice!(i16);
 impl_as_byte_slice!(i32);
 impl_as_byte_slice!(i64);
-#[cfg(feature="i128_support")] impl_as_byte_slice!(i128);
+#[cfg(rust_1_26)] impl_as_byte_slice!(i128);
 impl_as_byte_slice!(isize);
 
 macro_rules! impl_as_byte_slice_arrays {

--- a/src/prng/chacha.rs
+++ b/src/prng/chacha.rs
@@ -114,9 +114,8 @@ impl ChaChaRng {
     /// not supported, hence the result can simply be multiplied by 4 to get a
     /// byte-offset.
     /// 
-    /// Note: this function is currently only available when the `i128_support`
-    /// feature is enabled. In the future this will be enabled by default.
-    #[cfg(feature = "i128_support")]
+    /// Note: this function is currently only available with Rust 1.26 or later.
+    #[cfg(rust_1_26)]
     pub fn get_word_pos(&self) -> u128 {
         let mut c = (self.0.core.state[13] as u64) << 32
                   | (self.0.core.state[12] as u64);
@@ -136,9 +135,8 @@ impl ChaChaRng {
     /// simply cycles at the end of its period (1 ZiB), we ignore the upper
     /// 60 bits.
     /// 
-    /// Note: this function is currently only available when the `i128_support`
-    /// feature is enabled. In the future this will be enabled by default.
-    #[cfg(feature = "i128_support")]
+    /// Note: this function is currently only available with Rust 1.26 or later.
+    #[cfg(rust_1_26)]
     pub fn set_word_pos(&mut self, word_offset: u128) {
         let index = (word_offset as usize) & 0xF;
         let counter = (word_offset >> 4) as u64;
@@ -333,7 +331,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "i128_support")]
+    #[cfg(rust_1_26)]
     fn test_chacha_true_values_c() {
         // Test vector 4 from
         // https://tools.ietf.org/html/draft-nir-cfrg-chacha20-poly1305-04


### PR DESCRIPTION
This breaks builds using the `i128_support` feature with nightlies
supporting `i128` before Rust 1.26. I think this is acceptable, unless we want to support very old nightlies.