### PR TITLE
Update ChaChaRng doc

### DIFF
--- a/src/prng/chacha.rs
+++ b/src/prng/chacha.rs
@@ -20,10 +20,10 @@ const STATE_WORDS: usize = 16;
 /// A cryptographically secure random number generator that uses the ChaCha
 /// algorithm.
 ///
-/// ChaCha is a stream cipher designed by Daniel J. Bernstein [^1], that we use
+/// ChaCha is a stream cipher designed by Daniel J. Bernstein[^1], that we use
 /// as an RNG. It is an improved variant of the Salsa20 cipher family, which was
 /// selected as one of the "stream ciphers suitable for widespread adoption" by
-/// eSTREAM [^2].
+/// eSTREAM[^2].
 ///
 /// ChaCha uses add-rotate-xor (ARX) operations as its basis. These are safe
 /// against timing attacks, although that is mostly a concern for ciphers and
@@ -38,8 +38,8 @@ const STATE_WORDS: usize = 16;
 /// We use 20 rounds in this implementation, but hope to allow type-level
 /// configuration in the future.
 ///
-/// We use a 64-bit counter and 64-bit stream identifier as in Benstein's
-/// implementation [^1] except that we use a stream identifier in place of a
+/// We use a 64-bit counter and 64-bit stream identifier as in Bernstein's
+/// implementation[^1] except that we use a stream identifier in place of a
 /// nonce. A 64-bit counter over 64-byte (16 word) blocks allows 1 ZiB of output
 /// before cycling, and the stream identifier allows 2<sup>64</sup> unique
 /// streams of output per seed. Both counter and stream are initialized to zero
@@ -48,10 +48,10 @@ const STATE_WORDS: usize = 16;
 /// The word layout is:
 ///
 /// ```text
-/// constant constant constant constant
-/// seed     seed     seed     seed
-/// seed     seed     seed     seed
-/// counter  counter  nonce    nonce
+/// constant  constant  constant  constant
+/// seed      seed      seed      seed
+/// seed      seed      seed      seed
+/// counter   counter   stream_id stream_id
 /// ```
 ///
 /// This implementation uses an output buffer of sixteen `u32` words, and uses


### PR DESCRIPTION
 - Fix a typo
 - Use `stream_id` instead of `nonce` when describing the layout 
   to be consistent with the explanation
 - Remove spaces before footnotes


The footnote thing is debatable of course but most people don't use spaces before footnotes. I can revert that change if desired.