### PR TITLE
Prepare 0.5.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ A [separate changelog is kept for rand_core](rand_core/CHANGELOG.md).
 
 You may also find the [Update Guide](UPDATING.md) useful.
 
+## [0.5.5] - 2018-08-07
+### Documentation
+- Fix links in documentation (#582)
+
 ## [0.5.4] - 2018-07-11
 ### Platform support
 - Make `OsRng` work via WASM/stdweb for WebWorkers

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand"
-version = "0.5.4" # NB: When modifying, also modify html_root_url in lib.rs
+version = "0.5.5" # NB: When modifying, also modify html_root_url in lib.rs
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,7 +224,7 @@
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-       html_root_url = "https://docs.rs/rand/0.5.4")]
+       html_root_url = "https://docs.rs/rand/0.5.5")]
 
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,7 @@
 //!
 //! One further problem is that if Rand is unable to get any external randomness
 //! when initializing an RNG with [`EntropyRng`], it will panic in
-//! [`FromEntropy::from_entropy`], and notably in [`thread_rng`]. Except by
+//! [`FromEntropy::from_entropy`], and notably in [`thread_rng()`]. Except by
 //! compromising security, this problem is as unsolvable as running out of
 //! memory.
 //!
@@ -188,6 +188,7 @@
 //!
 //! [`distributions` module]: distributions/index.html
 //! [`distributions::WeightedChoice`]: distributions/struct.WeightedChoice.html
+//! [`FromEntropy::from_entropy`]: trait.FromEntropy.html#tymethod.from_entropy
 //! [`EntropyRng`]: rngs/struct.EntropyRng.html
 //! [`Error`]: struct.Error.html
 //! [`gen_range`]: trait.Rng.html#method.gen_range


### PR DESCRIPTION
This just fixes some documentation links (see #582).

@kpp please test this fixes your issue.